### PR TITLE
✨  Ytelse skal være flervalg

### DIFF
--- a/src/frontend/barnetilsyn/steg/2-hovedytelse/Hovedytelse.tsx
+++ b/src/frontend/barnetilsyn/steg/2-hovedytelse/Hovedytelse.tsx
@@ -8,23 +8,23 @@ import Side from '../../../components/Side';
 import LocaleCheckboxGroup from '../../../components/Teksthåndtering/LocaleCheckboxGroup';
 import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
 import { useSøknad } from '../../../context/SøknadContext';
-import { EnumFelt } from '../../../typer/skjema';
+import { EnumFlereValgFelt } from '../../../typer/skjema';
 import { Stønadstype } from '../../../typer/stønadstyper';
 import { hovedytelseInnhold } from '../../tekster/hovedytelse';
 
 const Hovedytelse = () => {
     const { hovedytelse, settHovedytelse } = useSøknad();
 
-    const [ytelse, settYtelse] = useState<EnumFelt<Ytelse[]> | undefined>(
+    const [ytelse, settYtelse] = useState<EnumFlereValgFelt<Ytelse> | undefined>(
         hovedytelse && hovedytelse.ytelse
     );
 
     const [ytelseFeil, settYtelseFeil] = useState('');
 
-    const kanFortsette = (ytelse?: EnumFelt<Ytelse[]>): boolean => {
+    const kanFortsette = (ytelse?: EnumFlereValgFelt<Ytelse>): boolean => {
         let kanFortsette = true;
 
-        if (ytelse === undefined || ytelse.verdi.length === 0) {
+        if (ytelse === undefined || ytelse.verdier.length === 0) {
             kanFortsette = false;
             settYtelseFeil('Du må velge et alternativ');
         } else {
@@ -53,7 +53,7 @@ const Hovedytelse = () => {
             </PellePanel>
             <LocaleCheckboxGroup
                 tekst={hovedytelseInnhold.checkbox_hovedytelse}
-                value={ytelse ? ytelse.verdi : []}
+                value={ytelse ? ytelse.verdier : []}
                 onChange={(verdi) => {
                     settYtelse(verdi);
                     settYtelseFeil('');

--- a/src/frontend/barnetilsyn/steg/2-hovedytelse/Hovedytelse.tsx
+++ b/src/frontend/barnetilsyn/steg/2-hovedytelse/Hovedytelse.tsx
@@ -1,63 +1,34 @@
 import { useState } from 'react';
 
-import { styled } from 'styled-components';
-
 import { Heading } from '@navikt/ds-react';
-import { AGray50 } from '@navikt/ds-tokens/dist/tokens';
 
-import { AnnenYtelse, erAnnenYtelse, erYtelse, erYtelseEllerAnnet, YtelseOgAnnet } from './typer';
+import { Ytelse } from './typer';
 import { PellePanel } from '../../../components/PellePanel/PellePanel';
 import Side from '../../../components/Side';
-import LocaleRadioGroup from '../../../components/Teksthåndtering/LocaleRadioGroup';
-import { LocaleReadMore } from '../../../components/Teksthåndtering/LocaleReadMore';
+import LocaleCheckboxGroup from '../../../components/Teksthåndtering/LocaleCheckboxGroup';
 import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
 import { useSøknad } from '../../../context/SøknadContext';
 import { EnumFelt } from '../../../typer/skjema';
 import { Stønadstype } from '../../../typer/stønadstyper';
 import { hovedytelseInnhold } from '../../tekster/hovedytelse';
 
-const GråBoks = styled.div`
-    background-color: ${AGray50};
-    padding: 2rem 1rem;
-`;
-
-const annetState: EnumFelt<YtelseOgAnnet> = {
-    label: '',
-    svarTekst: '',
-    verdi: 'ANNET',
-    alternativer: [],
-};
 const Hovedytelse = () => {
     const { hovedytelse, settHovedytelse } = useSøknad();
 
-    const [ytelse, settYtelse] = useState<EnumFelt<YtelseOgAnnet> | undefined>(
-        hovedytelse && (erYtelseEllerAnnet(hovedytelse.ytelse) ? hovedytelse.ytelse : annetState)
+    const [ytelse, settYtelse] = useState<EnumFelt<Ytelse[]> | undefined>(
+        hovedytelse && hovedytelse.ytelse
     );
+
     const [ytelseFeil, settYtelseFeil] = useState('');
 
-    const [annenYtelse, settAnnenYtelse] = useState<EnumFelt<AnnenYtelse> | undefined>(
-        hovedytelse && erAnnenYtelse(hovedytelse.ytelse) ? hovedytelse.ytelse : undefined
-    );
-    const [annenYtelseFeil, settAnnenYtelseFeil] = useState('');
-
-    const kanFortsette = (
-        ytelse?: EnumFelt<YtelseOgAnnet>,
-        annenYtelse?: EnumFelt<AnnenYtelse>
-    ): boolean => {
+    const kanFortsette = (ytelse?: EnumFelt<Ytelse[]>): boolean => {
         let kanFortsette = true;
 
-        if (ytelse === undefined) {
+        if (ytelse === undefined || ytelse.verdi.length === 0) {
             kanFortsette = false;
             settYtelseFeil('Du må velge et alternativ');
         } else {
             settYtelseFeil('');
-        }
-
-        if (ytelse?.verdi === 'ANNET' && annenYtelse === undefined) {
-            kanFortsette = false;
-            settAnnenYtelseFeil('Du må velge et alternativ');
-        } else {
-            settAnnenYtelseFeil('');
         }
 
         return kanFortsette;
@@ -67,12 +38,10 @@ const Hovedytelse = () => {
         <Side
             stønadstype={Stønadstype.BARNETILSYN}
             stegtittel={hovedytelseInnhold.steg_tittel}
-            validerSteg={() => kanFortsette(ytelse, annenYtelse)}
+            validerSteg={() => kanFortsette(ytelse)}
             oppdaterSøknad={() => {
-                if (ytelse && erYtelse(ytelse)) {
+                if (ytelse !== undefined) {
                     settHovedytelse({ ytelse: ytelse });
-                } else if (annenYtelse) {
-                    settHovedytelse({ ytelse: annenYtelse });
                 }
             }}
         >
@@ -82,32 +51,15 @@ const Hovedytelse = () => {
             <PellePanel>
                 <LocaleTekst tekst={hovedytelseInnhold.guide_innhold} />
             </PellePanel>
-            <LocaleRadioGroup
-                tekst={hovedytelseInnhold.radio_hovedytelse}
-                value={ytelse?.verdi || ''}
+            <LocaleCheckboxGroup
+                tekst={hovedytelseInnhold.checkbox_hovedytelse}
+                value={ytelse?.verdi}
                 onChange={(verdi) => {
                     settYtelse(verdi);
                     settYtelseFeil('');
-                    settAnnenYtelseFeil('');
-                    settAnnenYtelse(undefined);
                 }}
                 error={ytelseFeil}
-            >
-                <LocaleReadMore tekst={hovedytelseInnhold.flere_alternativer_lesmer} />
-            </LocaleRadioGroup>
-            {ytelse?.verdi === 'ANNET' && (
-                <GråBoks>
-                    <LocaleRadioGroup
-                        tekst={hovedytelseInnhold.radio_annen_ytelse}
-                        value={annenYtelse?.verdi || ''}
-                        onChange={(verdi) => {
-                            settAnnenYtelse(verdi);
-                            settAnnenYtelseFeil('');
-                        }}
-                        error={annenYtelseFeil}
-                    />
-                </GråBoks>
-            )}
+            />
         </Side>
     );
 };

--- a/src/frontend/barnetilsyn/steg/2-hovedytelse/Hovedytelse.tsx
+++ b/src/frontend/barnetilsyn/steg/2-hovedytelse/Hovedytelse.tsx
@@ -53,7 +53,7 @@ const Hovedytelse = () => {
             </PellePanel>
             <LocaleCheckboxGroup
                 tekst={hovedytelseInnhold.checkbox_hovedytelse}
-                value={(ytelse && ytelse.verdi) || []}
+                value={ytelse ? ytelse.verdi : []}
                 onChange={(verdi) => {
                     settYtelse(verdi);
                     settYtelseFeil('');

--- a/src/frontend/barnetilsyn/steg/2-hovedytelse/Hovedytelse.tsx
+++ b/src/frontend/barnetilsyn/steg/2-hovedytelse/Hovedytelse.tsx
@@ -53,7 +53,7 @@ const Hovedytelse = () => {
             </PellePanel>
             <LocaleCheckboxGroup
                 tekst={hovedytelseInnhold.checkbox_hovedytelse}
-                value={ytelse?.verdi}
+                value={(ytelse && ytelse.verdi) || []}
                 onChange={(verdi) => {
                     settYtelse(verdi);
                     settYtelseFeil('');

--- a/src/frontend/barnetilsyn/steg/2-hovedytelse/typer.ts
+++ b/src/frontend/barnetilsyn/steg/2-hovedytelse/typer.ts
@@ -1,32 +1,11 @@
-import { EnumFelt } from '../../../typer/skjema';
-
-export type Ytelse = 'AAP' | 'OVERGANGSSTØNAD' | 'GJENLEVENDEPENSJON';
-export type YtelseOgAnnet = Ytelse | 'ANNET';
-export type AnnenYtelse =
-    | 'DAGPENGER'
-    | 'TILTAKSPENGER'
-    | 'KVALIFIKASJONSPROGRAMMET'
-    | 'INTRODUKSJONSPROGRAMMET'
-    | 'SYKEPENGER'
+export type Ytelse =
+    | 'AAP'
+    | 'OVERGANGSSTØNAD'
+    | 'GJENLEVENDEPENSJON'
     | 'UFØRETRYGD'
-    | 'INGEN_PENGESTØTTE';
-
-export const erYtelse = (
-    verdi: EnumFelt<YtelseOgAnnet | AnnenYtelse>
-): verdi is EnumFelt<Ytelse> => {
-    switch (verdi.verdi) {
-        case 'AAP':
-        case 'OVERGANGSSTØNAD':
-        case 'GJENLEVENDEPENSJON':
-            return true;
-        default:
-            return false;
-    }
-};
-export const erYtelseEllerAnnet = (
-    verdi: EnumFelt<YtelseOgAnnet | AnnenYtelse>
-): verdi is EnumFelt<YtelseOgAnnet> => erYtelse(verdi) || verdi.verdi === 'ANNET';
-
-export const erAnnenYtelse = (
-    verdi: EnumFelt<Ytelse | AnnenYtelse>
-): verdi is EnumFelt<AnnenYtelse> => !erYtelseEllerAnnet(verdi);
+    | 'TILTAKSPENGER'
+    | 'DAGPENGER'
+    | 'SYKEPENGER'
+    | 'KVALIFISERINGSSTØNAD'
+    | 'INGEN_PENGESTØTTE'
+    | 'INGEN_PASSENDE_ALTERNATIVER';

--- a/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
@@ -125,9 +125,6 @@ const Hovedytelse: React.FC<{ hovedytelse: Hovedytelse | undefined }> = ({ hoved
                 tekst: oppsummeringTekster.accordians.ytelse.endre_button,
             }}
         >
-            <Label>
-                <LocaleTekst tekst={oppsummeringTekster.accordians.ytelse.label} />
-            </Label>
             {ytelser && (
                 <LocalePunktliste
                     tittel={oppsummeringTekster.accordians.ytelse.label}

--- a/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
@@ -30,14 +30,13 @@ import { Stønadstype } from '../../../typer/stønadstyper';
 import { Hovedytelse } from '../../../typer/søknad';
 import { TekstElement } from '../../../typer/tekst';
 import { formaterAdresse, formaterIsoDato, hentFornavn } from '../../../utils/formatering';
-import { listeTilTekstElement } from '../../../utils/tekster';
+import { verdiFelterTilTekstElement } from '../../../utils/tekster';
 import { RouteTilPath } from '../../routing/routesBarnetilsyn';
 import {
     barnepassTekster,
     PassTypeTilTekst,
     ÅrsakEkstraPassTilTekst,
 } from '../../tekster/barnepass';
-import { YtelseTilTekst } from '../../tekster/hovedytelse';
 import { oppsummeringTekster } from '../../tekster/oppsummering';
 import { personaliaTekster } from '../../tekster/personalia';
 
@@ -115,7 +114,7 @@ const OmDeg: React.FC<{ person: Person }> = ({ person }) => (
 );
 
 const Hovedytelse: React.FC<{ hovedytelse: Hovedytelse | undefined }> = ({ hovedytelse }) => {
-    const ytelser = hovedytelse && listeTilTekstElement(hovedytelse.ytelse.verdi, YtelseTilTekst);
+    const ytelser = hovedytelse && verdiFelterTilTekstElement(hovedytelse.ytelse.verdier);
 
     return (
         <AccordionItem

--- a/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
@@ -248,15 +248,15 @@ const Vedlegg: React.FC<{ dokumentasjon: DokumentasjonFelt[] }> = ({ dokumentasj
         <Label spacing>
             <LocaleTekst tekst={oppsummeringTekster.accordians.vedlegg.label} />
         </Label>
-        {dokumentasjon.map((d) => (
-            <>
+        {dokumentasjon.map((d, i) => (
+            <React.Fragment key={i}>
                 <BodyLong>{d.label}</BodyLong>
                 {d.opplastedeVedlegg.map((vedlegg) => (
-                    <BodyLong spacing>
+                    <BodyLong spacing key={vedlegg.id}>
                         <PaperclipIcon /> {vedlegg.navn}
                     </BodyLong>
                 ))}
-            </>
+            </React.Fragment>
         ))}
     </AccordionItem>
 );

--- a/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
@@ -17,6 +17,7 @@ import {
 
 import { PellePanel } from '../../../components/PellePanel/PellePanel';
 import Side from '../../../components/Side';
+import LocalePunktliste from '../../../components/Teksthåndtering/LocalePunktliste';
 import { LocaleReadMoreMedLenke } from '../../../components/Teksthåndtering/LocaleReadMore';
 import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
 import { usePerson } from '../../../context/PersonContext';
@@ -29,6 +30,7 @@ import { Stønadstype } from '../../../typer/stønadstyper';
 import { Hovedytelse } from '../../../typer/søknad';
 import { TekstElement } from '../../../typer/tekst';
 import { formaterAdresse, formaterIsoDato, hentFornavn } from '../../../utils/formatering';
+import { listeTilTekstElement } from '../../../utils/tekster';
 import { RouteTilPath } from '../../routing/routesBarnetilsyn';
 import {
     barnepassTekster,
@@ -112,24 +114,29 @@ const OmDeg: React.FC<{ person: Person }> = ({ person }) => (
     </AccordionItem>
 );
 
-const Hovedytelse: React.FC<{ hovedytelse: Hovedytelse | undefined }> = ({ hovedytelse }) => (
-    <AccordionItem
-        header={oppsummeringTekster.accordians.ytelse.tittel}
-        endreKnapp={{
-            route: RouteTilPath.HOVEDYTELSE,
-            tekst: oppsummeringTekster.accordians.ytelse.endre_button,
-        }}
-    >
-        <Label>
-            <LocaleTekst tekst={oppsummeringTekster.accordians.ytelse.label} />
-        </Label>
-        {hovedytelse && (
-            <BodyShort>
-                <LocaleTekst tekst={YtelseTilTekst[hovedytelse.ytelse.verdi]} />
-            </BodyShort>
-        )}
-    </AccordionItem>
-);
+const Hovedytelse: React.FC<{ hovedytelse: Hovedytelse | undefined }> = ({ hovedytelse }) => {
+    const ytelser = hovedytelse && listeTilTekstElement(hovedytelse.ytelse.verdi, YtelseTilTekst);
+
+    return (
+        <AccordionItem
+            header={oppsummeringTekster.accordians.ytelse.tittel}
+            endreKnapp={{
+                route: RouteTilPath.HOVEDYTELSE,
+                tekst: oppsummeringTekster.accordians.ytelse.endre_button,
+            }}
+        >
+            <Label>
+                <LocaleTekst tekst={oppsummeringTekster.accordians.ytelse.label} />
+            </Label>
+            {ytelser && (
+                <LocalePunktliste
+                    tittel={oppsummeringTekster.accordians.ytelse.label}
+                    innhold={ytelser}
+                />
+            )}
+        </AccordionItem>
+    );
+};
 
 const AktivitetUtdanning: React.FC = () => (
     <AccordionItem

--- a/src/frontend/barnetilsyn/tekster/hovedytelse.ts
+++ b/src/frontend/barnetilsyn/tekster/hovedytelse.ts
@@ -11,7 +11,7 @@ interface HovedytelseInnhold {
 export const YtelseTilTekst: Record<Ytelse, TekstElement<string>> = {
     AAP: { nb: 'Arbeidsavklaringspenger (AAP)' },
     OVERGANGSSTØNAD: { nb: 'Overgangsstønad til enslig mor eller far' },
-    GJENLEVENDEPENSJON: { nb: 'Gjenlevendepensjon/etterlattepensjon/omstillingsstønad' },
+    GJENLEVENDEPENSJON: { nb: 'Gjenlevendepensjon / etterlattepensjon / omstillingsstønad' },
     UFØRETRYGD: { nb: 'Uføretrygd' },
     TILTAKSPENGER: { nb: 'Tiltakspenger' },
     DAGPENGER: { nb: 'Dagpenger' },

--- a/src/frontend/barnetilsyn/tekster/hovedytelse.ts
+++ b/src/frontend/barnetilsyn/tekster/hovedytelse.ts
@@ -1,11 +1,11 @@
-import { Radiogruppe, TekstElement } from '../../typer/tekst';
+import { CheckboxGruppe, TekstElement } from '../../typer/tekst';
 import { Ytelse } from '../steg/2-hovedytelse/typer';
 
 interface HovedytelseInnhold {
     steg_tittel: TekstElement<string>;
     innhold_tittel: TekstElement<string>;
     guide_innhold: TekstElement<string>;
-    checkbox_hovedytelse: Radiogruppe<Ytelse>;
+    checkbox_hovedytelse: CheckboxGruppe<Ytelse>;
 }
 
 export const YtelseTilTekst: Record<Ytelse, TekstElement<string>> = {
@@ -36,47 +36,6 @@ export const hovedytelseInnhold: HovedytelseInnhold = {
         beskrivelse: {
             nb: 'Du kan velge flere.',
         },
-        alternativer: [
-            {
-                value: 'AAP',
-                label: YtelseTilTekst.AAP,
-            },
-            {
-                value: 'OVERGANGSSTØNAD',
-                label: YtelseTilTekst.OVERGANGSSTØNAD,
-            },
-            {
-                value: 'GJENLEVENDEPENSJON',
-                label: YtelseTilTekst.GJENLEVENDEPENSJON,
-            },
-            {
-                value: 'UFØRETRYGD',
-                label: YtelseTilTekst.UFØRETRYGD,
-            },
-            {
-                value: 'TILTAKSPENGER',
-                label: YtelseTilTekst.TILTAKSPENGER,
-            },
-            {
-                value: 'DAGPENGER',
-                label: YtelseTilTekst.DAGPENGER,
-            },
-            {
-                value: 'SYKEPENGER',
-                label: YtelseTilTekst.SYKEPENGER,
-            },
-            {
-                value: 'KVALIFISERINGSSTØNAD',
-                label: YtelseTilTekst.KVALIFISERINGSSTØNAD,
-            },
-            {
-                value: 'INGEN_PENGESTØTTE',
-                label: YtelseTilTekst.INGEN_PENGESTØTTE,
-            },
-            {
-                value: 'INGEN_PASSENDE_ALTERNATIVER',
-                label: YtelseTilTekst.INGEN_PASSENDE_ALTERNATIVER,
-            },
-        ],
+        alternativer: YtelseTilTekst,
     },
 };

--- a/src/frontend/barnetilsyn/tekster/hovedytelse.ts
+++ b/src/frontend/barnetilsyn/tekster/hovedytelse.ts
@@ -1,27 +1,24 @@
-import { LesMer, Radiogruppe, TekstElement } from '../../typer/tekst';
-import { AnnenYtelse, YtelseOgAnnet } from '../steg/2-hovedytelse/typer';
+import { Radiogruppe, TekstElement } from '../../typer/tekst';
+import { Ytelse } from '../steg/2-hovedytelse/typer';
 
 interface HovedytelseInnhold {
     steg_tittel: TekstElement<string>;
     innhold_tittel: TekstElement<string>;
     guide_innhold: TekstElement<string>;
-    radio_hovedytelse: Radiogruppe<YtelseOgAnnet>;
-    flere_alternativer_lesmer: LesMer<string>;
-    radio_annen_ytelse: Radiogruppe<AnnenYtelse>;
+    checkbox_hovedytelse: Radiogruppe<Ytelse>;
 }
 
-export const YtelseTilTekst: Record<YtelseOgAnnet | AnnenYtelse, TekstElement<string>> = {
+export const YtelseTilTekst: Record<Ytelse, TekstElement<string>> = {
     AAP: { nb: 'Arbeidsavklaringspenger (AAP)' },
-    DAGPENGER: { nb: 'Dagpenger' },
-    GJENLEVENDEPENSJON: { nb: 'Gjenlevendepensjon/etterlattepensjon' },
-    INGEN_PENGESTØTTE: { nb: 'Mottar ingen pengestøtte, men har nedsatt arbeidsevne' },
-    INTRODUKSJONSPROGRAMMET: { nb: 'Introduksjonsprogrammet' },
-    KVALIFIKASJONSPROGRAMMET: { nb: 'Kvalifikasjonsprogrammet' },
     OVERGANGSSTØNAD: { nb: 'Overgangsstønad til enslig mor eller far' },
-    SYKEPENGER: { nb: 'Sykepenger' },
-    TILTAKSPENGER: { nb: 'Tiltakspenger' },
+    GJENLEVENDEPENSJON: { nb: 'Gjenlevendepensjon/etterlattepensjon/omstillingsstønad' },
     UFØRETRYGD: { nb: 'Uføretrygd' },
-    ANNET: { nb: 'Nei, jeg har annen eller ingen ytelse/pengestøtte' },
+    TILTAKSPENGER: { nb: 'Tiltakspenger' },
+    DAGPENGER: { nb: 'Dagpenger' },
+    SYKEPENGER: { nb: 'Sykepenger' },
+    KVALIFISERINGSSTØNAD: { nb: 'Kvalifiseringsstønad ' },
+    INGEN_PENGESTØTTE: { nb: 'Mottar ingen pengestøtte, men har nedsatt arbeidsevne' },
+    INGEN_PASSENDE_ALTERNATIVER: { nb: 'Ingen av alternativene passer for meg' },
 };
 
 export const hovedytelseInnhold: HovedytelseInnhold = {
@@ -30,11 +27,14 @@ export const hovedytelseInnhold: HovedytelseInnhold = {
     },
     innhold_tittel: { nb: 'Din situasjon' },
     guide_innhold: {
-        nb: 'Vi spør om dette for å vite hvilke rettigheter du har og hvilke spørsmål vi må stille deg i skjemaet.',
+        nb: 'Vi spør om dette for å vite hvilke rettigheter du har og hvilke spørsmål vi må stille deg i søknadsskjemaet.',
     },
-    radio_hovedytelse: {
+    checkbox_hovedytelse: {
         header: {
             nb: 'Mottar du eller har du nylig søkt om noe av dette?',
+        },
+        beskrivelse: {
+            nb: 'Du kan velge flere.',
         },
         alternativer: [
             {
@@ -50,52 +50,32 @@ export const hovedytelseInnhold: HovedytelseInnhold = {
                 label: YtelseTilTekst.GJENLEVENDEPENSJON,
             },
             {
-                value: 'ANNET',
-                label: YtelseTilTekst.ANNET,
-            },
-        ],
-    },
-    flere_alternativer_lesmer: {
-        header: { nb: 'Hva gjør jeg hvis flere alternativer passer for meg?' },
-        innhold: {
-            nb: 'Har du rett på eller mottar flere av ytelsene/pengestøttene nevnt her trenger du bare å velge en. Er en av ytelsene du mottar AAP, velg AAP.',
-        },
-    },
-    radio_annen_ytelse: {
-        header: {
-            nb: 'Hvilken annen ytelse/pengestøtte mottar du eller har du søkt om?',
-        },
-        beskrivelse: {
-            nb: 'Vi spør om dette fordi vi trenger å vite hvilke rettigheter du har. ',
-        },
-        alternativer: [
-            {
-                value: 'DAGPENGER',
-                label: YtelseTilTekst.DAGPENGER,
+                value: 'UFØRETRYGD',
+                label: YtelseTilTekst.UFØRETRYGD,
             },
             {
                 value: 'TILTAKSPENGER',
                 label: YtelseTilTekst.TILTAKSPENGER,
             },
             {
-                value: 'KVALIFIKASJONSPROGRAMMET',
-                label: YtelseTilTekst.KVALIFIKASJONSPROGRAMMET,
-            },
-            {
-                value: 'INTRODUKSJONSPROGRAMMET',
-                label: YtelseTilTekst.INTRODUKSJONSPROGRAMMET,
+                value: 'DAGPENGER',
+                label: YtelseTilTekst.DAGPENGER,
             },
             {
                 value: 'SYKEPENGER',
                 label: YtelseTilTekst.SYKEPENGER,
             },
             {
-                value: 'UFØRETRYGD',
-                label: YtelseTilTekst.UFØRETRYGD,
+                value: 'KVALIFISERINGSSTØNAD',
+                label: YtelseTilTekst.KVALIFISERINGSSTØNAD,
             },
             {
                 value: 'INGEN_PENGESTØTTE',
                 label: YtelseTilTekst.INGEN_PENGESTØTTE,
+            },
+            {
+                value: 'INGEN_PASSENDE_ALTERNATIVER',
+                label: YtelseTilTekst.INGEN_PASSENDE_ALTERNATIVER,
             },
         ],
     },

--- a/src/frontend/components/Teksthåndtering/LocaleCheckboxGroup.tsx
+++ b/src/frontend/components/Teksthåndtering/LocaleCheckboxGroup.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+
+import {
+    CheckboxGroupProps as AkselCheckboxGroupProps,
+    CheckboxGroup,
+    Checkbox,
+} from '@navikt/ds-react';
+
+import { useSpråk } from '../../context/SpråkContext';
+import { EnumFelt } from '../../typer/skjema';
+import { Radiogruppe } from '../../typer/tekst';
+import { hentBeskjedMedEttParameter } from '../../utils/tekster';
+
+interface CheckboxGroupProps<T>
+    extends Omit<AkselCheckboxGroupProps, 'onChange' | 'legend' | 'children'> {
+    tekst: Radiogruppe<T>;
+    onChange: (enumFelt: EnumFelt<T[]>) => void;
+    children?: React.ReactNode;
+    argument0?: string;
+}
+
+function LocaleCheckboxGroup<T>({
+    children,
+    tekst,
+    argument0,
+    onChange,
+    ...props
+}: CheckboxGroupProps<T>) {
+    const { locale } = useSpråk();
+
+    const legend = argument0
+        ? hentBeskjedMedEttParameter(argument0, tekst.header[locale])
+        : tekst.header[locale];
+
+    const oppdaterValgteVerdier = (value: T[]) => {
+        const svarTekst = tekst.alternativer.find((alternativ) => alternativ.value === value);
+        onChange({
+            label: legend,
+            verdi: value,
+            alternativer: tekst.alternativer.map((alternativ) => alternativ.label[locale]),
+            svarTekst: svarTekst?.label[locale] || '',
+        });
+    };
+
+    return (
+        <CheckboxGroup
+            legend={legend}
+            description={
+                tekst.beskrivelse &&
+                (argument0
+                    ? hentBeskjedMedEttParameter(argument0, tekst.beskrivelse[locale])
+                    : tekst.beskrivelse[locale])
+            }
+            onChange={oppdaterValgteVerdier}
+            {...props}
+        >
+            {children}
+            {tekst.alternativer.map((alternativ, indeks) => (
+                <Checkbox value={alternativ.value} key={indeks}>
+                    {alternativ.label[locale]}
+                </Checkbox>
+            ))}
+        </CheckboxGroup>
+    );
+}
+
+export default LocaleCheckboxGroup;

--- a/src/frontend/context/SpråkContext.tsx
+++ b/src/frontend/context/SpråkContext.tsx
@@ -5,7 +5,7 @@ import createUseContext from 'constate';
 import { Locale } from '../typer/tekst';
 
 const [SpråkProvider, useSpråk] = createUseContext(() => {
-    const [locale, settLocale] = useState<Locale>('nb');
+    const [locale, settLocale] = useState<Locale>(Locale.NB);
     SpråkProvider.displayName = 'SPRÅK_PROVIDER';
 
     return { locale, settLocale };

--- a/src/frontend/typer/skjema.ts
+++ b/src/frontend/typer/skjema.ts
@@ -5,6 +5,17 @@ export interface EnumFelt<T> {
     alternativer: string[];
 }
 
+export interface EnumFlereValgFelt<T> {
+    label: string;
+    verdier: VerdiFelt<T>[];
+    alternativer: string[];
+}
+
+export interface VerdiFelt<T> {
+    verdi: T;
+    label: string;
+}
+
 export interface DokumentasjonFelt {
     type: Vedleggstype;
     label: string;

--- a/src/frontend/typer/søknad.ts
+++ b/src/frontend/typer/søknad.ts
@@ -1,8 +1,8 @@
-import { EnumFelt } from './skjema';
+import { EnumFelt, EnumFlereValgFelt } from './skjema';
 import { Ytelse } from '../barnetilsyn/steg/2-hovedytelse/typer';
 
 export interface Hovedytelse {
-    ytelse: EnumFelt<Ytelse[]>;
+    ytelse: EnumFlereValgFelt<Ytelse>;
 }
 
 export interface Aktivitet {

--- a/src/frontend/typer/søknad.ts
+++ b/src/frontend/typer/søknad.ts
@@ -1,8 +1,8 @@
 import { EnumFelt } from './skjema';
-import { AnnenYtelse, Ytelse } from '../barnetilsyn/steg/2-hovedytelse/typer';
+import { Ytelse } from '../barnetilsyn/steg/2-hovedytelse/typer';
 
 export interface Hovedytelse {
-    ytelse: EnumFelt<Ytelse | AnnenYtelse>;
+    ytelse: EnumFelt<Ytelse[]>;
 }
 
 export interface Aktivitet {

--- a/src/frontend/typer/tekst.ts
+++ b/src/frontend/typer/tekst.ts
@@ -21,3 +21,9 @@ export type Radiogruppe<T> = {
     beskrivelse?: TekstElement<string>;
     alternativer: { label: TekstElement<string>; value: T }[];
 };
+
+export type CheckboxGruppe<T extends string> = {
+    header: TekstElement<string>;
+    beskrivelse?: TekstElement<string>;
+    alternativer: Record<T, TekstElement<string>>;
+};

--- a/src/frontend/typer/tekst.ts
+++ b/src/frontend/typer/tekst.ts
@@ -1,4 +1,6 @@
-export type Locale = 'nb';
+export enum Locale {
+    NB = 'nb',
+}
 
 export type TekstElement<T> = Record<Locale, T>;
 

--- a/src/frontend/utils/tekster.ts
+++ b/src/frontend/utils/tekster.ts
@@ -1,18 +1,16 @@
+import { VerdiFelt } from '../typer/skjema';
 import { Locale, TekstElement } from '../typer/tekst';
 
 export const hentBeskjedMedEttParameter = (argument0: string, tekststreng: string) => {
     return tekststreng.replace('[0]', argument0);
 };
 
-export function listeTilTekstElement<T extends string>(
-    liste: T[],
-    tekstMapping: Record<T, TekstElement<string>>
+export function verdiFelterTilTekstElement<T extends string>(
+    liste: VerdiFelt<T>[]
 ): TekstElement<string[]> {
     return liste.reduce(
         (accumulated, currentValue) => {
-            Object.values(Locale).forEach((locale) =>
-                accumulated[locale].push(tekstMapping[currentValue][locale])
-            );
+            Object.values(Locale).forEach((locale) => accumulated[locale].push(currentValue.label));
             return accumulated;
         },
         { nb: [] } as TekstElement<string[]>

--- a/src/frontend/utils/tekster.ts
+++ b/src/frontend/utils/tekster.ts
@@ -1,3 +1,20 @@
+import { Locale, TekstElement } from '../typer/tekst';
+
 export const hentBeskjedMedEttParameter = (argument0: string, tekststreng: string) => {
     return tekststreng.replace('[0]', argument0);
 };
+
+export function listeTilTekstElement<T extends string>(
+    liste: T[],
+    tekstMapping: Record<T, TekstElement<string>>
+): TekstElement<string[]> {
+    return liste.reduce(
+        (accumulated, currentValue) => {
+            Object.values(Locale).forEach((locale) =>
+                accumulated[locale].push(tekstMapping[currentValue][locale])
+            );
+            return accumulated;
+        },
+        { nb: [] } as TekstElement<string[]>
+    );
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det var ønsket at alle ytelser skal listes opp som en lang checkbox liste:
![image](https://github.com/navikt/tilleggsstonader-soknad/assets/46678893/45f0b64d-e2f4-4873-b649-e8bf349f3bd5)

Dette krever oppdateringer i API, de kommer

Listes opp i oppsummering: 
![image](https://github.com/navikt/tilleggsstonader-soknad/assets/46678893/30ca64d6-fe85-413d-b365-b5cd274c85dd)

Henger sammen med: 
- [PR 47 i kontrakter](https://github.com/navikt/tilleggsstonader-kontrakter/pull/47)
