### PR TITLE
Skal ha key med ved listing av radio-alternativer

### DIFF
--- a/src/frontend/components/Teksthåndtering/LocaleRadioGroup.tsx
+++ b/src/frontend/components/Teksthåndtering/LocaleRadioGroup.tsx
@@ -20,8 +20,10 @@ function LocaleRadioGroup<T>({ children, tekst, ...props }: RadioGroupProps<T>) 
             {...props}
         >
             {children}
-            {tekst.alternativer.map((alternativ) => (
-                <Radio value={alternativ.value}>{alternativ.label[locale]}</Radio>
+            {tekst.alternativer.map((alternativ, indeks) => (
+                <Radio value={alternativ.value} key={indeks}>
+                    {alternativ.label[locale]}
+                </Radio>
             ))}
         </RadioGroup>
     );


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Optimalisering og unngå warnings i consolen.
