### PR TITLE
Sette opp BrowserRouter

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
     "webpack-merge": "^5.9.0"
   },
   "dependencies": {
+    "@types/react-router-dom": "^5.3.3",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.15.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "webpack --config ./webpack/webpack.production.js",
-    "build:dev": "webpack --config ./webpack/webpack.development.js",
-    "start:dev": "webpack serve --open --config ./webpack/webpack.development.js"
+    "build": "PUBLIC_URL=/tilleggsstonader/soknad webpack --config ./webpack/webpack.production.js",
+    "build:dev": "PUBLIC_URL=/tilleggsstonader/soknad webpack --config ./webpack/webpack.development.js",
+    "start:dev": "PUBLIC_URL=/tilleggsstonader/soknad webpack serve --config ./webpack/webpack.development.js"
   },
   "lint-staged": {
     "src/**/*.{js,jsx,ts,tsx,json,css}": [

--- a/src/backend/routes.ts
+++ b/src/backend/routes.ts
@@ -13,6 +13,11 @@ const routes = () => {
 
     expressRouter.use(BASE_PATH_SOKNAD, express.static(buildPath, { index: false }));
 
+    expressRouter.use(
+        /^(?!.*\/(internal|static|api)\/).*$/,
+        express.static(buildPath, { index: true })
+    );
+
     return expressRouter;
 };
 

--- a/src/frontend/index.tsx
+++ b/src/frontend/index.tsx
@@ -1,7 +1,15 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
 const rootElement = document.getElementById('app');
 const root = createRoot(rootElement!);
-root.render(<App />);
+
+root.render(
+    <BrowserRouter basename={process.env.PUBLIC_URL}>
+        <Routes>
+            <Route path={'/*'} element={<App />} />
+        </Routes>
+    </BrowserRouter>
+);

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -1,5 +1,8 @@
 import path from 'path';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
+import webpack from 'webpack';
+
+const publicPath = process.env.PUBLIC_URL || '/';
 
 const common = {
     entry: './src/frontend/index.tsx',
@@ -29,6 +32,10 @@ const common = {
         new HtmlWebpackPlugin({
             title: 'Søknad om tilleggsstønader',
             template: path.join(process.cwd(), 'src/frontend/index.html'),
+        }),
+        new webpack.DefinePlugin({
+            'process.env.NODE_ENV': JSON.stringify('development'),
+            'process.env.PUBLIC_URL': JSON.stringify(publicPath),
         }),
     ],
     resolve: {

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -39,7 +39,6 @@ const common = {
             template: path.join(process.cwd(), 'src/frontend/index.html'),
         }),
         new webpack.DefinePlugin({
-            'process.env.NODE_ENV': JSON.stringify('development'),
             'process.env.PUBLIC_URL': JSON.stringify(publicPath),
         }),
     ],

--- a/webpack/webpack.development.js
+++ b/webpack/webpack.development.js
@@ -1,4 +1,5 @@
 import path from 'path';
+import webpack from 'webpack';
 import { merge } from 'webpack-merge';
 
 import common from './webpack.common.js';
@@ -26,6 +27,11 @@ const developmentConfig = merge(common, {
     optimization: {
         runtimeChunk: 'single',
     },
+    plugins: [
+        new webpack.DefinePlugin({
+            'process.env.NODE_ENV': JSON.stringify('development'),
+        }),
+    ],
 });
 
 export default developmentConfig;

--- a/webpack/webpack.development.js
+++ b/webpack/webpack.development.js
@@ -2,16 +2,24 @@ import common from './webpack.common.js';
 import { merge } from 'webpack-merge';
 import path from 'path';
 
+const publicPath = process.env.PUBLIC_URL || '/';
+
 const developmentConfig = merge(common, {
     mode: 'development',
     devtool: 'inline-source-map',
     devServer: {
         static: '/dist_development',
+        port: 8080,
+        open: publicPath,
+        devMiddleware: { publicPath: publicPath },
+        historyApiFallback: {
+            index: publicPath,
+        },
     },
     output: {
         filename: '[name].bundle.js',
         path: path.join(process.cwd(), 'dist_development'),
-        publicPath: '/',
+        publicPath: publicPath,
         clean: true,
     },
     optimization: {

--- a/webpack/webpack.production.js
+++ b/webpack/webpack.production.js
@@ -1,9 +1,15 @@
+import webpack from 'webpack';
 import { merge } from 'webpack-merge';
 
 import common from './webpack.common.js';
 
 const productionConfig = merge(common, {
     mode: 'production',
+    plugins: [
+        new webpack.DefinePlugin({
+            'process.env.NODE_ENV': JSON.stringify('production'),
+        }),
+    ],
 });
 
 export default productionConfig;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1125,6 +1125,11 @@
     picocolors "^1.0.0"
     tslib "^2.6.0"
 
+"@remix-run/router@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.8.0.tgz#e848d2f669f601544df15ce2a313955e4bf0bafc"
+  integrity sha512-mrfKqIHnSZRyIzBcanNJmVQELTnX+qagEDlcKO90RgRBVOZGSGvZKeDihTRfWcqoDn5N/NkUcwWTccnpN18Tfg==
+
 "@types/body-parser@*":
   version "1.19.2"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.2.tgz#aea2059e28b7658639081347ac4fab3de166e6f0"
@@ -1196,6 +1201,11 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/history@^4.7.11":
+  version "4.7.11"
+  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.11.tgz#56588b17ae8f50c53983a524fc3cc47437969d64"
+  integrity sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==
+
 "@types/html-minifier-terser@^6.0.0":
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz#4fc33a00c1d0c16987b1a20cf92d20614c55ac35"
@@ -1253,6 +1263,23 @@
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.7.tgz#67222a08c0a6ae0a0da33c3532348277c70abb63"
   integrity sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==
   dependencies:
+    "@types/react" "*"
+
+"@types/react-router-dom@^5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.3.3.tgz#e9d6b4a66fcdbd651a5f106c2656a30088cc1e83"
+  integrity sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==
+  dependencies:
+    "@types/history" "^4.7.11"
+    "@types/react" "*"
+    "@types/react-router" "*"
+
+"@types/react-router@*":
+  version "5.1.20"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-5.1.20.tgz#88eccaa122a82405ef3efbcaaa5dcdd9f021387c"
+  integrity sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==
+  dependencies:
+    "@types/history" "^4.7.11"
     "@types/react" "*"
 
 "@types/react@*", "@types/react@^18.2.20":
@@ -4130,6 +4157,21 @@ react-dom@^18.2.0:
   dependencies:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
+
+react-router-dom@^6.15.0:
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.15.0.tgz#6da7db61e56797266fbbef0d5e324d6ac443ee40"
+  integrity sha512-aR42t0fs7brintwBGAv2+mGlCtgtFQeOzK0BM1/OiqEzRejOZtpMZepvgkscpMUnKb8YO84G7s3LsHnnDNonbQ==
+  dependencies:
+    "@remix-run/router" "1.8.0"
+    react-router "6.15.0"
+
+react-router@6.15.0:
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.15.0.tgz#bf2cb5a4a7ed57f074d4ea88db0d95033f39cac8"
+  integrity sha512-NIytlzvzLwJkCQj2HLefmeakxxWHWAP+02EGqWEZy+DgfHHKQMUoBBjUQLOtFInBMhWtb3hiUy6MfFgwLjXhqg==
+  dependencies:
+    "@remix-run/router" "1.8.0"
 
 react@^18.2.0:
   version "18.2.0"


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨ 
Skulle installere `react-router-dom` og fant da ut at ingenting skjedde med mindre man kun hadde route `/`. 

Måtte 
- legge til at serveren skal lytte på alle kall og returnere `index.html`. 
- definere fallback for webpack og at index finnes på publicPath (`historyApiFallback`)
- sette `PUBLIC_URL` i start:dev script
- fjerne `--open` fra start:dev script fordi den overskrev `open` i `devServer`, så nå åpnes den automatisk på `/tilleggstonader/soknad`
- definere hvordan process.env skal tolkes av webpack