### PR TITLE
Skal fjerne feilmelding på RadioGroup når man tar et valg

### DIFF
--- a/src/frontend/barnetilsyn/steg/2-hovedytelse/Hovedytelse.tsx
+++ b/src/frontend/barnetilsyn/steg/2-hovedytelse/Hovedytelse.tsx
@@ -69,6 +69,7 @@ const Hovedytelse = () => {
                 value={ytelse || ''}
                 onChange={(verdi) => {
                     settYtelse(verdi);
+                    settYtelseFeil('');
                     settAnnenYtelse(undefined);
                 }}
                 error={ytelseFeil}
@@ -79,7 +80,10 @@ const Hovedytelse = () => {
                 <LocaleRadioGroup
                     tekst={hovedytelseInnhold.radio_annen_ytelse}
                     value={annenYtelse || ''}
-                    onChange={(verdi) => settAnnenYtelse(verdi)}
+                    onChange={(verdi) => {
+                        settAnnenYtelse(verdi);
+                        settAnnenYtelseFeil('');
+                    }}
                     error={annenYtelseFeil}
                 />
             )}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Trenger ikke å vise feilmelding etter at man har tatt en nytt valg, da vi uansett validerer på nytt når man går til neste steg.


