### PR TITLE
Children skal ikke være obligatorisk prop for LocaleRadioGruppe

### DIFF
--- a/src/frontend/components/Teksthåndtering/LocaleRadioGroup.tsx
+++ b/src/frontend/components/Teksthåndtering/LocaleRadioGroup.tsx
@@ -5,8 +5,10 @@ import { Radio, RadioGroup, RadioGroupProps as AkselRadioGroupProps } from '@nav
 import { useSpråk } from '../../context/SpråkContext';
 import { Radiogruppe, TekstElement } from '../../typer/tekst';
 
-interface RadioGroupProps<T> extends Omit<AkselRadioGroupProps, 'legend' | 'description'> {
+interface RadioGroupProps<T>
+    extends Omit<AkselRadioGroupProps, 'legend' | 'description' | 'children'> {
     tekst: TekstElement<Radiogruppe<T>>;
+    children?: React.ReactNode;
 }
 function LocaleRadioGroup<T>({ children, tekst, ...props }: RadioGroupProps<T>) {
     const { locale } = useSpråk();


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Man vil ikke alltid sende inn `children`.