### PR TITLE
Bugfix. Hovedytelse skal settes til annet dersom det er av typen AnnenYtelse

### DIFF
--- a/src/frontend/barnetilsyn/steg/2-hovedytelse/Hovedytelse.tsx
+++ b/src/frontend/barnetilsyn/steg/2-hovedytelse/Hovedytelse.tsx
@@ -16,7 +16,7 @@ const Hovedytelse = () => {
     const { hovedytelse, settHovedytelse } = useSøknad();
 
     const [ytelse, settYtelse] = useState<Ytelse | undefined>(
-        hovedytelse && erYtelse(hovedytelse.ytelse) ? hovedytelse.ytelse : undefined
+        hovedytelse && erYtelse(hovedytelse.ytelse) ? hovedytelse.ytelse : 'annet'
     );
     const [ytelseFeil, settYtelseFeil] = useState('');
 

--- a/src/frontend/barnetilsyn/steg/2-hovedytelse/Hovedytelse.tsx
+++ b/src/frontend/barnetilsyn/steg/2-hovedytelse/Hovedytelse.tsx
@@ -16,7 +16,7 @@ const Hovedytelse = () => {
     const { hovedytelse, settHovedytelse } = useSøknad();
 
     const [ytelse, settYtelse] = useState<Ytelse | undefined>(
-        hovedytelse && erYtelse(hovedytelse.ytelse) ? hovedytelse.ytelse : 'annet'
+        hovedytelse && (erYtelse(hovedytelse.ytelse) ? hovedytelse.ytelse : 'annet')
     );
     const [ytelseFeil, settYtelseFeil] = useState('');
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Fiks. Man fikk ikke riktig initState dersom det var annen ytelse.
