### PR TITLE
Skal lage struktur for teksthåndtering

### DIFF
--- a/src/frontend/tekster/felles.ts
+++ b/src/frontend/tekster/felles.ts
@@ -1,0 +1,12 @@
+import { FellesInnhold } from '../typer/tekster/felles';
+
+export const fellesTekster: FellesInnhold = {
+    neste: {
+        nb: 'Neste',
+        en: 'Next',
+    },
+    forrige: {
+        nb: 'Forrige',
+        en: 'Back',
+    },
+};

--- a/src/frontend/tekster/felles.ts
+++ b/src/frontend/tekster/felles.ts
@@ -3,10 +3,8 @@ import { FellesInnhold } from '../typer/tekster/felles';
 export const fellesTekster: FellesInnhold = {
     neste: {
         nb: 'Neste',
-        en: 'Next',
     },
     forrige: {
         nb: 'Forrige',
-        en: 'Back',
     },
 };

--- a/src/frontend/tekster/forside.ts
+++ b/src/frontend/tekster/forside.ts
@@ -1,0 +1,8 @@
+import { ForsideInnhold } from '../typer/tekster/forside';
+
+export const forsideTekster: ForsideInnhold = {
+    veileder_tittel: {
+        nb: 'Hei [0]',
+        en: 'Hello [0]',
+    },
+};

--- a/src/frontend/tekster/forside.ts
+++ b/src/frontend/tekster/forside.ts
@@ -3,6 +3,5 @@ import { ForsideInnhold } from '../typer/tekster/forside';
 export const forsideTekster: ForsideInnhold = {
     veileder_tittel: {
         nb: 'Hei [0]',
-        en: 'Hello [0]',
     },
 };

--- a/src/frontend/typer/tekster/felles.ts
+++ b/src/frontend/typer/tekster/felles.ts
@@ -1,0 +1,5 @@
+import { Tekst } from './tekst';
+
+type FellesKeys = 'neste' | 'forrige';
+
+export type FellesInnhold = Record<FellesKeys, Tekst>;

--- a/src/frontend/typer/tekster/forside.ts
+++ b/src/frontend/typer/tekster/forside.ts
@@ -1,0 +1,5 @@
+import { Tekst } from './tekst';
+
+type ForsideKeys = 'veileder_tittel';
+
+export type ForsideInnhold = Record<ForsideKeys, Tekst>;

--- a/src/frontend/typer/tekster/tekst.ts
+++ b/src/frontend/typer/tekster/tekst.ts
@@ -1,4 +1,3 @@
 export type Tekst = {
     nb: string;
-    en: string;
 };

--- a/src/frontend/typer/tekster/tekst.ts
+++ b/src/frontend/typer/tekster/tekst.ts
@@ -1,0 +1,4 @@
+export type Tekst = {
+    nb: string;
+    en: string;
+};


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det kommer til å bli mye tekster i søknaden, så disse må håndteres på et vis. 

Har foreløpig kun tatt bokmål med, men det er tilrettelagt for å enkelt kunne legge inn engelsk og nynorsk om ønskelig. 

### Forklaringer 🤓 

- I mappen`/typer/tekster` defineres keys og innhold for den aktuelle siden. 
  - I `typer/tekster/felles.ts` skal man definere `fellesKeys` og `fellesInnhold = Record<fellesKeys, Tekst>`
  - I `typer/tekster/forside.ts` skal man definere `forsideKeys` og `forsideInnhold = Record<forsideKeys, Tekst>`
- I mappen `/tekster` lages det en fil med samme navn som i typer mappen, og filen skal bestå av et object av typen `xInnhold`. Her legges selve teksten inn. 
  - Eksempel: `tekster/felles.ts` inneholder `const felles: FellesInnhold = ...`. 
- Typen `Tekst` er et objekt som foreløpig kun består av `nb`, men man kan senere legge til engelsk og nynorsk i denne typen. 