### PR TITLE
✨ Oppsett av side-komponent

### DIFF
--- a/src/frontend/barnetilsyn/Forside.tsx
+++ b/src/frontend/barnetilsyn/Forside.tsx
@@ -1,10 +1,3 @@
-import { fellesTekster } from './tekster/felles';
-import { Banner } from '../components/Banner';
-
 export const Forside = () => {
-    return (
-        <div>
-            <Banner tittel={fellesTekster.banner} />
-        </div>
-    );
+    return <p>Forside</p>;
 };

--- a/src/frontend/barnetilsyn/Forside.tsx
+++ b/src/frontend/barnetilsyn/Forside.tsx
@@ -1,3 +1,5 @@
-export const Forside = () => {
+const Forside = () => {
     return <p>Forside</p>;
 };
+
+export default Forside;

--- a/src/frontend/barnetilsyn/Søknadsdialog.tsx
+++ b/src/frontend/barnetilsyn/Søknadsdialog.tsx
@@ -2,13 +2,18 @@ import { Route, Routes } from 'react-router';
 
 import { Forside } from './Forside';
 import { Personalia } from './steg/1-personalia/Personalia';
+import { fellesTeksterBT } from './tekster/felles';
+import { Banner } from '../components/Banner';
 
 const Søknadsdialog: React.FC = () => {
     return (
-        <Routes>
-            <Route path={'*'} element={<Forside />} />
-            <Route path={'/personalia'} element={<Personalia />} />
-        </Routes>
+        <>
+            <Banner tittel={fellesTeksterBT.banner} />
+            <Routes>
+                <Route path={'*'} element={<Forside />} />
+                <Route path={'/personalia'} element={<Personalia />} />
+            </Routes>
+        </>
     );
 };
 

--- a/src/frontend/barnetilsyn/Søknadsdialog.tsx
+++ b/src/frontend/barnetilsyn/Søknadsdialog.tsx
@@ -1,7 +1,7 @@
 import { Route, Routes } from 'react-router';
 
-import { Forside } from './Forside';
-import { Personalia } from './steg/1-personalia/Personalia';
+import Forside from './Forside';
+import Personalia from './steg/1-personalia/Personalia';
 import { fellesTeksterBT } from './tekster/felles';
 import { Banner } from '../components/Banner';
 

--- a/src/frontend/barnetilsyn/routing/routesBarnetilsyn.ts
+++ b/src/frontend/barnetilsyn/routing/routesBarnetilsyn.ts
@@ -1,0 +1,17 @@
+import { IRoute } from '../../typer/routes';
+
+export enum ERouteBarnetilsyn {
+    Forside = 'Forside',
+    Personalia = 'Personalia',
+}
+
+export const barnetilsynPath = '/barnetilsyn';
+
+export const RoutesBarnetilsyn: IRoute[] = [
+    { path: barnetilsynPath, label: 'Forside', route: ERouteBarnetilsyn.Forside },
+    {
+        path: barnetilsynPath + '/personalia',
+        label: 'Personalia',
+        route: ERouteBarnetilsyn.Personalia,
+    },
+];

--- a/src/frontend/barnetilsyn/steg/1-personalia/Personalia.tsx
+++ b/src/frontend/barnetilsyn/steg/1-personalia/Personalia.tsx
@@ -1,3 +1,5 @@
-export const Personalia = () => {
+const Personalia = () => {
     return <p>Personalia</p>;
 };
+
+export default Personalia;

--- a/src/frontend/barnetilsyn/tekster/felles.ts
+++ b/src/frontend/barnetilsyn/tekster/felles.ts
@@ -1,12 +1,6 @@
 import { FellesInnhold } from '../typer/tekster/felles';
 
-export const fellesTekster: FellesInnhold = {
-    neste: {
-        nb: 'Neste',
-    },
-    forrige: {
-        nb: 'Forrige',
-    },
+export const fellesTeksterBT: FellesInnhold = {
     banner: {
         nb: 'Søknad om støtte til pass av barn',
     },

--- a/src/frontend/barnetilsyn/typer/tekster/felles.ts
+++ b/src/frontend/barnetilsyn/typer/tekster/felles.ts
@@ -1,5 +1,5 @@
 import { TekstElement } from '../../../typer/tekst';
 
-type FellesKeys = 'neste' | 'forrige' | 'banner';
+type FellesKeys = 'banner';
 
 export type FellesInnhold = Record<FellesKeys, TekstElement>;

--- a/src/frontend/components/Side.tsx
+++ b/src/frontend/components/Side.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 
 import { BodyShort, Button, Heading } from '@navikt/ds-react';
@@ -10,7 +10,7 @@ import { Banner } from './Banner';
 import { LocaleTekst } from './LocaleTekst';
 import { fellesTekster } from '../barnetilsyn/tekster/felles';
 import { Stønadstype } from '../typer/stønadstyper';
-import { hentRoutes } from '../utils/routes';
+import { hentForrigeRoute, hentNesteRoute, hentRoutes } from '../utils/routes';
 
 interface ISide {
     stønadstype: Stønadstype;
@@ -51,9 +51,21 @@ const KnappeContainer = styled.div`
 
 const Side: React.FC<ISide> = ({ stønadstype, stegtittel, children }) => {
     const location = useLocation();
+    const navigate = useNavigate();
 
     const routes = hentRoutes(stønadstype);
-    const aktivtSteg = routes.findIndex((steg) => steg.path === location.pathname);
+    const nåværendePath = location.pathname;
+    const aktivtSteg = routes.findIndex((steg) => steg.path === nåværendePath);
+
+    const navigerTilNesteSide = () => {
+        const nesteRoute = hentNesteRoute(routes, nåværendePath);
+        navigate(nesteRoute.path);
+    };
+
+    const navigerTilForrigeSide = () => {
+        const forrigeRoute = hentForrigeRoute(routes, nåværendePath);
+        navigate(forrigeRoute.path);
+    };
 
     return (
         <>
@@ -69,10 +81,10 @@ const Side: React.FC<ISide> = ({ stønadstype, stegtittel, children }) => {
                 </Steg>
                 <Innhold>{children}</Innhold>
                 <KnappeContainer>
-                    <Button variant="secondary">
+                    <Button variant="secondary" onClick={navigerTilForrigeSide}>
                         <LocaleTekst tekst={fellesTekster.forrige} />
                     </Button>
-                    <Button>
+                    <Button onClick={navigerTilNesteSide}>
                         <LocaleTekst tekst={fellesTekster.neste} />
                     </Button>
                 </KnappeContainer>

--- a/src/frontend/components/Side.tsx
+++ b/src/frontend/components/Side.tsx
@@ -12,7 +12,7 @@ import { fellesTekster } from '../barnetilsyn/tekster/felles';
 import { Stønadstype } from '../typer/stønadstyper';
 import { hentForrigeRoute, hentNesteRoute, hentRoutes } from '../utils/routes';
 
-interface ISide {
+interface Props {
     stønadstype: Stønadstype;
     stegtittel: string;
     children?: React.ReactNode;
@@ -49,7 +49,7 @@ const KnappeContainer = styled.div`
     gap: 1rem;
 `;
 
-const Side: React.FC<ISide> = ({ stønadstype, stegtittel, children }) => {
+const Side: React.FC<Props> = ({ stønadstype, stegtittel, children }) => {
     const location = useLocation();
     const navigate = useNavigate();
 

--- a/src/frontend/components/Side.tsx
+++ b/src/frontend/components/Side.tsx
@@ -8,7 +8,7 @@ import { ABreakpointMd } from '@navikt/ds-tokens/dist/tokens';
 
 import { Banner } from './Banner';
 import { LocaleTekst } from './LocaleTekst';
-import { fellesTekster } from '../barnetilsyn/tekster/felles';
+import { fellesTekster } from '../tekster/felles';
 import { Stønadstype } from '../typer/stønadstyper';
 import { hentForrigeRoute, hentNesteRoute, hentRoutes } from '../utils/routes';
 

--- a/src/frontend/components/Side.tsx
+++ b/src/frontend/components/Side.tsx
@@ -6,7 +6,6 @@ import { styled } from 'styled-components';
 import { BodyShort, Button, Heading } from '@navikt/ds-react';
 import { ABreakpointMd } from '@navikt/ds-tokens/dist/tokens';
 
-import { Banner } from './Banner';
 import { LocaleTekst } from './LocaleTekst';
 import { fellesTekster } from '../tekster/felles';
 import { Stønadstype } from '../typer/stønadstyper';
@@ -68,28 +67,25 @@ const Side: React.FC<Props> = ({ stønadstype, stegtittel, children }) => {
     };
 
     return (
-        <>
-            <Banner tittel={fellesTekster.banner} />
-            <InnholdContainer>
-                <Steg>
-                    <Heading size="medium" as="h2">
-                        {stegtittel}
-                    </Heading>
-                    <BodyShort size="small">
-                        Steg {aktivtSteg} av {routes.length - 1}
-                    </BodyShort>
-                </Steg>
-                <Innhold>{children}</Innhold>
-                <KnappeContainer>
-                    <Button variant="secondary" onClick={navigerTilForrigeSide}>
-                        <LocaleTekst tekst={fellesTekster.forrige} />
-                    </Button>
-                    <Button onClick={navigerTilNesteSide}>
-                        <LocaleTekst tekst={fellesTekster.neste} />
-                    </Button>
-                </KnappeContainer>
-            </InnholdContainer>
-        </>
+        <InnholdContainer>
+            <Steg>
+                <Heading size="medium" as="h2">
+                    {stegtittel}
+                </Heading>
+                <BodyShort size="small">
+                    Steg {aktivtSteg} av {routes.length - 1}
+                </BodyShort>
+            </Steg>
+            <Innhold>{children}</Innhold>
+            <KnappeContainer>
+                <Button variant="secondary" onClick={navigerTilForrigeSide}>
+                    <LocaleTekst tekst={fellesTekster.forrige} />
+                </Button>
+                <Button onClick={navigerTilNesteSide}>
+                    <LocaleTekst tekst={fellesTekster.neste} />
+                </Button>
+            </KnappeContainer>
+        </InnholdContainer>
     );
 };
 

--- a/src/frontend/components/Side.tsx
+++ b/src/frontend/components/Side.tsx
@@ -17,7 +17,7 @@ interface Props {
     children?: React.ReactNode;
 }
 
-const InnholdContainer = styled.div`
+const Container = styled.div`
     padding: 2rem;
     display: flex;
     flex-direction: column;
@@ -67,7 +67,7 @@ const Side: React.FC<Props> = ({ stønadstype, stegtittel, children }) => {
     };
 
     return (
-        <InnholdContainer>
+        <Container>
             <Steg>
                 <Heading size="medium" as="h2">
                     {stegtittel}
@@ -85,7 +85,7 @@ const Side: React.FC<Props> = ({ stønadstype, stegtittel, children }) => {
                     <LocaleTekst tekst={fellesTekster.neste} />
                 </Button>
             </KnappeContainer>
-        </InnholdContainer>
+        </Container>
     );
 };
 

--- a/src/frontend/components/Side.tsx
+++ b/src/frontend/components/Side.tsx
@@ -30,7 +30,7 @@ const Container = styled.div`
     }
 `;
 
-const Steg = styled.div`
+const StegIndikator = styled.div`
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
@@ -68,14 +68,14 @@ const Side: React.FC<Props> = ({ stønadstype, stegtittel, children }) => {
 
     return (
         <Container>
-            <Steg>
+            <StegIndikator>
                 <Heading size="medium" as="h2">
                     {stegtittel}
                 </Heading>
                 <BodyShort size="small">
                     Steg {aktivtSteg} av {routes.length - 1}
                 </BodyShort>
-            </Steg>
+            </StegIndikator>
             <Innhold>{children}</Innhold>
             <KnappeContainer>
                 <Button variant="secondary" onClick={navigerTilForrigeSide}>

--- a/src/frontend/components/Side.tsx
+++ b/src/frontend/components/Side.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+
+import { useLocation } from 'react-router-dom';
+import { styled } from 'styled-components';
+
+import { BodyShort, Button, Heading } from '@navikt/ds-react';
+import { ABreakpointMd } from '@navikt/ds-tokens/dist/tokens';
+
+import { Banner } from './Banner';
+import { LocaleTekst } from './LocaleTekst';
+import { fellesTekster } from '../barnetilsyn/tekster/felles';
+import { Stønadstype } from '../typer/stønadstyper';
+import { hentRoutes } from '../utils/routes';
+
+interface ISide {
+    stønadstype: Stønadstype;
+    stegtittel: string;
+    children?: React.ReactNode;
+}
+
+const InnholdContainer = styled.div`
+    padding: 2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 2.5rem;
+
+    @media (min-width: ${ABreakpointMd}) {
+        max-width: 40rem;
+        margin: auto;
+        padding: 2rem 0;
+    }
+`;
+
+const Steg = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+`;
+
+const Innhold = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+`;
+
+const KnappeContainer = styled.div`
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+`;
+
+const Side: React.FC<ISide> = ({ stønadstype, stegtittel, children }) => {
+    const location = useLocation();
+
+    const routes = hentRoutes(stønadstype);
+    const aktivtSteg = routes.findIndex((steg) => steg.path === location.pathname);
+
+    return (
+        <>
+            <Banner tittel={fellesTekster.banner} />
+            <InnholdContainer>
+                <Steg>
+                    <Heading size="medium" as="h2">
+                        {stegtittel}
+                    </Heading>
+                    <BodyShort size="small">
+                        Steg {aktivtSteg} av {routes.length - 1}
+                    </BodyShort>
+                </Steg>
+                <Innhold>{children}</Innhold>
+                <KnappeContainer>
+                    <Button variant="secondary">
+                        <LocaleTekst tekst={fellesTekster.forrige} />
+                    </Button>
+                    <Button>
+                        <LocaleTekst tekst={fellesTekster.neste} />
+                    </Button>
+                </KnappeContainer>
+            </InnholdContainer>
+        </>
+    );
+};
+
+export default Side;

--- a/src/frontend/tekster/felles.ts
+++ b/src/frontend/tekster/felles.ts
@@ -1,0 +1,10 @@
+import { FellesInnhold } from '../typer/tekst';
+
+export const fellesTekster: FellesInnhold = {
+    neste: {
+        nb: 'Neste',
+    },
+    forrige: {
+        nb: 'Forrige',
+    },
+};

--- a/src/frontend/typer/routes.ts
+++ b/src/frontend/typer/routes.ts
@@ -1,0 +1,9 @@
+import { ERouteBarnetilsyn } from '../barnetilsyn/routing/routesBarnetilsyn';
+
+export type RouteType = ERouteBarnetilsyn;
+
+export interface IRoute {
+    route: RouteType;
+    path: string;
+    label: string;
+}

--- a/src/frontend/typer/stønadstyper.ts
+++ b/src/frontend/typer/stønadstyper.ts
@@ -1,0 +1,3 @@
+export enum Stønadstype {
+    barnetilsyn = 'barnetilsyn',
+}

--- a/src/frontend/typer/tekst.ts
+++ b/src/frontend/typer/tekst.ts
@@ -1,3 +1,7 @@
 export type Locale = 'nb';
 
 export type TekstElement = Record<Locale, string>;
+
+type FellesKeys = 'neste' | 'forrige';
+
+export type FellesInnhold = Record<FellesKeys, TekstElement>;

--- a/src/frontend/utils/routes.ts
+++ b/src/frontend/utils/routes.ts
@@ -1,0 +1,10 @@
+import { RoutesBarnetilsyn } from '../barnetilsyn/routing/routesBarnetilsyn';
+import { IRoute } from '../typer/routes';
+import { Stønadstype } from '../typer/stønadstyper';
+
+export const hentRoutes = (stønadstype: Stønadstype): IRoute[] => {
+    switch (stønadstype) {
+        case Stønadstype.barnetilsyn:
+            return RoutesBarnetilsyn;
+    }
+};

--- a/src/frontend/utils/routes.ts
+++ b/src/frontend/utils/routes.ts
@@ -8,3 +8,13 @@ export const hentRoutes = (stønadstype: Stønadstype): IRoute[] => {
             return RoutesBarnetilsyn;
     }
 };
+
+export const hentNesteRoute = (routes: IRoute[], nåværendePath: string) => {
+    const routeIndex = routes.findIndex((route) => route.path === nåværendePath);
+    return routes[routeIndex + 1];
+};
+
+export const hentForrigeRoute = (routes: IRoute[], nåværendePath: string) => {
+    const routeIndex = routes.findIndex((route) => route.path === nåværendePath);
+    return routes[routeIndex - 1];
+};


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Lage komponent som styrer oppbygningen av sider. Den består av tittel + stegindikator, innhold og navigeringsknapper. 

Har ikke tatt hensyn til noe annet enn "forrige" og "neste" foreløpig, og stegindikatoren er kun i tekst. 

### Bilder 🎨 
<img width="403" alt="image" src="https://github.com/navikt/tilleggsstonader-soknad/assets/46678893/85b831bb-3ee0-4e9f-91d6-f9c6d6f9cea3">
