### PR TITLE
Alert og oppfølgingsspørsmål dersom ikke søker ifb regisrtert tiltak/utdanning

### DIFF
--- a/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
+++ b/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
 
-import { Alert, BodyLong, BodyShort, Heading } from '@navikt/ds-react';
+import { Alert, BodyShort, Heading } from '@navikt/ds-react';
 
 import UtadnningTiltak from './UtdanningTiltak';
 import Side from '../../../components/Side';
 import LocaleRadioGroup from '../../../components/Teksthåndtering/LocaleRadioGroup';
 import LocaleReadMore from '../../../components/Teksthåndtering/LocaleReadMore';
 import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
+import LocaleTekstAvsnitt from '../../../components/Teksthåndtering/LocaleTekstAvsnitt';
 import { useSøknad } from '../../../context/SøknadContext';
 import { useTiltak } from '../../../hooks/useTiltak';
 import { Stønadstype } from '../../../typer/stønadstyper';
@@ -79,21 +80,9 @@ const Aktivitet = () => {
                     {utdanning === 'nei' && (
                         <>
                             <Alert variant={'info'}>
-                                <BodyLong spacing>
-                                    <LocaleTekst
-                                        tekst={aktivitetTekster.feil_utdanning_infoalert1}
-                                    />
-                                </BodyLong>
-                                <BodyLong spacing>
-                                    <LocaleTekst
-                                        tekst={aktivitetTekster.feil_utdanning_infoalert2}
-                                    />
-                                </BodyLong>
-                                <BodyLong>
-                                    <LocaleTekst
-                                        tekst={aktivitetTekster.feil_utdanning_infoalert3}
-                                    />
-                                </BodyLong>
+                                <LocaleTekstAvsnitt
+                                    tekst={aktivitetTekster.feil_utdanning_infoalert}
+                                />
                             </Alert>
                             <LocaleRadioGroup
                                 tekst={aktivitetTekster.radio_utdanning}

--- a/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
+++ b/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { BodyShort, Heading } from '@navikt/ds-react';
+import { Alert, BodyLong, BodyShort, Heading } from '@navikt/ds-react';
 
 import UtadnningTiltak from './UtdanningTiltak';
 import Side from '../../../components/Side';
@@ -23,9 +23,19 @@ const Aktivitet = () => {
     );
     const [feil, settFeil] = useState('');
 
+    const [fortsattSøke, settFortsattSøke] = useState<JaNei | undefined>(
+        aktivitet && aktivitet.utdanning === 'nei' ? 'ja' : undefined
+    );
+    const [fortsattSøkeFeil, settFortsattSøkeFeil] = useState('');
+
     const kanFortsette = (barnepassPgaUtdanning?: JaNei): boolean => {
         if (barnepassPgaUtdanning === undefined) {
             settFeil('Du må velge et alternativ');
+            return false;
+        }
+
+        if (barnepassPgaUtdanning === 'nei' && fortsattSøke !== 'ja') {
+            settFortsattSøkeFeil('Du må velge et alternativ');
             return false;
         }
 
@@ -60,9 +70,40 @@ const Aktivitet = () => {
                         onChange={(verdi) => {
                             settUtdanning(verdi);
                             settFeil('');
+                            settFortsattSøkeFeil('');
                         }}
                         error={feil}
                     />
+                    {utdanning === 'nei' && (
+                        <>
+                            <Alert variant={'info'}>
+                                <BodyLong spacing>
+                                    <LocaleTekst
+                                        tekst={aktivitetTekster.feil_utdanning_infoalert1}
+                                    />
+                                </BodyLong>
+                                <BodyLong spacing>
+                                    <LocaleTekst
+                                        tekst={aktivitetTekster.feil_utdanning_infoalert2}
+                                    />
+                                </BodyLong>
+                                <BodyLong>
+                                    <LocaleTekst
+                                        tekst={aktivitetTekster.feil_utdanning_infoalert3}
+                                    />
+                                </BodyLong>
+                            </Alert>
+                            <LocaleRadioGroup
+                                tekst={aktivitetTekster.radio_utdanning}
+                                value={fortsattSøke || ''}
+                                onChange={(verdi) => {
+                                    settFortsattSøke(verdi);
+                                    settFortsattSøkeFeil('');
+                                }}
+                                error={fortsattSøkeFeil}
+                            />
+                        </>
+                    )}
                 </>
             )}
         </Side>

--- a/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
+++ b/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
@@ -47,7 +47,7 @@ const Aktivitet = () => {
             settAktivitet({ utdanning: utdanning });
         }
     };
-    
+
     return (
         <Side
             stegtittel={aktivitetTekster.steg_tittel}
@@ -70,6 +70,7 @@ const Aktivitet = () => {
                         value={utdanning || ''}
                         onChange={(verdi) => {
                             settUtdanning(verdi);
+                            settFortsattSøke(undefined);
                             settFeil('');
                             settFortsattSøkeFeil('');
                         }}

--- a/src/frontend/barnetilsyn/tekster/aktivitet.ts
+++ b/src/frontend/barnetilsyn/tekster/aktivitet.ts
@@ -9,9 +9,7 @@ interface AktivitetInnhold {
     innhold_utdanning: TekstElement<string>;
     godkjent_utdanning: TekstElement<string>;
     noe_feil_utdanning_lesmer: TekstElement<LesMer>;
-    feil_utdanning_infoalert1: TekstElement<string>;
-    feil_utdanning_infoalert2: TekstElement<string>;
-    feil_utdanning_infoalert3: TekstElement<string>;
+    feil_utdanning_infoalert: TekstElement<string[]>;
     radio_fortsatt_søke: Radiogruppe<JaNei>;
 }
 
@@ -43,14 +41,12 @@ export const aktivitetTekster: AktivitetInnhold = {
             ],
         },
     },
-    feil_utdanning_infoalert1: {
-        nb: 'Vi anbefaler deg å ta kontakt med din veileder for å få registrert din arbeidsrettede aktivitet eller utdanning.',
-    },
-    feil_utdanning_infoalert2: {
-        nb: 'Du kan fortsatt søke nå, men da vil det ta lengre tid for oss å behandle din søknad.',
-    },
-    feil_utdanning_infoalert3: {
-        nb: 'Merk deg at medisinsk behandling ikke gir rett til støtte for pass av barn.',
+    feil_utdanning_infoalert: {
+        nb: [
+            'Vi anbefaler deg å ta kontakt med din veileder for å få registrert din arbeidsrettede aktivitet eller utdanning.',
+            'Du kan fortsatt søke nå, men da vil det ta lengre tid for oss å behandle din søknad.',
+            'Merk deg at medisinsk behandling ikke gir rett til støtte for pass av barn.',
+        ],
     },
     radio_fortsatt_søke: {
         header: {

--- a/src/frontend/barnetilsyn/tekster/aktivitet.ts
+++ b/src/frontend/barnetilsyn/tekster/aktivitet.ts
@@ -9,6 +9,10 @@ interface AktivitetInnhold {
     innhold_utdanning: TekstElement<string>;
     godkjent_utdanning: TekstElement<string>;
     noe_feil_utdanning_lesmer: TekstElement<LesMer>;
+    feil_utdanning_infoalert1: TekstElement<string>;
+    feil_utdanning_infoalert2: TekstElement<string>;
+    feil_utdanning_infoalert3: TekstElement<string>;
+    radio_fortsatt_søke: Radiogruppe<JaNei>;
 }
 
 export const aktivitetTekster: AktivitetInnhold = {
@@ -38,5 +42,20 @@ export const aktivitetTekster: AktivitetInnhold = {
                 'Du kan fortsatt søke nå, men da kan det ta lengre tid for oss å behandle din søknad. ',
             ],
         },
+    },
+    feil_utdanning_infoalert1: {
+        nb: 'Vi anbefaler deg å ta kontakt med din veileder for å få registrert din arbeidsrettede aktivitet eller utdanning.',
+    },
+    feil_utdanning_infoalert2: {
+        nb: 'Du kan fortsatt søke nå, men da vil det ta lengre tid for oss å behandle din søknad.',
+    },
+    feil_utdanning_infoalert3: {
+        nb: 'Merk deg at medisinsk behandling ikke gir rett til støtte for pass av barn.',
+    },
+    radio_fortsatt_søke: {
+        header: {
+            nb: 'Vil du fortsatt søke nå?',
+        },
+        alternativer: jaNeiAlternativer,
     },
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Hvis bruker ikke søker støtte til pass i forbindelse med registrert utdanning skal vi vise alert og oppfølgingsspørsmål. Har ikke implementert logikk for hva som skjer når man trykker "nei".

![image](https://github.com/navikt/tilleggsstonader-soknad/assets/21220467/568b963e-6dd1-4b3c-a698-4d33b97f0b72)
![image](https://github.com/navikt/tilleggsstonader-soknad/assets/21220467/8fa9a11f-922f-405c-9222-2ee765479507)


