### PR TITLE
Skal kun bygge filer fra entrypoint ved bundling

### DIFF
--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -12,6 +12,7 @@ const common = {
                     compilerOptions: {
                         noEmit: false,
                     },
+                    onlyCompileBundledFiles: true,
                 },
                 exclude: /node_modules/,
             },


### PR DESCRIPTION
**Hvorfor?**
ts-loader prøvde tidligere å kompilere alle filer, og feilet derfor ved bygging dersom man ikke hadde kjørt `yarn install` i backend-mappen, selvom denne ikke skulle være en del av bundlen