### PR TITLE
Vedlegg opplasting

### DIFF
--- a/.nais/naiserator/dev.yaml
+++ b/.nais/naiserator/dev.yaml
@@ -40,6 +40,8 @@ spec:
     outbound:
       rules:
         - application: tilleggsstonader-soknad-api
+        - application: familie-dokument
+          namespace: teamfamilie
         - application: nav-dekoratoren
           namespace: personbruker
       external:

--- a/.nais/naiserator/prod.yaml
+++ b/.nais/naiserator/prod.yaml
@@ -37,13 +37,13 @@ spec:
   ingresses:
     - https://www.nav.no/tilleggsstonader/soknad
   accessPolicy:
-    rules:
-      - application: tilleggsstonader-soknad-api
-      - application: familie-dokument
-        namespace: teamfamilie
-      - application: nav-dekoratoren
-        namespace: personbruker
     outbound:
+      rules:
+        - application: tilleggsstonader-soknad-api
+        - application: familie-dokument
+          namespace: teamfamilie
+        - application: nav-dekoratoren
+          namespace: personbruker
       external:
         - host: nav.no
   env:

--- a/.nais/naiserator/prod.yaml
+++ b/.nais/naiserator/prod.yaml
@@ -39,6 +39,8 @@ spec:
   accessPolicy:
     rules:
       - application: tilleggsstonader-soknad-api
+      - application: familie-dokument
+        namespace: teamfamilie
       - application: nav-dekoratoren
         namespace: personbruker
     outbound:

--- a/src/backend/miljø.ts
+++ b/src/backend/miljø.ts
@@ -2,17 +2,20 @@ import logger from './logger';
 
 const lokaltMiljø = {
     apiUrl: 'http://localhost:8001/api',
+    vedleggUrl: 'http://localhost:8001/api/vedlegg',
     oauthCallbackUri: 'https://localhost:8080/tilleggsstonader/soknad/soknad/oauth2/callback',
 };
 
 const devMiljø = {
     apiUrl: 'http://tilleggsstonader-soknad-api/api',
+    vedleggUrl: 'http://familie-dokument.teamfamilie/api/mapper/tilleggsstonad',
     oauthCallbackUri:
         'https://tilleggsstonader.ekstern.dev.nav.no/tilleggsstonader/soknad/oauth2/callback',
 };
 
 const prodMiljø = {
     apiUrl: 'http://tilleggsstonader-soknad-api/api',
+    vedleggUrl: 'http://familie-dokument.teamfamilie/api/mapper/tilleggsstonad',
     oauthCallbackUri: 'https://www.nav.no/tilleggsstonader/soknad/soknad/oauth2/callback',
 };
 

--- a/src/backend/routes.ts
+++ b/src/backend/routes.ts
@@ -21,22 +21,32 @@ const routes = () => {
 
     expressRouter.use(BASE_PATH_SOKNAD, express.static(buildPath, { index: false }));
 
-    expressRouter.use(/^(?!.*\/(internal|static|api)\/).*$/, (_req: Request, res: Response) => {
-        getDecoratedHtml(path.join(buildPath, 'index.html'))
-            .then((html) => {
-                res.send(html);
-            })
-            .catch((e) => {
-                logger.error(e);
-                res.status(500).send(e);
-            });
-    });
+    expressRouter.use(
+        /^(?!.*\/(internal|static|api|vedlegg)\/).*$/,
+        (_req: Request, res: Response) => {
+            getDecoratedHtml(path.join(buildPath, 'index.html'))
+                .then((html) => {
+                    res.send(html);
+                })
+                .catch((e) => {
+                    logger.error(e);
+                    res.status(500).send(e);
+                });
+        }
+    );
 
     expressRouter.use(
         `${BASE_PATH_SOKNAD}/api`,
         addRequestInfo(),
         attachToken('tilleggsstonader-soknad-api'),
         doProxy(miljø.apiUrl, `${BASE_PATH_SOKNAD}/api`)
+    );
+
+    expressRouter.use(
+        `${BASE_PATH_SOKNAD}/vedlegg`,
+        addRequestInfo(),
+        attachToken('familie-dokument'),
+        doProxy(miljø.vedleggUrl, `${BASE_PATH_SOKNAD}/vedlegg`)
     );
 
     return expressRouter;

--- a/src/backend/routes.ts
+++ b/src/backend/routes.ts
@@ -21,18 +21,22 @@ const routes = () => {
 
     expressRouter.use(BASE_PATH_SOKNAD, express.static(buildPath, { index: false }));
 
+    expressRouter.use(/^(?!.*\/(internal|static|api)\/).*$/, (_req: Request, res: Response) => {
+        getDecoratedHtml(path.join(buildPath, 'index.html'))
+            .then((html) => {
+                res.send(html);
+            })
+            .catch((e) => {
+                logger.error(e);
+                res.status(500).send(e);
+            });
+    });
+
     expressRouter.use(
-        /^(?!.*\/(internal|static|api|vedlegg)\/).*$/,
-        (_req: Request, res: Response) => {
-            getDecoratedHtml(path.join(buildPath, 'index.html'))
-                .then((html) => {
-                    res.send(html);
-                })
-                .catch((e) => {
-                    logger.error(e);
-                    res.status(500).send(e);
-                });
-        }
+        `${BASE_PATH_SOKNAD}/api/vedlegg`,
+        addRequestInfo(),
+        attachToken('familie-dokument'),
+        doProxy(miljø.vedleggUrl, `${BASE_PATH_SOKNAD}/api/vedlegg`)
     );
 
     expressRouter.use(
@@ -40,13 +44,6 @@ const routes = () => {
         addRequestInfo(),
         attachToken('tilleggsstonader-soknad-api'),
         doProxy(miljø.apiUrl, `${BASE_PATH_SOKNAD}/api`)
-    );
-
-    expressRouter.use(
-        `${BASE_PATH_SOKNAD}/vedlegg`,
-        addRequestInfo(),
-        attachToken('familie-dokument'),
-        doProxy(miljø.vedleggUrl, `${BASE_PATH_SOKNAD}/vedlegg`)
     );
 
     return expressRouter;

--- a/src/backend/tokenx.ts
+++ b/src/backend/tokenx.ts
@@ -7,6 +7,11 @@ import logger from './logger';
 import { miljø } from './miljø';
 import { ApplicationName } from './tokenProxy';
 
+const namespace: { [key in ApplicationName]: string } = {
+    'familie-dokument': 'teamfamilie',
+    'tilleggsstonader-soknad-api': 'tilleggsstonader',
+};
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 class TokenXClient {
     private tokenxClient: any = null;
@@ -33,7 +38,7 @@ class TokenXClient {
                 client_assertion: clientAssertion,
                 subject_token_type: 'urn:ietf:params:oauth:token-type:jwt',
                 subject_token: idportenToken,
-                audience: `${tokenxConfig.clusterName}:tilleggsstonader:${applicationName}`,
+                audience: `${tokenxConfig.clusterName}:${namespace[applicationName]}:${applicationName}`,
             })
             .then((tokenSet: any) => {
                 return Promise.resolve(tokenSet.access_token);

--- a/src/frontend/api/Environment.ts
+++ b/src/frontend/api/Environment.ts
@@ -1,5 +1,6 @@
 interface EnvironmentProps {
     apiProxyUrl: string;
+    vedleggProxyUrl: string;
     wonderwallUrl: string;
     sentryUrl?: string;
     miljø: string;
@@ -16,6 +17,8 @@ const Environment = (): EnvironmentProps => {
     if (window.location.hostname.indexOf('dev.nav.no') > -1) {
         return {
             apiProxyUrl: 'https://tilleggsstonader.ekstern.dev.nav.no/tilleggsstonader/soknad/api',
+            vedleggProxyUrl:
+                'https://tilleggsstonader.ekstern.dev.nav.no/tilleggsstonader/soknad/vedlegg',
             wonderwallUrl:
                 'https://tilleggsstonader.ekstern.dev.nav.no/tilleggsstonader/soknad/oauth2/login?redirect=',
             sentryUrl: 'https://06b839ad5487467cb88097c5a27bbbb5@sentry.gc.nav.no/167',
@@ -25,6 +28,7 @@ const Environment = (): EnvironmentProps => {
     } else if (window.location.hostname.indexOf('www') > -1) {
         return {
             apiProxyUrl: 'https://www.nav.no/tilleggsstonader/soknad/api',
+            vedleggProxyUrl: 'https://www.nav.no/tilleggsstonader/soknad/vedlegg',
             wonderwallUrl: 'https://www.nav.no/tilleggsstonader/soknad/oauth2/login?redirect=',
             sentryUrl: 'https://06b839ad5487467cb88097c5a27bbbb5@sentry.gc.nav.no/167',
             miljø: 'production',
@@ -33,6 +37,7 @@ const Environment = (): EnvironmentProps => {
     } else {
         return {
             apiProxyUrl: 'http://localhost:8080/api',
+            vedleggProxyUrl: 'http://localhost:8080/api/vedlegg/tillegg',
             wonderwallUrl: `http://localhost:8001/test/cookie?redirect=`,
             miljø: 'local',
             modellVersjon: modellVersjon,

--- a/src/frontend/api/Environment.ts
+++ b/src/frontend/api/Environment.ts
@@ -18,7 +18,7 @@ const Environment = (): EnvironmentProps => {
         return {
             apiProxyUrl: 'https://tilleggsstonader.ekstern.dev.nav.no/tilleggsstonader/soknad/api',
             vedleggProxyUrl:
-                'https://tilleggsstonader.ekstern.dev.nav.no/tilleggsstonader/soknad/vedlegg',
+                'https://tilleggsstonader.ekstern.dev.nav.no/tilleggsstonader/soknad/api/vedlegg',
             wonderwallUrl:
                 'https://tilleggsstonader.ekstern.dev.nav.no/tilleggsstonader/soknad/oauth2/login?redirect=',
             sentryUrl: 'https://06b839ad5487467cb88097c5a27bbbb5@sentry.gc.nav.no/167',
@@ -28,7 +28,7 @@ const Environment = (): EnvironmentProps => {
     } else if (window.location.hostname.indexOf('www') > -1) {
         return {
             apiProxyUrl: 'https://www.nav.no/tilleggsstonader/soknad/api',
-            vedleggProxyUrl: 'https://www.nav.no/tilleggsstonader/soknad/vedlegg',
+            vedleggProxyUrl: 'https://www.nav.no/tilleggsstonader/soknad/api/vedlegg',
             wonderwallUrl: 'https://www.nav.no/tilleggsstonader/soknad/oauth2/login?redirect=',
             sentryUrl: 'https://06b839ad5487467cb88097c5a27bbbb5@sentry.gc.nav.no/167',
             miljø: 'production',

--- a/src/frontend/api/api.ts
+++ b/src/frontend/api/api.ts
@@ -34,3 +34,25 @@ export const sendInnSøknad = (stønadstype: Stønadstype, søknad: object) => {
     const url = `${Environment().apiProxyUrl}/soknad/${stønadstypeTilPath(stønadstype)}`;
     return axios.post(url, søknad, defaultConfig()).then((response) => response.data);
 };
+
+interface VedleggResponse {
+    data: {
+        dokumentId: string;
+    };
+}
+export const lastOppVedlegg = (fil: File): Promise<string> => {
+    const url = `${Environment().vedleggProxyUrl}`;
+    const requestData = new FormData();
+    requestData.append('file', fil);
+    return axios
+        .post<FormData, VedleggResponse>(url, requestData, {
+            withCredentials: true,
+            headers: {
+                'x-request-id': requestId(),
+                'Content-Type': 'multipart/form-data',
+                accept: 'application/json',
+            },
+            transformRequest: () => requestData,
+        })
+        .then((response: VedleggResponse) => response.data.dokumentId);
+};

--- a/src/frontend/barnetilsyn/steg/4-dine-barn/DineBarn.tsx
+++ b/src/frontend/barnetilsyn/steg/4-dine-barn/DineBarn.tsx
@@ -24,7 +24,7 @@ const DineBarn = () => {
                     <Checkbox
                         key={barn.ident}
                         value={barn.ident}
-                        checked={barn.skalHaBarnepass}
+                        checked={barn.skalHaBarnepass ?? false}
                         onChange={() => toggleSkalHaBarnepass(barn.ident)}
                     >
                         {barn.navn}, født {formaterIsoDato(barn.fødselsdato)}

--- a/src/frontend/barnetilsyn/steg/6-vedlegg/Vedlegg.tsx
+++ b/src/frontend/barnetilsyn/steg/6-vedlegg/Vedlegg.tsx
@@ -1,16 +1,20 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { styled } from 'styled-components';
 
 import { UploadIcon } from '@navikt/aksel-icons';
 import { Accordion, BodyLong, BodyShort, Button, Heading, Label } from '@navikt/ds-react';
 
+import Filopplaster from '../../../components/Filopplaster/Filopplaster';
 import { PellePanel } from '../../../components/PellePanel/PellePanel';
 import Side from '../../../components/Side';
 import LocalePunktliste from '../../../components/Teksthåndtering/LocalePunktliste';
 import { LocaleReadMore } from '../../../components/Teksthåndtering/LocaleReadMore';
 import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
 import LocaleTekstAvsnitt from '../../../components/Teksthåndtering/LocaleTekstAvsnitt';
+import { useSpråk } from '../../../context/SpråkContext';
+import { useSøknad } from '../../../context/SøknadContext';
+import { Dokument, DokumentasjonFelt, Vedleggstype } from '../../../typer/skjema';
 import { Stønadstype } from '../../../typer/stønadstyper';
 import { vedleggTekster } from '../../tekster/vedlegg';
 
@@ -27,8 +31,27 @@ const VedleggContainer = styled.div`
 `;
 
 const Vedlegg = () => {
+    const { dokumentasjon, settDokumentasjon } = useSøknad();
+    const { locale } = useSpråk();
+    const [nyDokumentasjon, settNyDokumentasjon] = useState<DokumentasjonFelt[]>(
+        dokumentasjon.length
+            ? dokumentasjon
+            : [
+                  {
+                      type: Vedleggstype.EKSEMPEL,
+                      label: vedleggTekster.typerVedlegg[Vedleggstype.EKSEMPEL][locale],
+                      harSendtInn: false,
+                      opplastedeVedlegg: [],
+                  },
+              ]
+    );
+
     return (
-        <Side stønadstype={Stønadstype.barnetilsyn} stegtittel={vedleggTekster.steg_tittel}>
+        <Side
+            stønadstype={Stønadstype.barnetilsyn}
+            stegtittel={vedleggTekster.steg_tittel}
+            oppdaterSøknad={() => settDokumentasjon(nyDokumentasjon)}
+        >
             <Heading size={'medium'}>
                 <LocaleTekst tekst={vedleggTekster.innhold_tittel} />
             </Heading>
@@ -48,9 +71,14 @@ const Vedlegg = () => {
                         <LocaleTekst tekst={vedleggTekster.samlet_faktura} />
                     </BodyShort>
                     <LocaleReadMore tekst={vedleggTekster.faktura_lesmer} />
-                    <StyledKnapp icon={<UploadIcon title="a11y-title" />}>
-                        <LocaleTekst tekst={vedleggTekster.last_opp_faktura} />
-                    </StyledKnapp>
+                    <Filopplaster
+                        dokumentasjonFelt={nyDokumentasjon[0]}
+                        oppdaterVedlegg={(dokument: Dokument[]) => {
+                            settNyDokumentasjon([
+                                { ...nyDokumentasjon[0], opplastedeVedlegg: dokument },
+                            ]);
+                        }}
+                    />
                 </section>
                 <section>
                     <Heading size={'small'}>

--- a/src/frontend/barnetilsyn/steg/6-vedlegg/Vedlegg.tsx
+++ b/src/frontend/barnetilsyn/steg/6-vedlegg/Vedlegg.tsx
@@ -39,7 +39,7 @@ const Vedlegg = () => {
             : [
                   {
                       type: Vedleggstype.EKSEMPEL,
-                      label: vedleggTekster.typerVedlegg[Vedleggstype.EKSEMPEL][locale],
+                      label: vedleggTekster.typerVedlegg[Vedleggstype.EKSEMPEL].label[locale],
                       harSendtInn: false,
                       opplastedeVedlegg: [],
                   },

--- a/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
@@ -24,6 +24,7 @@ import { useSøknad } from '../../../context/SøknadContext';
 import { JaNeiTilTekst } from '../../../tekster/felles';
 import { Barn, Barnepass } from '../../../typer/barn';
 import { Person } from '../../../typer/person';
+import { DokumentasjonFelt } from '../../../typer/skjema';
 import { Stønadstype } from '../../../typer/stønadstyper';
 import { Hovedytelse } from '../../../typer/søknad';
 import { TekstElement } from '../../../typer/tekst';
@@ -229,7 +230,7 @@ const BarnMedBarnepass: React.FC<{ person: Person; barnMedBarnepass: Barnepass[]
     </AccordionItem>
 );
 
-const Vedlegg: React.FC = () => (
+const Vedlegg: React.FC<{ dokumentasjon: DokumentasjonFelt[] }> = ({ dokumentasjon }) => (
     <AccordionItem
         header={oppsummeringTekster.accordians.vedlegg.tittel}
         endreKnapp={{
@@ -240,24 +241,21 @@ const Vedlegg: React.FC = () => (
         <Label spacing>
             <LocaleTekst tekst={oppsummeringTekster.accordians.vedlegg.label} />
         </Label>
-        {/*TODO: Hardkodet*/}
-        <BodyLong>Faktura på pass for Espen og Ronja</BodyLong>
-        <BodyLong>
-            <PaperclipIcon /> barnehage.pdf
-        </BodyLong>
-        <BodyLong spacing>
-            <PaperclipIcon /> sfo.pdf
-        </BodyLong>
-
-        <BodyLong>Legeerklæring for Espen</BodyLong>
-        <BodyLong spacing>
-            <PaperclipIcon /> legen.pdf
-        </BodyLong>
+        {dokumentasjon.map((d) => (
+            <>
+                <BodyLong>{d.label}</BodyLong>
+                {d.opplastedeVedlegg.map((vedlegg) => (
+                    <BodyLong spacing>
+                        <PaperclipIcon /> {vedlegg.navn}
+                    </BodyLong>
+                ))}
+            </>
+        ))}
     </AccordionItem>
 );
 
 const Oppsummering = () => {
-    const { hovedytelse, barnMedBarnepass } = useSøknad();
+    const { hovedytelse, barnMedBarnepass, dokumentasjon } = useSøknad();
     const { person } = usePerson();
     const [harBekreftet, settHarBekreftet] = useState(false);
     const [feil, settFeil] = useState<string>('');
@@ -287,7 +285,7 @@ const Oppsummering = () => {
                 <AktivitetUtdanning />
                 <DineBarn person={person} />
                 <BarnMedBarnepass person={person} barnMedBarnepass={barnMedBarnepass} />
-                <Vedlegg />
+                <Vedlegg dokumentasjon={dokumentasjon} />
             </Accordion>
 
             <CheckboxGroup

--- a/src/frontend/barnetilsyn/tekster/vedlegg.ts
+++ b/src/frontend/barnetilsyn/tekster/vedlegg.ts
@@ -2,7 +2,10 @@ import { Vedleggstype } from '../../typer/skjema';
 import { LesMer, TekstElement } from '../../typer/tekst';
 
 type TekstTypeVedlegg = {
-    [key in Vedleggstype]: TekstElement<string>;
+    [key in Vedleggstype]: {
+        label: TekstElement<string>;
+        knapp: TekstElement<string>;
+    };
 };
 
 interface VedleggInnhold {
@@ -75,7 +78,12 @@ const harIkkeVedleggDigitalAccordian: VedleggInnhold['accordians']['har_ikke_ved
 
 const typerVedlegg: TekstTypeVedlegg = {
     [Vedleggstype.EKSEMPEL]: {
-        nb: 'Eksempel',
+        label: {
+            nb: 'Faktura',
+        },
+        knapp: {
+            nb: 'Last opp faktura',
+        },
     },
 };
 

--- a/src/frontend/barnetilsyn/tekster/vedlegg.ts
+++ b/src/frontend/barnetilsyn/tekster/vedlegg.ts
@@ -1,4 +1,9 @@
+import { Vedleggstype } from '../../typer/skjema';
 import { LesMer, TekstElement } from '../../typer/tekst';
+
+type TekstTypeVedlegg = {
+    [key in Vedleggstype]: TekstElement<string>;
+};
 
 interface VedleggInnhold {
     steg_tittel: TekstElement<string>;
@@ -29,6 +34,8 @@ interface VedleggInnhold {
     vedlegg_espen_ronja: TekstElement<string[]>;
     legeerklæring_espen_tittel: TekstElement<string>;
     legeerklæring_espen: TekstElement<string>;
+
+    typerVedlegg: TekstTypeVedlegg;
 }
 
 const formatKvalitetAccordian: VedleggInnhold['accordians']['format_kvalitet'] = {
@@ -63,6 +70,12 @@ const harIkkeVedleggDigitalAccordian: VedleggInnhold['accordians']['har_ikke_ved
             'Teksten til dokumentet er godt leselig.',
             'Bildet er godt opplyst, uten skygger.',
         ],
+    },
+};
+
+const typerVedlegg: TekstTypeVedlegg = {
+    [Vedleggstype.EKSEMPEL]: {
+        nb: 'Eksempel',
     },
 };
 
@@ -122,4 +135,5 @@ export const vedleggTekster: VedleggInnhold = {
     legeerklæring_espen: {
         nb: 'Legerklæringen må inneholde opplysninger om hvorfor Espen trenger ekstra pass. ',
     },
+    typerVedlegg: typerVedlegg,
 };

--- a/src/frontend/components/Filopplaster/Filopplaster.tsx
+++ b/src/frontend/components/Filopplaster/Filopplaster.tsx
@@ -7,10 +7,12 @@ import { Alert, BodyShort, Button } from '@navikt/ds-react';
 
 import { MAKS_FILSTØRRELSE_FORMATTERT, MAX_FILSTØRRELSE, TILLATE_FILTYPER } from './utils';
 import { lastOppVedlegg } from '../../api/api';
+import { vedleggTekster } from '../../barnetilsyn/tekster/vedlegg';
 import { useSpråk } from '../../context/SpråkContext';
 import { Dokument, DokumentasjonFelt } from '../../typer/skjema';
 import { TekstElement } from '../../typer/tekst';
 import { hentBeskjedMedEttParameter } from '../../utils/tekster';
+import LocaleTekst from '../Teksthåndtering/LocaleTekst';
 
 const StyledKnapp = styled(Button)`
     width: max-content;
@@ -96,7 +98,7 @@ const Filopplaster: React.FC<{
                 icon={<UploadIcon title="a11y-title" />}
                 disabled={laster}
             >
-                {dokumentasjonFelt.label}
+                <LocaleTekst tekst={vedleggTekster.typerVedlegg[dokumentasjonFelt.type].knapp} />
             </StyledKnapp>
             <input
                 type="file"

--- a/src/frontend/components/Filopplaster/Filopplaster.tsx
+++ b/src/frontend/components/Filopplaster/Filopplaster.tsx
@@ -1,0 +1,110 @@
+import React, { useRef, useState } from 'react';
+
+import styled from 'styled-components';
+
+import { UploadIcon } from '@navikt/aksel-icons';
+import { Alert, BodyShort, Button } from '@navikt/ds-react';
+
+import { MAKS_FILSTØRRELSE_FORMATTERT, MAX_FILSTØRRELSE, TILLATE_FILTYPER } from './utils';
+import { lastOppVedlegg } from '../../api/api';
+import { useSpråk } from '../../context/SpråkContext';
+import { Dokument, DokumentasjonFelt } from '../../typer/skjema';
+import { TekstElement } from '../../typer/tekst';
+import { hentBeskjedMedEttParameter } from '../../utils/tekster';
+
+const StyledKnapp = styled(Button)`
+    width: max-content;
+    margin-top: 1rem;
+`;
+
+const teksterFeilmeldinger: {
+    enFil: TekstElement<string>;
+    maksstørrelse: TekstElement<string>;
+    filtype: TekstElement<string>;
+    feiletOpplasting: TekstElement<string>;
+} = {
+    enFil: {
+        nb: `Må laste opp en og en fil`,
+    },
+    maksstørrelse: {
+        nb: `"[0]" er for stor (maksimal filstørrelse er ${MAKS_FILSTØRRELSE_FORMATTERT}).`,
+    },
+    filtype: {
+        nb: '"[0]" – Ugyldig filtype.',
+    },
+    feiletOpplasting: {
+        nb: 'Feilet opplasting av "[0]".',
+    },
+};
+const Filopplaster: React.FC<{
+    dokumentasjonFelt: DokumentasjonFelt;
+    oppdaterVedlegg: (vedlegg: Dokument[]) => void;
+}> = ({ dokumentasjonFelt, oppdaterVedlegg }) => {
+    const { locale } = useSpråk();
+    const hiddenFileInput = useRef<HTMLInputElement>(null);
+
+    const [feilmelding, settFeilmelding] = useState<string>();
+    const [laster, settLaster] = useState<boolean>(false);
+
+    const lastOppValgteFiler = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const filer = event.target.files;
+        if (filer?.length !== 1) {
+            settFeilmelding(teksterFeilmeldinger.enFil[locale]);
+            return;
+        }
+        const fil = filer[0];
+
+        if (fil.size > MAX_FILSTØRRELSE) {
+            settFeilmelding(
+                hentBeskjedMedEttParameter(fil.name, teksterFeilmeldinger.maksstørrelse[locale])
+            );
+        } else if (!TILLATE_FILTYPER.includes(fil.type)) {
+            settFeilmelding(
+                hentBeskjedMedEttParameter(fil.name, teksterFeilmeldinger.filtype[locale])
+            );
+        } else {
+            settLaster(true);
+            lastOppVedlegg(fil)
+                .then((id) =>
+                    oppdaterVedlegg([
+                        ...dokumentasjonFelt.opplastedeVedlegg,
+                        { id: id, navn: fil.name },
+                    ])
+                )
+                .catch(() => {
+                    settFeilmelding(
+                        hentBeskjedMedEttParameter(
+                            fil.name,
+                            teksterFeilmeldinger.feiletOpplasting[locale]
+                        )
+                    );
+                })
+                .finally(() => settLaster(false));
+        }
+    };
+
+    return (
+        <>
+            {dokumentasjonFelt.opplastedeVedlegg.map((dokument) => (
+                <BodyShort key={dokument.id} size="small">
+                    {dokument.navn}
+                </BodyShort>
+            ))}
+            {feilmelding && <Alert variant="error">{feilmelding}</Alert>}
+            <StyledKnapp
+                onClick={() => hiddenFileInput.current?.click()}
+                icon={<UploadIcon title="a11y-title" />}
+                disabled={laster}
+            >
+                {dokumentasjonFelt.label}
+            </StyledKnapp>
+            <input
+                type="file"
+                onChange={lastOppValgteFiler}
+                ref={hiddenFileInput}
+                style={{ display: 'none' }}
+            />
+        </>
+    );
+};
+export default Filopplaster;

--- a/src/frontend/components/Filopplaster/utils.ts
+++ b/src/frontend/components/Filopplaster/utils.ts
@@ -13,15 +13,10 @@ export const formaterFilstørrelse = (bytes: number, decimals: number = 2) => {
 export const MAX_FILSTØRRELSE = 1024 * 1024 * 10; // 10mb
 export const MAKS_FILSTØRRELSE_FORMATTERT = formaterFilstørrelse(MAX_FILSTØRRELSE);
 
-enum EFiltyper {
+enum Filtyper {
     PDF = 'application/pdf',
     PNG = 'image/png',
     JPG = 'image/jpg',
     JPEG = 'image/jpeg',
 }
-export const TILLATE_FILTYPER: string[] = [
-    EFiltyper.PNG,
-    EFiltyper.PDF,
-    EFiltyper.JPG,
-    EFiltyper.JPEG,
-];
+export const TILLATE_FILTYPER: string[] = [Filtyper.PNG, Filtyper.PDF, Filtyper.JPG, Filtyper.JPEG];

--- a/src/frontend/components/Filopplaster/utils.ts
+++ b/src/frontend/components/Filopplaster/utils.ts
@@ -1,0 +1,27 @@
+export const formaterFilstørrelse = (bytes: number, decimals: number = 2) => {
+    if (bytes === 0) return '0 Bytes';
+
+    const k = 1024;
+    const dm = decimals < 0 ? 0 : decimals;
+    const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
+};
+
+export const MAX_FILSTØRRELSE = 1024 * 1024 * 10; // 10mb
+export const MAKS_FILSTØRRELSE_FORMATTERT = formaterFilstørrelse(MAX_FILSTØRRELSE);
+
+enum EFiltyper {
+    PDF = 'application/pdf',
+    PNG = 'image/png',
+    JPG = 'image/jpg',
+    JPEG = 'image/jpeg',
+}
+export const TILLATE_FILTYPER: string[] = [
+    EFiltyper.PNG,
+    EFiltyper.PDF,
+    EFiltyper.JPG,
+    EFiltyper.JPEG,
+];

--- a/src/frontend/components/Side.tsx
+++ b/src/frontend/components/Side.tsx
@@ -68,7 +68,7 @@ const Side: React.FC<Props> = ({
 }) => {
     const location = useLocation();
     const navigate = useNavigate();
-    const { hovedytelse, aktivitet, barnMedBarnepass } = useSøknad();
+    const { hovedytelse, aktivitet, barnMedBarnepass, dokumentasjon } = useSøknad();
 
     const [sendInnFeil, settSendInnFeil] = useState<boolean>(false);
 
@@ -103,6 +103,7 @@ const Side: React.FC<Props> = ({
             hovedytelse: hovedytelse?.ytelse,
             aktivitet,
             barnMedBarnepass,
+            dokumentasjon,
         })
             .then(() => navigate(nesteRoute.path))
             // TODO håndtering av 401?

--- a/src/frontend/context/SøknadContext.tsx
+++ b/src/frontend/context/SøknadContext.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import createUseContext from 'constate';
 
 import { Barnepass } from '../typer/barn';
+import { DokumentasjonFelt } from '../typer/skjema';
 import { Aktivitet, Hovedytelse } from '../typer/søknad';
 
 const [SøknadProvider, useSøknad] = createUseContext(() => {
@@ -14,6 +15,7 @@ const [SøknadProvider, useSøknad] = createUseContext(() => {
     const [aktivitet, settAktivitet] = useState<Aktivitet>();
 
     const [barnMedBarnepass, settBarnMedBarnepass] = useState<Barnepass[]>([]);
+    const [dokumentasjon, settDokumentasjon] = useState<DokumentasjonFelt[]>([]);
 
     return {
         harBekreftet,
@@ -24,6 +26,8 @@ const [SøknadProvider, useSøknad] = createUseContext(() => {
         settBarnMedBarnepass,
         aktivitet,
         settAktivitet,
+        dokumentasjon,
+        settDokumentasjon,
     };
 });
 

--- a/src/frontend/typer/skjema.ts
+++ b/src/frontend/typer/skjema.ts
@@ -4,3 +4,20 @@ export interface EnumFelt<T> {
     svarTekst: string;
     alternativer: string[];
 }
+
+export interface DokumentasjonFelt {
+    type: Vedleggstype;
+    label: string;
+    harSendtInn: boolean;
+    opplastedeVedlegg: Dokument[];
+}
+
+// Disse må synke med Vedleggstype i kontrakter
+export enum Vedleggstype {
+    EKSEMPEL = 'EKSEMPEL',
+}
+
+export interface Dokument {
+    id: string;
+    navn: string;
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Bruker skal kunne laste opp vedlegg.

Begrensninger i denne PR:
* Man kun laste opp en fil, tenker det er greit, trenger ikke å tenke på om en feiler og en annen ikke gjør det 👀 
* Kun lagt til støtte for å laste opp faktura (trenger mer arbeide for en mer generisk håndtering, og avklaringer før det gjøres)
* Kan ikke fjerne opplastet vedlegg fra statet

Koblet til
* https://favro.com/organization/98c34fb974ce445eac854de0/8a5276563da0f059dccd52a0?card=NAV-17104
* https://github.com/navikt/tilleggsstonader-soknad-api/pull/52

Lister filene som har blitt lastet opp
<img width="657" alt="image" src="https://github.com/navikt/tilleggsstonader-soknad/assets/937168/7c071c6b-b66f-434f-be62-7d8eddf6fdc2">

Oppsummering:
<img width="410" alt="image" src="https://github.com/navikt/tilleggsstonader-soknad/assets/937168/12652ac3-d11d-40ed-9800-00ff3adf72da">
