### PR TITLE
Skal bare lage en dependabot-PR med alle oppdateringer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,9 @@ updates:
   open-pull-requests-limit: 30
   registries: "*"
   versioning-strategy: increase
+  groups:
+    patterns:
+      - "*"
   ignore:
    - dependency-name: "*"
      update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Vi pleier uansett å lage en samlebranch med alle dependabot-oppdateringer. Så lenge dependabot ikke kan automerge tenker jeg dette er like greit, da vi sjeldent må gjøre endringer.