### PR TITLE
Oppsummeringsside 📄 

### DIFF
--- a/src/frontend/barnetilsyn/routing/routesBarnetilsyn.ts
+++ b/src/frontend/barnetilsyn/routing/routesBarnetilsyn.ts
@@ -13,46 +13,57 @@ export enum ERouteBarnetilsyn {
 }
 
 export const barnetilsynPath = '/barnetilsyn';
+export const RouteTilPath: Record<ERouteBarnetilsyn, string> = {
+    AKTIVITET: barnetilsynPath + '/aktivitet',
+    BARNEPASS: barnetilsynPath + '/barnepass',
+    DINE_BARN: barnetilsynPath + '/dine-barn',
+    FORSIDE: barnetilsynPath,
+    HOVEDYTELSE: barnetilsynPath + '/hovedytelse',
+    KVITTERING: barnetilsynPath + '/kvittering',
+    OPPSUMMERING: barnetilsynPath + '/oppsummering',
+    PERSONALIA: barnetilsynPath + '/personalia',
+    VEDLEGG: barnetilsynPath + '/vedlegg',
+};
 
 export const RoutesBarnetilsyn: IRoute[] = [
     { path: barnetilsynPath, label: 'Forside', route: ERouteBarnetilsyn.FORSIDE },
     {
-        path: barnetilsynPath + '/personalia',
+        path: RouteTilPath.PERSONALIA,
         label: 'Personalia',
         route: ERouteBarnetilsyn.PERSONALIA,
     },
     {
-        path: barnetilsynPath + '/hovedytelse',
+        path: RouteTilPath.HOVEDYTELSE,
         label: 'Hovedytelse',
         route: ERouteBarnetilsyn.HOVEDYTELSE,
     },
     {
-        path: barnetilsynPath + '/aktivitet',
+        path: RouteTilPath.AKTIVITET,
         label: 'Aktivitet',
         route: ERouteBarnetilsyn.AKTIVITET,
     },
     {
-        path: barnetilsynPath + '/dine-barn',
-        label: 'Personalia',
+        path: RouteTilPath.DINE_BARN,
+        label: 'Dine barn',
         route: ERouteBarnetilsyn.DINE_BARN,
     },
     {
-        path: barnetilsynPath + '/barnepass',
+        path: RouteTilPath.BARNEPASS,
         label: 'Barnepass',
         route: ERouteBarnetilsyn.BARNEPASS,
     },
     {
-        path: barnetilsynPath + '/vedlegg',
+        path: RouteTilPath.VEDLEGG,
         label: 'Vedlegg',
         route: ERouteBarnetilsyn.VEDLEGG,
     },
     {
-        path: barnetilsynPath + '/oppsummering',
+        path: RouteTilPath.OPPSUMMERING,
         label: 'Oppsummering',
         route: ERouteBarnetilsyn.OPPSUMMERING,
     },
     {
-        path: barnetilsynPath + '/kvittering',
+        path: RouteTilPath.KVITTERING,
         label: 'Personalia',
         route: ERouteBarnetilsyn.KVITTERING,
     },

--- a/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
@@ -38,6 +38,7 @@ const FlexDiv = styled.div`
     display: flex;
     flex-direction: column;
     gap: 1rem;
+    align-items: flex-start;
 `;
 
 const Oppsummering = () => {

--- a/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
@@ -1,13 +1,264 @@
+import { useState } from 'react';
+
+import { styled } from 'styled-components';
+
+import { PaperclipIcon } from '@navikt/aksel-icons';
+import {
+    Accordion,
+    BodyLong,
+    BodyShort,
+    Checkbox,
+    CheckboxGroup,
+    Heading,
+    Label,
+} from '@navikt/ds-react';
+
+import { PellePanel } from '../../../components/PellePanel/PellePanel';
 import Side from '../../../components/Side';
+import LocaleReadMore from '../../../components/Teksthåndtering/LocaleReadMore';
+import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
+import { usePerson } from '../../../context/PersonContext';
+import { useSøknad } from '../../../context/SøknadContext';
+import { JaNeiTilTekst } from '../../../tekster/felles';
 import { Stønadstype } from '../../../typer/stønadstyper';
+import { formaterAdresse, formaterIsoDato, hentFornavn } from '../../../utils/formatering';
+import {
+    barnepassTekster,
+    PassTypeTilTekst,
+    ÅrsakEkstraPassTilTekst,
+} from '../../tekster/barnepass';
+import { YtelseTilTekst } from '../../tekster/hovedytelse';
 import { oppsummeringTekster } from '../../tekster/oppsummering';
+import { personaliaTekster } from '../../tekster/personalia';
+
+const FlexDiv = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+`;
 
 const Oppsummering = () => {
+    const { hovedytelse, barnMedBarnepass } = useSøknad();
+    const { person } = usePerson();
+
+    const [harBekreftet, settHarBekreftet] = useState(false);
+    const [feil, settFeil] = useState<string>('');
+
     return (
         <Side
             stegtittel={oppsummeringTekster.steg_tittel}
             stønadstype={Stønadstype.barnetilsyn}
-        ></Side>
+            validerSteg={() => {
+                if (!harBekreftet) {
+                    settFeil('Du må bekrefte for å sende inn søknaden');
+                    return false;
+                }
+                settFeil('');
+                return true;
+            }}
+        >
+            <Heading size={'medium'}>
+                <LocaleTekst tekst={oppsummeringTekster.steg_tittel} />
+            </Heading>
+            <PellePanel>
+                <LocaleTekst tekst={oppsummeringTekster.guide_innhold} />
+            </PellePanel>
+            <Accordion>
+                <Accordion.Item>
+                    <Accordion.Header>
+                        <LocaleTekst tekst={oppsummeringTekster.accordians.om_deg.tittel} />
+                    </Accordion.Header>
+                    <Accordion.Content>
+                        <FlexDiv>
+                            <div>
+                                <Label>
+                                    <LocaleTekst tekst={personaliaTekster.adresse_label} />
+                                </Label>
+                                <BodyShort>{formaterAdresse(person.adresse)}</BodyShort>
+                                <LocaleReadMore tekst={personaliaTekster.adresse_lesmer} />
+                            </div>
+                            <div>
+                                <Label>
+                                    <LocaleTekst tekst={personaliaTekster.telefonnr_label} />
+                                </Label>
+                                <BodyShort>{person.telefonnr}</BodyShort>
+                            </div>
+                            <div>
+                                <Label>
+                                    <LocaleTekst tekst={personaliaTekster.epost_label} />
+                                </Label>
+                                <BodyShort>{person.epost}</BodyShort>
+                                <LocaleReadMore tekst={personaliaTekster.tlf_epost_lesmer} />
+                            </div>
+                            <div>
+                                <Label>
+                                    <LocaleTekst tekst={personaliaTekster.kontonr_label} />
+                                </Label>
+                                <BodyShort>{person.epost}</BodyShort>
+                                <LocaleReadMore tekst={personaliaTekster.kontonr_lesmer} />
+                            </div>
+                        </FlexDiv>
+                    </Accordion.Content>
+                </Accordion.Item>
+                <Accordion.Item>
+                    <Accordion.Header>
+                        <LocaleTekst tekst={oppsummeringTekster.accordians.ytelse.tittel} />
+                    </Accordion.Header>
+                    <Accordion.Content>
+                        <Label>
+                            <LocaleTekst tekst={oppsummeringTekster.accordians.ytelse.label} />
+                        </Label>
+                        {hovedytelse && (
+                            <BodyShort>
+                                <LocaleTekst tekst={YtelseTilTekst[hovedytelse.ytelse]} />
+                            </BodyShort>
+                        )}
+                    </Accordion.Content>
+                </Accordion.Item>
+                <Accordion.Item>
+                    <Accordion.Header>
+                        <LocaleTekst
+                            tekst={oppsummeringTekster.accordians.aktivitet_utdanning.tittel}
+                        />
+                    </Accordion.Header>
+                    <Accordion.Content>
+                        {/*TODO: Hardkodet*/}
+                        <Label>Utdanning</Label>
+                        <BodyShort>Livets skole</BodyShort>
+                        <BodyShort>Universitetsgaten 22</BodyShort>
+                        <BodyLong spacing>2004 Lillestrøm</BodyLong>
+
+                        <BodyShort>1. januar 2023 - 30. juni 2026</BodyShort>
+                    </Accordion.Content>
+                </Accordion.Item>
+                <Accordion.Item>
+                    <Accordion.Header>
+                        <LocaleTekst tekst={oppsummeringTekster.accordians.dine_barn.tittel} />
+                    </Accordion.Header>
+                    <Accordion.Content>
+                        <Label>
+                            <LocaleTekst tekst={oppsummeringTekster.accordians.dine_barn.label} />
+                        </Label>
+                        {person.barn
+                            .filter((barn) => barn.skalHaBarnepass)
+                            .map((barn) => (
+                                <BodyShort key={barn.id}>
+                                    {barn.navn}, født {formaterIsoDato(barn.fødselsdato)}
+                                </BodyShort>
+                            ))}
+                    </Accordion.Content>
+                </Accordion.Item>
+                <Accordion.Item>
+                    <Accordion.Header>
+                        <LocaleTekst tekst={oppsummeringTekster.accordians.barnepass.tittel} />
+                    </Accordion.Header>
+                    <Accordion.Content>
+                        <FlexDiv>
+                            {barnMedBarnepass.map((barnepass) => {
+                                const barn = person.barn.find(
+                                    (barn) => barn.id === barnepass.barnId
+                                );
+                                return barn ? (
+                                    <div key={barnepass.barnId}>
+                                        <Label>
+                                            <LocaleTekst
+                                                tekst={barnepassTekster.hvem_passer_radio.header}
+                                                argument0={hentFornavn(barn.navn)}
+                                            />
+                                        </Label>
+                                        <BodyShort>
+                                            <LocaleTekst
+                                                tekst={PassTypeTilTekst[barnepass.passType]}
+                                            />
+                                        </BodyShort>
+                                        {barn.alder >= 9 && (
+                                            <>
+                                                <Label>
+                                                    <LocaleTekst
+                                                        tekst={
+                                                            barnepassTekster.startet_femte_radio
+                                                                .header
+                                                        }
+                                                        argument0={hentFornavn(barn.navn)}
+                                                    />
+                                                </Label>
+                                                <BodyShort>
+                                                    <LocaleTekst
+                                                        tekst={
+                                                            barnepass.startetIFemte
+                                                                ? JaNeiTilTekst.ja
+                                                                : JaNeiTilTekst.nei
+                                                        }
+                                                    />
+                                                </BodyShort>
+                                                <Label>
+                                                    <LocaleTekst
+                                                        tekst={
+                                                            barnepassTekster.årsak_ekstra_pass_radio
+                                                                .header
+                                                        }
+                                                        argument0={hentFornavn(barn.navn)}
+                                                    />
+                                                </Label>
+                                                {barnepass.årsakBarnepass && (
+                                                    <BodyShort>
+                                                        <LocaleTekst
+                                                            tekst={
+                                                                ÅrsakEkstraPassTilTekst[
+                                                                    barnepass.årsakBarnepass
+                                                                ]
+                                                            }
+                                                        />
+                                                    </BodyShort>
+                                                )}
+                                            </>
+                                        )}
+                                    </div>
+                                ) : null;
+                            })}
+                        </FlexDiv>
+                    </Accordion.Content>
+                </Accordion.Item>
+                <Accordion.Item>
+                    <Accordion.Header>
+                        <LocaleTekst tekst={oppsummeringTekster.accordians.vedlegg.tittel} />
+                    </Accordion.Header>
+                    <Accordion.Content>
+                        <Label spacing>
+                            <LocaleTekst tekst={oppsummeringTekster.accordians.vedlegg.label} />
+                        </Label>
+                        {/*TODO: Hardkodet*/}
+                        <BodyLong>Faktura på pass for Espen og Ronja</BodyLong>
+                        <BodyLong>
+                            <PaperclipIcon /> barnehage.pdf
+                        </BodyLong>
+                        <BodyLong spacing>
+                            <PaperclipIcon /> sfo.pdf
+                        </BodyLong>
+
+                        <BodyLong>Legeerklæring for Espen</BodyLong>
+                        <BodyLong spacing>
+                            <PaperclipIcon /> legen.pdf
+                        </BodyLong>
+                    </Accordion.Content>
+                </Accordion.Item>
+            </Accordion>
+
+            <CheckboxGroup
+                value={[harBekreftet]}
+                onChange={(verdier) => {
+                    settHarBekreftet(verdier.includes(true));
+                    settFeil('');
+                }}
+                legend={<LocaleTekst tekst={oppsummeringTekster.bekreft_checkboks} />}
+                hideLegend
+                error={feil}
+            >
+                <Checkbox value={true} error={!!feil}>
+                    <LocaleTekst tekst={oppsummeringTekster.bekreft_checkboks} />
+                </Checkbox>
+            </CheckboxGroup>
+        </Side>
     );
 };
 

--- a/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
@@ -1,12 +1,14 @@
 import { useState } from 'react';
 
+import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 
-import { PaperclipIcon } from '@navikt/aksel-icons';
+import { ChevronLeftIcon, PaperclipIcon } from '@navikt/aksel-icons';
 import {
     Accordion,
     BodyLong,
     BodyShort,
+    Button,
     Checkbox,
     CheckboxGroup,
     Heading,
@@ -22,6 +24,7 @@ import { useSøknad } from '../../../context/SøknadContext';
 import { JaNeiTilTekst } from '../../../tekster/felles';
 import { Stønadstype } from '../../../typer/stønadstyper';
 import { formaterAdresse, formaterIsoDato, hentFornavn } from '../../../utils/formatering';
+import { RouteTilPath } from '../../routing/routesBarnetilsyn';
 import {
     barnepassTekster,
     PassTypeTilTekst,
@@ -40,6 +43,7 @@ const FlexDiv = styled.div`
 const Oppsummering = () => {
     const { hovedytelse, barnMedBarnepass } = useSøknad();
     const { person } = usePerson();
+    const navigate = useNavigate();
 
     const [harBekreftet, settHarBekreftet] = useState(false);
     const [feil, settFeil] = useState<string>('');
@@ -113,6 +117,16 @@ const Oppsummering = () => {
                                 <LocaleTekst tekst={YtelseTilTekst[hovedytelse.ytelse]} />
                             </BodyShort>
                         )}
+                        <Button
+                            variant={'tertiary'}
+                            onClick={() => navigate(RouteTilPath.HOVEDYTELSE)}
+                            iconPosition="left"
+                            icon={<ChevronLeftIcon aria-hidden />}
+                        >
+                            <LocaleTekst
+                                tekst={oppsummeringTekster.accordians.ytelse.endre_button}
+                            />
+                        </Button>
                     </Accordion.Content>
                 </Accordion.Item>
                 <Accordion.Item>
@@ -129,6 +143,18 @@ const Oppsummering = () => {
                         <BodyLong spacing>2004 Lillestrøm</BodyLong>
 
                         <BodyShort>1. januar 2023 - 30. juni 2026</BodyShort>
+                        <Button
+                            variant={'tertiary'}
+                            onClick={() => navigate(RouteTilPath.AKTIVITET)}
+                            iconPosition="left"
+                            icon={<ChevronLeftIcon aria-hidden />}
+                        >
+                            <LocaleTekst
+                                tekst={
+                                    oppsummeringTekster.accordians.aktivitet_utdanning.endre_button
+                                }
+                            />
+                        </Button>
                     </Accordion.Content>
                 </Accordion.Item>
                 <Accordion.Item>
@@ -146,6 +172,16 @@ const Oppsummering = () => {
                                     {barn.navn}, født {formaterIsoDato(barn.fødselsdato)}
                                 </BodyShort>
                             ))}
+                        <Button
+                            variant={'tertiary'}
+                            onClick={() => navigate(RouteTilPath.DINE_BARN)}
+                            iconPosition="left"
+                            icon={<ChevronLeftIcon aria-hidden />}
+                        >
+                            <LocaleTekst
+                                tekst={oppsummeringTekster.accordians.dine_barn.endre_button}
+                            />
+                        </Button>
                     </Accordion.Content>
                 </Accordion.Item>
                 <Accordion.Item>
@@ -216,6 +252,16 @@ const Oppsummering = () => {
                                     </div>
                                 ) : null;
                             })}
+                            <Button
+                                variant={'tertiary'}
+                                onClick={() => navigate(RouteTilPath.BARNEPASS)}
+                                iconPosition="left"
+                                icon={<ChevronLeftIcon aria-hidden />}
+                            >
+                                <LocaleTekst
+                                    tekst={oppsummeringTekster.accordians.barnepass.endre_button}
+                                />
+                            </Button>
                         </FlexDiv>
                     </Accordion.Content>
                 </Accordion.Item>
@@ -240,6 +286,16 @@ const Oppsummering = () => {
                         <BodyLong spacing>
                             <PaperclipIcon /> legen.pdf
                         </BodyLong>
+                        <Button
+                            variant={'tertiary'}
+                            onClick={() => navigate(RouteTilPath.VEDLEGG)}
+                            iconPosition="left"
+                            icon={<ChevronLeftIcon aria-hidden />}
+                        >
+                            <LocaleTekst
+                                tekst={oppsummeringTekster.accordians.vedlegg.endre_button}
+                            />
+                        </Button>
                     </Accordion.Content>
                 </Accordion.Item>
             </Accordion>

--- a/src/frontend/barnetilsyn/tekster/barnepass.ts
+++ b/src/frontend/barnetilsyn/tekster/barnepass.ts
@@ -12,6 +12,22 @@ interface BarnepassInnhold {
     uvanlig_arbeidstid_alert: TekstElement<string>;
 }
 
+export const PassTypeTilTekst: Record<PassType, TekstElement<string>> = {
+    BARNEHAGE_SFO_AKS: { nb: 'Barnehage, skolefritidsordning (SFO) eller aktivitetsskole (AKS)' },
+    ANDRE: {
+        nb: 'Andre',
+    },
+};
+
+export const ÅrsakEkstraPassTilTekst: Record<ÅrsakBarnepass, TekstElement<string>> = {
+    TRENGER_MER_PASS_ENN_JEVNALDRENDE: {
+        nb: 'Trenger mer pleie eller tilsyn enn det som er vanlig for jevnaldrende',
+    },
+    MYE_BORTE_ELLER_UVANLIG_ARBEIDSTID: {
+        nb: 'Jeg må være borte fra hjemmet i lengre perioder eller på andre tidspunkter enn en vanlig arbeidsdag ',
+    },
+};
+
 export const barnepassTekster: BarnepassInnhold = {
     steg_tittel: {
         nb: 'Om pass av barn',
@@ -24,13 +40,11 @@ export const barnepassTekster: BarnepassInnhold = {
         alternativer: [
             {
                 value: PassType.BARNEHAGE_SFO_AKS,
-                label: { nb: 'Barnehage, skolefritidsordning (SFO) eller aktivitetsskole (AKS)' },
+                label: PassTypeTilTekst.BARNEHAGE_SFO_AKS,
             },
             {
                 value: PassType.ANDRE,
-                label: {
-                    nb: 'Andre',
-                },
+                label: PassTypeTilTekst.ANDRE,
             },
         ],
     },
@@ -72,15 +86,11 @@ export const barnepassTekster: BarnepassInnhold = {
         alternativer: [
             {
                 value: ÅrsakBarnepass.TRENGER_MER_PASS_ENN_JEVNALDRENDE,
-                label: {
-                    nb: 'Trenger mer pleie eller tilsyn enn det som er vanlig for jevnaldrende',
-                },
+                label: ÅrsakEkstraPassTilTekst.TRENGER_MER_PASS_ENN_JEVNALDRENDE,
             },
             {
                 value: ÅrsakBarnepass.MYE_BORTE_ELLER_UVANLIG_ARBEIDSTID,
-                label: {
-                    nb: 'Jeg må være borte fra hjemmet i lengre perioder eller på andre tidspunkter enn en vanlig arbeidsdag ',
-                },
+                label: ÅrsakEkstraPassTilTekst.MYE_BORTE_ELLER_UVANLIG_ARBEIDSTID,
             },
         ],
     },

--- a/src/frontend/barnetilsyn/tekster/hovedytelse.ts
+++ b/src/frontend/barnetilsyn/tekster/hovedytelse.ts
@@ -10,6 +10,20 @@ interface HovedytelseInnhold {
     radio_annen_ytelse: Radiogruppe<AnnenYtelse>;
 }
 
+export const YtelseTilTekst: Record<Ytelse | AnnenYtelse, TekstElement<string>> = {
+    aap: { nb: 'Arbeidsavklaringspenger (AAP)' },
+    dagpenger: { nb: 'Dagpenger' },
+    gjenlevendepensjon: { nb: 'Gjenlevendepensjon/etterlattepensjon' },
+    ingen_pengestøtte: { nb: 'Mottar ingen pengestøtte, men har nedsatt arbeidsevne' },
+    introduksjonsprogrammet: { nb: 'Introduksjonsprogrammet' },
+    kvalifikasjonsprogrammet: { nb: 'Kvalifikasjonsprogrammet' },
+    overgangsstønad: { nb: 'Overgangsstønad til enslig mor eller far' },
+    sykepenger: { nb: 'Sykepenger' },
+    tiltakspenger: { nb: 'Tiltakspenger' },
+    uføretrygd: { nb: 'Uføretrygd' },
+    annet: { nb: 'Nei, jeg har annen eller ingen ytelse/pengestøtte' },
+};
+
 export const hovedytelseInnhold: HovedytelseInnhold = {
     steg_tittel: {
         nb: 'Ytelse',
@@ -25,27 +39,19 @@ export const hovedytelseInnhold: HovedytelseInnhold = {
         alternativer: [
             {
                 value: 'aap',
-                label: {
-                    nb: 'Arbeidsavklaringspenger (AAP)',
-                },
+                label: YtelseTilTekst.aap,
             },
             {
                 value: 'overgangsstønad',
-                label: {
-                    nb: 'Overgangsstønad til enslig mor eller far',
-                },
+                label: YtelseTilTekst.overgangsstønad,
             },
             {
                 value: 'gjenlevendepensjon',
-                label: {
-                    nb: 'Gjenlevendepensjon/etterlattepensjon',
-                },
+                label: YtelseTilTekst.gjenlevendepensjon,
             },
             {
                 value: 'annet',
-                label: {
-                    nb: 'Nei, jeg har annen eller ingen ytelse/pengestøtte',
-                },
+                label: YtelseTilTekst.annet,
             },
         ],
     },
@@ -66,45 +72,31 @@ export const hovedytelseInnhold: HovedytelseInnhold = {
         alternativer: [
             {
                 value: 'dagpenger',
-                label: {
-                    nb: 'Dagpenger',
-                },
+                label: YtelseTilTekst.dagpenger,
             },
             {
                 value: 'tiltakspenger',
-                label: {
-                    nb: 'Tiltakspenger',
-                },
+                label: YtelseTilTekst.tiltakspenger,
             },
             {
                 value: 'kvalifikasjonsprogrammet',
-                label: {
-                    nb: 'Kvalifikasjonsprogrammet',
-                },
+                label: YtelseTilTekst.kvalifikasjonsprogrammet,
             },
             {
                 value: 'introduksjonsprogrammet',
-                label: {
-                    nb: 'Introduksjonsprogrammet',
-                },
+                label: YtelseTilTekst.introduksjonsprogrammet,
             },
             {
                 value: 'sykepenger',
-                label: {
-                    nb: 'Sykepenger',
-                },
+                label: YtelseTilTekst.sykepenger,
             },
             {
                 value: 'uføretrygd',
-                label: {
-                    nb: 'Uføretrygd',
-                },
+                label: YtelseTilTekst.uføretrygd,
             },
             {
                 value: 'ingen_pengestøtte',
-                label: {
-                    nb: 'Mottar ingen pengestøtte, men har nedsatt arbeidsevne',
-                },
+                label: YtelseTilTekst.ingen_pengestøtte,
             },
         ],
     },

--- a/src/frontend/barnetilsyn/tekster/oppsummering.ts
+++ b/src/frontend/barnetilsyn/tekster/oppsummering.ts
@@ -12,20 +12,25 @@ interface OppsummeringInnhold {
         ytelse: {
             tittel: TekstElement<string>;
             label: TekstElement<string>;
+            endre_button: TekstElement<string>;
         };
         aktivitet_utdanning: {
             tittel: TekstElement<string>;
+            endre_button: TekstElement<string>;
         };
         dine_barn: {
             tittel: TekstElement<string>;
             label: TekstElement<string>;
+            endre_button: TekstElement<string>;
         };
         barnepass: {
             tittel: TekstElement<string>;
+            endre_button: TekstElement<string>;
         };
         vedlegg: {
             tittel: TekstElement<string>;
             label: TekstElement<string>;
+            endre_button: TekstElement<string>;
         };
     };
 }
@@ -47,10 +52,16 @@ export const oppsummeringTekster: OppsummeringInnhold = {
             tittel: {
                 nb: 'Aktivitet / utdanning',
             },
+            endre_button: {
+                nb: 'Endre aktivitet / utdanning',
+            },
         },
         barnepass: {
             tittel: {
                 nb: 'Pass av barn',
+            },
+            endre_button: {
+                nb: 'Endre barn',
             },
         },
         dine_barn: {
@@ -59,6 +70,9 @@ export const oppsummeringTekster: OppsummeringInnhold = {
             },
             label: {
                 nb: 'Barn som skal ha pass',
+            },
+            endre_button: {
+                nb: 'Endre barn',
             },
         },
         om_deg: {
@@ -73,6 +87,9 @@ export const oppsummeringTekster: OppsummeringInnhold = {
             label: {
                 nb: 'Dokumenter du har lagt ved:',
             },
+            endre_button: {
+                nb: 'Endre vedlegg',
+            },
         },
         ytelse: {
             tittel: {
@@ -80,6 +97,9 @@ export const oppsummeringTekster: OppsummeringInnhold = {
             },
             label: {
                 nb: 'Din situasjon',
+            },
+            endre_button: {
+                nb: 'Endre ytelse',
             },
         },
     },

--- a/src/frontend/barnetilsyn/tekster/oppsummering.ts
+++ b/src/frontend/barnetilsyn/tekster/oppsummering.ts
@@ -2,10 +2,85 @@ import { TekstElement } from '../../typer/tekst';
 
 interface OppsummeringInnhold {
     steg_tittel: TekstElement<string>;
+    guide_innhold: TekstElement<string>;
+    bekreft_checkboks: TekstElement<string>;
+
+    accordians: {
+        om_deg: {
+            tittel: TekstElement<string>;
+        };
+        ytelse: {
+            tittel: TekstElement<string>;
+            label: TekstElement<string>;
+        };
+        aktivitet_utdanning: {
+            tittel: TekstElement<string>;
+        };
+        dine_barn: {
+            tittel: TekstElement<string>;
+            label: TekstElement<string>;
+        };
+        barnepass: {
+            tittel: TekstElement<string>;
+        };
+        vedlegg: {
+            tittel: TekstElement<string>;
+            label: TekstElement<string>;
+        };
+    };
 }
 
 export const oppsummeringTekster: OppsummeringInnhold = {
     steg_tittel: {
-        nb: 'Send inn søknad',
+        nb: 'Oppsummering',
+    },
+    guide_innhold: {
+        nb: 'Alt du har fyllt inn er nå lagret. Her kan du se over at alt er riktig. Hvis noe er feil, kan du gå tilbake og endre opplysninger, før du sender inn søknaden din. ',
+    },
+
+    bekreft_checkboks: {
+        nb: 'Jeg bekrefter at jeg har lest og forstått informasjonen i søknaden og svarer så godt jeg kan.',
+    },
+
+    accordians: {
+        aktivitet_utdanning: {
+            tittel: {
+                nb: 'Aktivitet / utdanning',
+            },
+        },
+        barnepass: {
+            tittel: {
+                nb: 'Pass av barn',
+            },
+        },
+        dine_barn: {
+            tittel: {
+                nb: 'Dine barn',
+            },
+            label: {
+                nb: 'Barn som skal ha pass',
+            },
+        },
+        om_deg: {
+            tittel: {
+                nb: 'Om deg',
+            },
+        },
+        vedlegg: {
+            tittel: {
+                nb: 'Vedlegg',
+            },
+            label: {
+                nb: 'Dokumenter du har lagt ved:',
+            },
+        },
+        ytelse: {
+            tittel: {
+                nb: 'Ytelse',
+            },
+            label: {
+                nb: 'Din situasjon',
+            },
+        },
     },
 };

--- a/src/frontend/components/Side.tsx
+++ b/src/frontend/components/Side.tsx
@@ -92,6 +92,10 @@ const Side: React.FC<Props> = ({
     };
 
     const sendSøknad = () => {
+        if (validerSteg && !validerSteg()) {
+            return;
+        }
+
         const nesteRoute = hentNesteRoute(routes, nåværendePath);
         sendInnSøknad(stønadstype, {})
             .then(() => navigate(nesteRoute.path))

--- a/src/frontend/tekster/felles.ts
+++ b/src/frontend/tekster/felles.ts
@@ -26,17 +26,23 @@ export const fellesTekster: FellesInnhold = {
         nb: 'Søknad om støtte til pass av barn',
     },
 };
+
+export const JaNeiTilTekst: Record<JaNei, TekstElement<string>> = {
+    ja: {
+        nb: 'Ja',
+    },
+    nei: {
+        nb: 'Nei',
+    },
+};
+
 export const jaNeiAlternativer: { value: JaNei; label: TekstElement<string> }[] = [
     {
         value: 'ja',
-        label: {
-            nb: 'Ja',
-        },
+        label: JaNeiTilTekst.ja,
     },
     {
         value: 'nei',
-        label: {
-            nb: 'Nei',
-        },
+        label: JaNeiTilTekst.nei,
     },
 ];


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Vil ha med oppsummeringssiden på brukertest. Har derfor implementert den med delvis hardkodet verdier/tekster. `Aktivitet` og `Vedlegg` er hardkodet og må endres før prodsetting.

**Kan forbedres senere**
* Ikke bruke `<Button />` for navigasjon
*  Mangler generelt styling
* Bruk av `<CheckboxGroup />` for sjekkboks med et alternativ. Må til for å få feilmelding på sjekkboksen.
* Kan vurdere å refaktorere `<LocaleRadioGroup />` for å slippe duplisering av labels. 


### Bilder

#### Mobil 📱 
<img width="441" alt="image" src="https://github.com/navikt/tilleggsstonader-soknad/assets/21220467/cddcc3db-bb68-4ae3-ae50-45c01c2d2812">
<img width="425" alt="image" src="https://github.com/navikt/tilleggsstonader-soknad/assets/21220467/c4df2380-d537-4c1f-9771-deb6a6294e3f">

#### Desktop 🖥️ 
<img width="1018" alt="image" src="https://github.com/navikt/tilleggsstonader-soknad/assets/21220467/27d35581-ffb9-4a36-9d39-73aa2d0399ff">

