### PR TITLE
Skal lagre og hente personopplysninger i context

### DIFF
--- a/src/frontend/context/PersonContext.tsx
+++ b/src/frontend/context/PersonContext.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+
+import createUseContext from 'constate';
+
+import { initiellPerson } from '../mock/initiellPerson';
+import { Person } from '../typer/person';
+
+const [PersonProvider, usePerson] = createUseContext(() => {
+    PersonProvider.displayName = 'PERSON_PROVIDER';
+    const [person, settPerson] = useState<Person>(initiellPerson);
+
+    useEffect(() => {
+        // TODO: Fetch persondata.
+        settPerson({
+            fnr: 'fødselsnummer',
+            navn: 'Ole Jørgen Nilsen',
+            adresse: {
+                adresse: 'Liaveien 34',
+                postnummer: '0152',
+                poststed: 'Oslo',
+            },
+            telefonnr: '950863265',
+            epost: 'mail@gmail.com',
+            kontonr: '1234.56.78910',
+        });
+    }, []);
+
+    return { person, settPerson };
+});
+
+export { PersonProvider, usePerson };

--- a/src/frontend/mock/initiellPerson.ts
+++ b/src/frontend/mock/initiellPerson.ts
@@ -1,0 +1,14 @@
+import { Person } from '../typer/person';
+
+export const initiellPerson: Person = {
+    fnr: '',
+    navn: '',
+    adresse: {
+        adresse: '',
+        postnummer: '',
+        poststed: '',
+    },
+    telefonnr: '',
+    epost: '',
+    kontonr: '',
+};

--- a/src/frontend/typer/person.ts
+++ b/src/frontend/typer/person.ts
@@ -1,13 +1,13 @@
 export interface Person {
     fnr: string;
     navn: string;
-    adresse: IAdresse;
+    adresse: Adresse;
     telefonnr: string;
     epost: string;
     kontonr: string;
 }
 
-export interface IAdresse {
+export interface Adresse {
     adresse: string;
     postnummer: string;
     poststed?: string;

--- a/src/frontend/typer/person.ts
+++ b/src/frontend/typer/person.ts
@@ -1,0 +1,14 @@
+export interface Person {
+    fnr: string;
+    navn: string;
+    adresse: IAdresse;
+    telefonnr: string;
+    epost: string;
+    kontonr: string;
+}
+
+export interface IAdresse {
+    adresse: string;
+    postnummer: string;
+    poststed?: string;
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
For side 2 (personalia) trenger vi å vise personopplysninger. Vi trenger også navnet til side 1.

Dette har nå blitt løst ved å lage en context for person. Per nå legges det inn tulledata direkte, men det er markert med TODO hvor et kall til backend kan legges inn.