### PR TITLE
Bygg skal ikke feile for  dependabot PRer

### DIFF
--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -11,9 +11,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '18'
-          cache: yarn
+          cache: ${{ github.actor != 'dependabot[bot]' && 'yarn' || '' }}
           registry-url: "https://npm.pkg.github.com"
-        if: github.actor != 'dependabot[bot]'
       - name: Yarn install
         run: yarn --prefer-offline --frozen-lockfile
         env:

--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '18'
-          cache: ${{ github.actor != 'dependabot[bot]' && 'yarn' || '' }}
+          cache: yarn
           registry-url: "https://npm.pkg.github.com"
       - name: Yarn install
         run: yarn --prefer-offline --frozen-lockfile


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Fjerner if-sjekk som gjorde at node/npm config kun ble utført dersom actor ikke var dependabot. Dette gjorde at henting av @navikt-pakker feilet og at man fikk 403 på yarn install.

Med denne endringen vil vi fortsatt ikke bruke cache for dependabot-PRer.


