### PR TITLE
Skjema state etterlevelse/sende inn søknad

### DIFF
--- a/src/frontend/barnetilsyn/steg/2-hovedytelse/typer.ts
+++ b/src/frontend/barnetilsyn/steg/2-hovedytelse/typer.ts
@@ -1,4 +1,7 @@
-export type Ytelse = 'AAP' | 'OVERGANGSSTØNAD' | 'GJENLEVENDEPENSJON' | 'ANNET';
+import { EnumFelt } from '../../../typer/skjema';
+
+export type Ytelse = 'AAP' | 'OVERGANGSSTØNAD' | 'GJENLEVENDEPENSJON';
+export type YtelseOgAnnet = Ytelse | 'ANNET';
 export type AnnenYtelse =
     | 'DAGPENGER'
     | 'TILTAKSPENGER'
@@ -7,14 +10,23 @@ export type AnnenYtelse =
     | 'SYKEPENGER'
     | 'UFØRETRYGD'
     | 'INGEN_PENGESTØTTE';
-export const erYtelse = (verdi: Ytelse | AnnenYtelse): verdi is Ytelse => {
-    switch (verdi) {
+
+export const erYtelse = (
+    verdi: EnumFelt<YtelseOgAnnet | AnnenYtelse>
+): verdi is EnumFelt<Ytelse> => {
+    switch (verdi.verdi) {
         case 'AAP':
         case 'OVERGANGSSTØNAD':
         case 'GJENLEVENDEPENSJON':
-        case 'ANNET':
             return true;
         default:
             return false;
     }
 };
+export const erYtelseEllerAnnet = (
+    verdi: EnumFelt<YtelseOgAnnet | AnnenYtelse>
+): verdi is EnumFelt<YtelseOgAnnet> => erYtelse(verdi) || verdi.verdi === 'ANNET';
+
+export const erAnnenYtelse = (
+    verdi: EnumFelt<Ytelse | AnnenYtelse>
+): verdi is EnumFelt<AnnenYtelse> => !erYtelseEllerAnnet(verdi);

--- a/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
+++ b/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
@@ -10,6 +10,7 @@ import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
 import LocaleTekstAvsnitt from '../../../components/Teksthåndtering/LocaleTekstAvsnitt';
 import { useSøknad } from '../../../context/SøknadContext';
 import { useTiltak } from '../../../hooks/useTiltak';
+import { EnumFelt } from '../../../typer/skjema';
 import { Stønadstype } from '../../../typer/stønadstyper';
 import { JaNei } from '../../../typer/søknad';
 import { aktivitetTekster } from '../../tekster/aktivitet';
@@ -19,13 +20,13 @@ const Aktivitet = () => {
 
     const { tiltak } = useTiltak();
 
-    const [utdanning, settUtdanning] = useState<JaNei | undefined>(
+    const [utdanning, settUtdanning] = useState<EnumFelt<JaNei> | undefined>(
         aktivitet ? aktivitet.utdanning : undefined
     );
     const [feil, settFeil] = useState('');
 
     const [fortsattSøke, settFortsattSøke] = useState<JaNei | undefined>(
-        aktivitet && aktivitet.utdanning === 'NEI' ? 'JA' : undefined
+        aktivitet && aktivitet.utdanning.verdi === 'NEI' ? 'JA' : undefined
     );
     const [fortsattSøkeFeil, settFortsattSøkeFeil] = useState('');
 
@@ -53,7 +54,7 @@ const Aktivitet = () => {
         <Side
             stegtittel={aktivitetTekster.steg_tittel}
             stønadstype={Stønadstype.barnetilsyn}
-            validerSteg={() => kanFortsette(utdanning)}
+            validerSteg={() => kanFortsette(utdanning?.verdi)}
             oppdaterSøknad={oppdaterAktivitetISøknad}
         >
             {tiltak.type === 'utdanning' && (
@@ -68,7 +69,7 @@ const Aktivitet = () => {
                     <LocaleReadMore tekst={aktivitetTekster.noe_feil_utdanning_lesmer} />
                     <LocaleRadioGroup
                         tekst={aktivitetTekster.radio_utdanning}
-                        value={utdanning || ''}
+                        value={utdanning?.verdi || ''}
                         onChange={(verdi) => {
                             settUtdanning(verdi);
                             settFortsattSøke(undefined);
@@ -77,7 +78,7 @@ const Aktivitet = () => {
                         }}
                         error={feil}
                     />
-                    {utdanning === 'NEI' && (
+                    {utdanning?.verdi === 'NEI' && (
                         <>
                             <Alert variant={'info'}>
                                 <LocaleTekstAvsnitt
@@ -88,7 +89,7 @@ const Aktivitet = () => {
                                 tekst={aktivitetTekster.radio_fortsatt_søke}
                                 value={fortsattSøke || ''}
                                 onChange={(verdi) => {
-                                    settFortsattSøke(verdi);
+                                    settFortsattSøke(verdi.verdi);
                                     settFortsattSøkeFeil('');
                                 }}
                                 error={fortsattSøkeFeil}

--- a/src/frontend/barnetilsyn/steg/5-barnepass/BarnOver9År.tsx
+++ b/src/frontend/barnetilsyn/steg/5-barnepass/BarnOver9År.tsx
@@ -6,6 +6,7 @@ import LocaleRadioGroup from '../../../components/Teksthåndtering/LocaleRadioGr
 import { LocaleReadMoreMedChildren } from '../../../components/Teksthåndtering/LocaleReadMore';
 import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
 import { Barn, ÅrsakBarnepass } from '../../../typer/barn';
+import { EnumFelt } from '../../../typer/skjema';
 import { JaNei } from '../../../typer/søknad';
 import { hentFornavn } from '../../../utils/formatering';
 import { barnepassTekster } from '../../tekster/barnepass';
@@ -22,7 +23,7 @@ const BarnOver9År: React.FC<Props> = ({
     oppdaterBarnMedBarnepass,
     visFeilmeldinger,
 }) => {
-    const oppdaterStartetIFemte = (val: JaNei) => {
+    const oppdaterStartetIFemte = (val: EnumFelt<JaNei>) => {
         oppdaterBarnMedBarnepass({
             ...passInfo,
             startetIFemte: val,
@@ -35,7 +36,7 @@ const BarnOver9År: React.FC<Props> = ({
             <LocaleRadioGroup
                 tekst={barnepassTekster.startet_femte_radio}
                 argument0={hentFornavn(barn.navn)}
-                value={passInfo.startetIFemte ?? ''}
+                value={passInfo.startetIFemte?.verdi ?? ''}
                 onChange={oppdaterStartetIFemte}
                 error={
                     visFeilmeldinger &&
@@ -50,12 +51,12 @@ const BarnOver9År: React.FC<Props> = ({
                     />
                 </LocaleReadMoreMedChildren>
             </LocaleRadioGroup>
-            {passInfo.startetIFemte == 'JA' && (
+            {passInfo.startetIFemte?.verdi == 'JA' && (
                 <>
                     <LocaleRadioGroup
                         tekst={barnepassTekster.årsak_ekstra_pass_radio}
                         argument0={hentFornavn(barn.navn)}
-                        value={passInfo.årsak || ''}
+                        value={passInfo.årsak?.verdi || ''}
                         onChange={(val) => oppdaterBarnMedBarnepass({ ...passInfo, årsak: val })}
                         error={
                             visFeilmeldinger &&
@@ -64,12 +65,13 @@ const BarnOver9År: React.FC<Props> = ({
                             'Du må velge et alternativ'
                         }
                     />
-                    {passInfo.årsak === ÅrsakBarnepass.TRENGER_MER_PASS_ENN_JEVNALDRENDE && (
+                    {passInfo.årsak?.verdi === ÅrsakBarnepass.TRENGER_MER_PASS_ENN_JEVNALDRENDE && (
                         <Alert variant="info">
                             <LocaleTekst tekst={barnepassTekster.mer_pleie_alert} />
                         </Alert>
                     )}
-                    {passInfo.årsak === ÅrsakBarnepass.MYE_BORTE_ELLER_UVANLIG_ARBEIDSTID && (
+                    {passInfo.årsak?.verdi ===
+                        ÅrsakBarnepass.MYE_BORTE_ELLER_UVANLIG_ARBEIDSTID && (
                         <Alert variant="info">
                             <LocaleTekst tekst={barnepassTekster.uvanlig_arbeidstid_alert} />
                         </Alert>

--- a/src/frontend/barnetilsyn/steg/5-barnepass/Barnepass.tsx
+++ b/src/frontend/barnetilsyn/steg/5-barnepass/Barnepass.tsx
@@ -21,7 +21,7 @@ const Barnepass = () => {
                 (barn) =>
                     barnMedBarnepass.find((barnepass) => barnepass.ident == barn.ident) || {
                         ident: barn.ident,
-                        startetIFemte: barn.alder < 9 ? 'NEI' : undefined,
+                        //startetIFemte: barn.alder < 9 ? 'NEI' : undefined, TODO fix annars får man ikke gå videre når man velger Ronja
                     }
             )
     );

--- a/src/frontend/barnetilsyn/steg/5-barnepass/BarnepassSpørsmål.tsx
+++ b/src/frontend/barnetilsyn/steg/5-barnepass/BarnepassSpørsmål.tsx
@@ -27,11 +27,11 @@ const BarnepassSpørsmål: React.FC<Props> = ({
             <LocaleRadioGroup
                 tekst={barnepassTekster.hvem_passer_radio}
                 argument0={hentFornavn(barn.navn)}
-                value={barnepass.type || ''}
-                onChange={(type) => oppdaterBarnMedBarnepass({ ...barnepass, type: type })}
+                value={barnepass.type?.verdi || ''}
+                onChange={(passType) => oppdaterBarnMedBarnepass({ ...barnepass, type: passType })}
                 error={visFeilmelding && barnepass.type === undefined && 'Du må velge et alernativ'}
             />
-            {barnepass.type === PassType.ANDRE && (
+            {barnepass.type?.verdi === PassType.ANDRE && (
                 <Alert variant="info">
                     <LocaleInlineLenke tekst={barnepassTekster.hvem_passer_andre_alert} />
                 </Alert>

--- a/src/frontend/barnetilsyn/steg/5-barnepass/utils.ts
+++ b/src/frontend/barnetilsyn/steg/5-barnepass/utils.ts
@@ -4,7 +4,7 @@ import { Barnepass } from '../../../typer/barn';
 export const validerBarnepass = (barn: BarnepassIntern): barn is Barnepass => {
     if (!barn.type || barn.startetIFemte === undefined) {
         return false;
-    } else if (barn.startetIFemte === 'JA' && !barn.årsak) {
+    } else if (barn.startetIFemte?.verdi === 'JA' && !barn.årsak) {
         return false;
     }
     return true;

--- a/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
@@ -124,7 +124,7 @@ const Hovedytelse: React.FC<{ hovedytelse: Hovedytelse | undefined }> = ({ hoved
         </Label>
         {hovedytelse && (
             <BodyShort>
-                <LocaleTekst tekst={YtelseTilTekst[hovedytelse.ytelse]} />
+                <LocaleTekst tekst={YtelseTilTekst[hovedytelse.ytelse.verdi]} />
             </BodyShort>
         )}
     </AccordionItem>
@@ -189,7 +189,7 @@ const BarnOver9År: React.FC<{ barn: Barn; barnepass: Barnepass }> = ({ barn, ba
                     />
                 </Label>
                 <BodyShort>
-                    <LocaleTekst tekst={ÅrsakEkstraPassTilTekst[barnepass.årsak]} />
+                    <LocaleTekst tekst={ÅrsakEkstraPassTilTekst[barnepass.årsak.verdi]} />
                 </BodyShort>
             </>
         )}
@@ -219,7 +219,7 @@ const BarnMedBarnepass: React.FC<{ person: Person; barnMedBarnepass: Barnepass[]
                             />
                         </Label>
                         <BodyShort>
-                            <LocaleTekst tekst={PassTypeTilTekst[barnepass.type]} />
+                            <LocaleTekst tekst={PassTypeTilTekst[barnepass.type.verdi]} />
                         </BodyShort>
                         {barn.alder >= 9 && <BarnOver9År barn={barn} barnepass={barnepass} />}
                     </div>

--- a/src/frontend/barnetilsyn/tekster/hovedytelse.ts
+++ b/src/frontend/barnetilsyn/tekster/hovedytelse.ts
@@ -1,16 +1,16 @@
 import { LesMer, Radiogruppe, TekstElement } from '../../typer/tekst';
-import { AnnenYtelse, Ytelse } from '../steg/2-hovedytelse/typer';
+import { AnnenYtelse, YtelseOgAnnet } from '../steg/2-hovedytelse/typer';
 
 interface HovedytelseInnhold {
     steg_tittel: TekstElement<string>;
     innhold_tittel: TekstElement<string>;
     guide_innhold: TekstElement<string>;
-    radio_hovedytelse: Radiogruppe<Ytelse>;
+    radio_hovedytelse: Radiogruppe<YtelseOgAnnet>;
     flere_alternativer_lesmer: LesMer<string>;
     radio_annen_ytelse: Radiogruppe<AnnenYtelse>;
 }
 
-export const YtelseTilTekst: Record<Ytelse | AnnenYtelse, TekstElement<string>> = {
+export const YtelseTilTekst: Record<YtelseOgAnnet | AnnenYtelse, TekstElement<string>> = {
     AAP: { nb: 'Arbeidsavklaringspenger (AAP)' },
     DAGPENGER: { nb: 'Dagpenger' },
     GJENLEVENDEPENSJON: { nb: 'Gjenlevendepensjon/etterlattepensjon' },

--- a/src/frontend/components/Side.tsx
+++ b/src/frontend/components/Side.tsx
@@ -9,6 +9,7 @@ import { ABreakpointMd } from '@navikt/ds-tokens/dist/tokens';
 import LocaleTekst from './Teksthåndtering/LocaleTekst';
 import { sendInnSøknad } from '../api/api';
 import { ERouteBarnetilsyn } from '../barnetilsyn/routing/routesBarnetilsyn';
+import { useSøknad } from '../context/SøknadContext';
 import { fellesTekster } from '../tekster/felles';
 import { IRoute } from '../typer/routes';
 import { Stønadstype } from '../typer/stønadstyper';
@@ -67,6 +68,7 @@ const Side: React.FC<Props> = ({
 }) => {
     const location = useLocation();
     const navigate = useNavigate();
+    const { hovedytelse, aktivitet, barnMedBarnepass } = useSøknad();
 
     const [sendInnFeil, settSendInnFeil] = useState<boolean>(false);
 
@@ -97,7 +99,11 @@ const Side: React.FC<Props> = ({
         }
 
         const nesteRoute = hentNesteRoute(routes, nåværendePath);
-        sendInnSøknad(stønadstype, {})
+        sendInnSøknad(stønadstype, {
+            hovedytelse: hovedytelse?.ytelse,
+            aktivitet,
+            barnMedBarnepass,
+        })
             .then(() => navigate(nesteRoute.path))
             // TODO håndtering av 401?
             .catch(() => settSendInnFeil(true));

--- a/src/frontend/components/Teksthåndtering/LocaleRadioGroup.tsx
+++ b/src/frontend/components/Teksthåndtering/LocaleRadioGroup.tsx
@@ -3,31 +3,50 @@ import React from 'react';
 import { Radio, RadioGroup, RadioGroupProps as AkselRadioGroupProps } from '@navikt/ds-react';
 
 import { useSpråk } from '../../context/SpråkContext';
+import { EnumFelt } from '../../typer/skjema';
 import { Radiogruppe } from '../../typer/tekst';
 import { hentBeskjedMedEttParameter } from '../../utils/tekster';
 
 interface RadioGroupProps<T>
     extends Omit<AkselRadioGroupProps, 'legend' | 'description' | 'children'> {
     tekst: Radiogruppe<T>;
+    onChange: (enumFelt: EnumFelt<T>) => void;
     children?: React.ReactNode;
     argument0?: string;
 }
-function LocaleRadioGroup<T>({ children, tekst, argument0, ...props }: RadioGroupProps<T>) {
+function LocaleRadioGroup<T>({
+    children,
+    tekst,
+    argument0,
+    onChange,
+    ...props
+}: RadioGroupProps<T>) {
     const { locale } = useSpråk();
+
+    const legend = argument0
+        ? hentBeskjedMedEttParameter(argument0, tekst.header[locale])
+        : tekst.header[locale];
+
+    const onChangeEnumVerdi = (value: T) => {
+        const svarTekst = tekst.alternativer.find((alternativ) => alternativ.value === value);
+        onChange({
+            label: legend,
+            verdi: value,
+            alternativer: tekst.alternativer.map((alternativ) => alternativ.label[locale]),
+            svarTekst: svarTekst?.label[locale] || '',
+        });
+    };
 
     return (
         <RadioGroup
-            legend={
-                argument0
-                    ? hentBeskjedMedEttParameter(argument0, tekst.header[locale])
-                    : tekst.header[locale]
-            }
+            legend={legend}
             description={
                 tekst.beskrivelse &&
                 (argument0
                     ? hentBeskjedMedEttParameter(argument0, tekst.beskrivelse[locale])
                     : tekst.beskrivelse[locale])
             }
+            onChange={onChangeEnumVerdi}
             {...props}
         >
             {children}

--- a/src/frontend/context/SøknadContext.tsx
+++ b/src/frontend/context/SøknadContext.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import createUseContext from 'constate';
 
 import { Barnepass } from '../typer/barn';
-import { Hovedytelse, Aktivitet } from '../typer/søknad';
+import { Aktivitet, Hovedytelse } from '../typer/søknad';
 
 const [SøknadProvider, useSøknad] = createUseContext(() => {
     SøknadProvider.displayName = 'SØKNAD_PROVIDER';

--- a/src/frontend/typer/barn.ts
+++ b/src/frontend/typer/barn.ts
@@ -1,3 +1,4 @@
+import { EnumFelt } from './skjema';
 import { JaNei } from './søknad';
 
 export interface Barn {
@@ -10,9 +11,9 @@ export interface Barn {
 
 export interface Barnepass {
     ident: string;
-    type: PassType;
-    startetIFemte: JaNei;
-    årsak?: ÅrsakBarnepass;
+    type: EnumFelt<PassType>;
+    startetIFemte: EnumFelt<JaNei>;
+    årsak?: EnumFelt<ÅrsakBarnepass>;
 }
 
 export enum PassType {

--- a/src/frontend/typer/skjema.ts
+++ b/src/frontend/typer/skjema.ts
@@ -1,0 +1,6 @@
+export interface EnumFelt<T> {
+    label: string;
+    verdi: T;
+    svarTekst: string;
+    alternativer: string[];
+}

--- a/src/frontend/typer/søknad.ts
+++ b/src/frontend/typer/søknad.ts
@@ -1,11 +1,12 @@
+import { EnumFelt } from './skjema';
 import { AnnenYtelse, Ytelse } from '../barnetilsyn/steg/2-hovedytelse/typer';
 
 export interface Hovedytelse {
-    ytelse: Exclude<Ytelse, 'ANNET'> | AnnenYtelse;
+    ytelse: EnumFelt<Ytelse | AnnenYtelse>;
 }
 
 export interface Aktivitet {
-    utdanning: JaNei;
+    utdanning: EnumFelt<JaNei>;
 }
 
 export type JaNei = 'JA' | 'NEI';


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skal kunne sende inn søknad
Backend forventer at man sender inn det som ble vist til bruker for etterlevelse - blir med i den PDF som blir generert.

Bygger videre på 
* https://github.com/navikt/tilleggsstonader-soknad/pull/148

* Må gå opp en løypa på hvilke felter som må sendes inn som idag ikke sendes inn. Eks så er hovedsstønad delt opp i 2 ulike spm. Denne kommer nog bli merget til en checkbox senere. Og er et spørsmål om aktivitet som ikke blir lagret ned i søknaden.
 
https://favro.com/organization/98c34fb974ce445eac854de0/8a5276563da0f059dccd52a0?card=NAV-15648

Det går nå å sende inn søknad, og den blir arkivert :-) 
Kan finnes på gosys-q1
https://gosys-q1.dev.intern.nav.no/gosys/bruker/brukeroversikt.jsf?execution=e2s2

<img width="756" alt="image" src="https://github.com/navikt/tilleggsstonader-soknad/assets/937168/284ed58b-f315-4a91-a946-9c086a70d969">
