### PR TITLE
Skal ha med Heading på hovedytelse-siden

### DIFF
--- a/src/frontend/barnetilsyn/steg/2-hovedytelse/Hovedytelse.tsx
+++ b/src/frontend/barnetilsyn/steg/2-hovedytelse/Hovedytelse.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 
+import { Heading } from '@navikt/ds-react';
+
 import { AnnenYtelse, erYtelse, Ytelse } from './typer';
 import { PellePanel } from '../../../components/PellePanel/PellePanel';
 import Side from '../../../components/Side';
@@ -56,6 +58,9 @@ const Hovedytelse = () => {
                 }
             }}
         >
+            <Heading size="medium">
+                <LocaleTekst tekst={hovedytelseInnhold.innhold_tittel} />
+            </Heading>
             <PellePanel>
                 <LocaleTekst tekst={hovedytelseInnhold.guide_innhold} />
             </PellePanel>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Glemte denne

<img width="810" alt="image" src="https://github.com/navikt/tilleggsstonader-soknad/assets/21220467/b8dce291-ec9c-48ed-9451-35c990a33ace">
