### PR TITLE
Skal kunne sette inn variabel i LocaleTekst

### DIFF
--- a/src/frontend/barnetilsyn/Forside.tsx
+++ b/src/frontend/barnetilsyn/Forside.tsx
@@ -20,6 +20,7 @@ import { Container } from '../components/Side';
 import LocalePunktliste from '../components/Teksthåndtering/LocalePunktliste';
 import LocaleTekst from '../components/Teksthåndtering/LocaleTekst';
 import LocaleTekstAvsnitt from '../components/Teksthåndtering/LocaleTekstAvsnitt';
+import { usePerson } from '../context/PersonContext';
 import { useSøknad } from '../context/SøknadContext';
 import { hentNesteRoute } from '../utils/routes';
 
@@ -33,6 +34,7 @@ const Forside: React.FC = () => {
     const navigate = useNavigate();
     const location = useLocation();
     const { harBekreftet, settHarBekreftet } = useSøknad();
+    const { person } = usePerson();
 
     const startSøknad = () => {
         if (harBekreftet) {
@@ -45,7 +47,7 @@ const Forside: React.FC = () => {
         <Container>
             <PellePanel poster>
                 <Label>
-                    <LocaleTekst tekst={forsideTekster.veileder_tittel} />
+                    <LocaleTekst tekst={forsideTekster.veileder_tittel} argument0={person.navn} />
                 </Label>
                 <LocaleTekstAvsnitt tekst={forsideTekster.veileder_innhold} />
             </PellePanel>

--- a/src/frontend/components/Teksthåndtering/LocaleTekst.tsx
+++ b/src/frontend/components/Teksthåndtering/LocaleTekst.tsx
@@ -1,10 +1,15 @@
 import { useSpråk } from '../../context/SpråkContext';
 import { TekstElement } from '../../typer/tekst';
+import { hentBeskjedMedEttParameter } from '../../utils/tekster';
 
-const LocaleTekst: React.FC<{ tekst: TekstElement<string> }> = ({ tekst }) => {
+const LocaleTekst: React.FC<{ tekst: TekstElement<string>; argument0?: string }> = ({
+    tekst,
+    argument0,
+}) => {
     const { locale } = useSpråk();
+    const tekstStreng = tekst[locale];
 
-    return <>{tekst[locale]}</>;
+    return <>{argument0 ? hentBeskjedMedEttParameter(argument0, tekstStreng) : tekstStreng}</>;
 };
 
 export default LocaleTekst;

--- a/src/frontend/utils/tekster.ts
+++ b/src/frontend/utils/tekster.ts
@@ -1,0 +1,3 @@
+export const hentBeskjedMedEttParameter = (argument0: string, tekststreng: string) => {
+    return tekststreng.replace('[0]', argument0);
+};


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det er nødvendig å kunne legge inn f.eks. brukers navn i tekster. 

Dette ble nå lagt inn i `LocaleTekst` men det kunne evt vært en egen komponent. Hva tenker dere?

Navn satt inn som `argument0`
<img width="640" alt="image" src="https://github.com/navikt/tilleggsstonader-soknad/assets/46678893/c976709a-1692-4add-ac31-d3a7f5b649b8">
