### PR TITLE
✨ Ta i bruk Side for å strukturere innhold på personalia-steg

### DIFF
--- a/src/frontend/barnetilsyn/steg/1-personalia/Personalia.tsx
+++ b/src/frontend/barnetilsyn/steg/1-personalia/Personalia.tsx
@@ -1,5 +1,20 @@
-const Personalia = () => {
-    return <p>Personalia</p>;
-};
+import { GuidePanel, Heading } from '@navikt/ds-react';
 
+import { LocaleTekst } from '../../../components/LocaleTekst';
+import Side from '../../../components/Side';
+import { Stønadstype } from '../../../typer/stønadstyper';
+import { personaliaTekster } from '../../tekster/personalia';
+
+const Personalia = () => {
+    return (
+        <Side stegtittel={personaliaTekster.steg_tittel} stønadstype={Stønadstype.barnetilsyn}>
+            <Heading size="medium">
+                <LocaleTekst tekst={personaliaTekster.innhold_tittel} />
+            </Heading>
+            <GuidePanel>
+                <LocaleTekst tekst={personaliaTekster.guide_innhold} />
+            </GuidePanel>
+        </Side>
+    );
+};
 export default Personalia;

--- a/src/frontend/barnetilsyn/tekster/personalia.ts
+++ b/src/frontend/barnetilsyn/tekster/personalia.ts
@@ -1,0 +1,13 @@
+import { PersonaliaInnhold } from '../typer/tekster/personalia';
+
+export const personaliaTekster: PersonaliaInnhold = {
+    steg_tittel: {
+        nb: 'Om deg',
+    },
+    innhold_tittel: {
+        nb: 'Vi har registrert dette om deg',
+    },
+    guide_innhold: {
+        nb: 'Det er lurt å sjekke om alt er riktig her så du får svar fra oss i tide og eventuelle utbetalinger kommer til rett konto.',
+    },
+};

--- a/src/frontend/barnetilsyn/typer/tekster/personalia.ts
+++ b/src/frontend/barnetilsyn/typer/tekster/personalia.ts
@@ -1,0 +1,5 @@
+import { TekstElement } from '../../../typer/tekst';
+
+type PersonaliaKeys = 'steg_tittel' | 'innhold_tittel' | 'guide_innhold';
+
+export type PersonaliaInnhold = Record<PersonaliaKeys, TekstElement>;

--- a/src/frontend/components/Side.tsx
+++ b/src/frontend/components/Side.tsx
@@ -9,11 +9,12 @@ import { ABreakpointMd } from '@navikt/ds-tokens/dist/tokens';
 import { LocaleTekst } from './LocaleTekst';
 import { fellesTekster } from '../tekster/felles';
 import { Stønadstype } from '../typer/stønadstyper';
+import { TekstElement } from '../typer/tekst';
 import { hentForrigeRoute, hentNesteRoute, hentRoutes } from '../utils/routes';
 
 interface Props {
     stønadstype: Stønadstype;
-    stegtittel: string;
+    stegtittel: TekstElement;
     children?: React.ReactNode;
 }
 
@@ -70,7 +71,7 @@ const Side: React.FC<Props> = ({ stønadstype, stegtittel, children }) => {
         <Container>
             <StegIndikator>
                 <Heading size="medium" as="h2">
-                    {stegtittel}
+                    <LocaleTekst tekst={stegtittel} />
                 </Heading>
                 <BodyShort size="small">
                     Steg {aktivtSteg} av {routes.length - 1}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ta i bruk `Side` som ble laget i #23  

### Hva er gjort? 
- Definert tekster for personalia-steg (steg 1)
- Tatt inn guidepanelet
- Endret så tittel sendes inn som `TekstElement` og ikke `string` til `Side`

<img width="404" alt="image" src="https://github.com/navikt/tilleggsstonader-soknad/assets/46678893/ebadb8a2-b4c0-4198-be09-bf3d4c4e1dd3">
