### PR TITLE
✨ 💄 Kvittering: legg til innsendt tidspunkt + tekstendinger og nøytral lenke

### DIFF
--- a/src/frontend/api/api.ts
+++ b/src/frontend/api/api.ts
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import Environment from './Environment';
 import { Person } from '../typer/person';
 import { Stønadstype } from '../typer/stønadstyper';
+import { Kvittering } from '../typer/søknad';
 
 const requestId = () => uuidv4().replaceAll('-', '');
 
@@ -30,7 +31,7 @@ const stønadstypeTilPath = (stønadstype: Stønadstype): string => {
     }
 };
 
-export const sendInnSøknad = (stønadstype: Stønadstype, søknad: object) => {
+export const sendInnSøknad = (stønadstype: Stønadstype, søknad: object): Promise<Kvittering> => {
     const url = `${Environment().apiProxyUrl}/soknad/${stønadstypeTilPath(stønadstype)}`;
     return axios.post(url, søknad, defaultConfig()).then((response) => response.data);
 };

--- a/src/frontend/barnetilsyn/Kvittering.tsx
+++ b/src/frontend/barnetilsyn/Kvittering.tsx
@@ -24,6 +24,8 @@ const Kvittering = () => {
                         tekst={kvitteringTekster.søknad_mottatt_alert_innhold1}
                         argument0={formaterDatoTid(innsentTidspunkt)}
                     />
+                </BodyLong>
+                <BodyLong>
                     <LocaleTekst tekst={kvitteringTekster.søknad_mottatt_alert_innhold2} />
                 </BodyLong>
             </Alert>

--- a/src/frontend/barnetilsyn/Kvittering.tsx
+++ b/src/frontend/barnetilsyn/Kvittering.tsx
@@ -5,7 +5,7 @@ import { Container } from '../components/Side';
 import LocaleInlineLenke from '../components/Teksthåndtering/LocaleInlineLenke';
 import LocaleTekst from '../components/Teksthåndtering/LocaleTekst';
 import { useSøknad } from '../context/SøknadContext';
-import { formaterDatoTid } from '../utils/formatering';
+import { formaterNullableIsoDatoTid } from '../utils/formatering';
 
 const Kvittering = () => {
     const { innsentTidspunkt } = useSøknad();
@@ -22,7 +22,7 @@ const Kvittering = () => {
                 <BodyLong spacing>
                     <LocaleTekst
                         tekst={kvitteringTekster.søknad_mottatt_alert_innhold1}
-                        argument0={formaterDatoTid(innsentTidspunkt)}
+                        argument0={formaterNullableIsoDatoTid(innsentTidspunkt)}
                     />
                 </BodyLong>
                 <BodyLong>

--- a/src/frontend/barnetilsyn/Kvittering.tsx
+++ b/src/frontend/barnetilsyn/Kvittering.tsx
@@ -1,12 +1,15 @@
-import { Alert, BodyShort, Heading } from '@navikt/ds-react';
+import { Alert, BodyLong, BodyShort, Heading } from '@navikt/ds-react';
 
 import { kvitteringTekster } from './tekster/kvittering';
 import { Container } from '../components/Side';
 import LocaleInlineLenke from '../components/Teksthåndtering/LocaleInlineLenke';
 import LocaleTekst from '../components/Teksthåndtering/LocaleTekst';
-import LocaleTekstAvsnitt from '../components/Teksthåndtering/LocaleTekstAvsnitt';
+import { useSøknad } from '../context/SøknadContext';
+import { formaterDatoTid } from '../utils/formatering';
 
 const Kvittering = () => {
+    const { innsentTidspunkt } = useSøknad();
+
     return (
         <Container>
             <Heading size="medium" as="h2">
@@ -16,7 +19,13 @@ const Kvittering = () => {
                 <Heading size="small" as="h3">
                     <LocaleTekst tekst={kvitteringTekster.søknad_mottatt_alert_tittel} />
                 </Heading>
-                <LocaleTekstAvsnitt tekst={kvitteringTekster.søknad_mottatt_alert_innhold} />
+                <BodyLong spacing>
+                    <LocaleTekst
+                        tekst={kvitteringTekster.søknad_mottatt_alert_innhold1}
+                        argument0={formaterDatoTid(innsentTidspunkt)}
+                    />
+                    <LocaleTekst tekst={kvitteringTekster.søknad_mottatt_alert_innhold2} />
+                </BodyLong>
             </Alert>
             <BodyShort>
                 <LocaleTekst tekst={kvitteringTekster.varsel_info} />

--- a/src/frontend/barnetilsyn/tekster/kvittering.ts
+++ b/src/frontend/barnetilsyn/tekster/kvittering.ts
@@ -27,7 +27,7 @@ export const kvitteringTekster: KvitteringInnhold = {
     se_søknad: {
         nb: [
             'Du kan se søknaden din på ',
-            { tekst: 'Min side', url: 'https://www.nav.no/min-side' },
+            { tekst: 'Mitt NAV.', url: 'https://www.nav.no/min-side', variant: 'neutral' },
         ],
     },
     se_saksbehandlingstid: {

--- a/src/frontend/barnetilsyn/tekster/kvittering.ts
+++ b/src/frontend/barnetilsyn/tekster/kvittering.ts
@@ -3,7 +3,8 @@ import { InlineLenke, TekstElement } from '../../typer/tekst';
 interface KvitteringInnhold {
     steg_tittel: TekstElement<string>;
     søknad_mottatt_alert_tittel: TekstElement<string>;
-    søknad_mottatt_alert_innhold: TekstElement<string[]>;
+    søknad_mottatt_alert_innhold1: TekstElement<string>;
+    søknad_mottatt_alert_innhold2: TekstElement<string>;
     varsel_info: TekstElement<string>;
     se_søknad: TekstElement<InlineLenke>;
     se_saksbehandlingstid: TekstElement<InlineLenke>;
@@ -14,11 +15,11 @@ export const kvitteringTekster: KvitteringInnhold = {
         nb: 'Kvittering',
     },
     søknad_mottatt_alert_tittel: { nb: 'Søknad mottatt' },
-    søknad_mottatt_alert_innhold: {
-        nb: [
-            'Vi har mottatt søknaden din om støtte til pass av barn. Saken din er nå til behandling hos NAV.',
-            'Vi vil ta kontakt med deg på telefon eller via Min side hvis vi trenger mer informasjon eller dokumentasjon fra deg.',
-        ],
+    søknad_mottatt_alert_innhold1: {
+        nb: 'Vi har mottatt søknaden din om støtte til pass av barn [0]. Saken din er nå til behandling hos NAV.',
+    },
+    søknad_mottatt_alert_innhold2: {
+        nb: 'Vi vil ta kontakt med deg på telefon eller via Min side hvis vi trenger mer informasjon eller dokumentasjon fra deg.',
     },
     varsel_info: {
         nb: 'Du får varsel på SMS eller e-post når saken er ferdig behandlet.',

--- a/src/frontend/components/Side.tsx
+++ b/src/frontend/components/Side.tsx
@@ -68,7 +68,8 @@ const Side: React.FC<Props> = ({
 }) => {
     const location = useLocation();
     const navigate = useNavigate();
-    const { hovedytelse, aktivitet, barnMedBarnepass, dokumentasjon } = useSøknad();
+    const { hovedytelse, aktivitet, barnMedBarnepass, dokumentasjon, settInnsentTidspunkt } =
+        useSøknad();
 
     const [sendInnFeil, settSendInnFeil] = useState<boolean>(false);
 
@@ -105,7 +106,10 @@ const Side: React.FC<Props> = ({
             barnMedBarnepass,
             dokumentasjon,
         })
-            .then(() => navigate(nesteRoute.path))
+            .then(() => {
+                settInnsentTidspunkt(new Date());
+                navigate(nesteRoute.path);
+            })
             // TODO håndtering av 401?
             .catch(() => settSendInnFeil(true));
     };

--- a/src/frontend/components/Side.tsx
+++ b/src/frontend/components/Side.tsx
@@ -106,8 +106,8 @@ const Side: React.FC<Props> = ({
             barnMedBarnepass,
             dokumentasjon,
         })
-            .then(() => {
-                settInnsentTidspunkt(new Date());
+            .then((res) => {
+                settInnsentTidspunkt(res.mottattTidspunkt);
                 navigate(nesteRoute.path);
             })
             // TODO håndtering av 401?

--- a/src/frontend/components/Teksthåndtering/LocaleInlineLenke.tsx
+++ b/src/frontend/components/Teksthåndtering/LocaleInlineLenke.tsx
@@ -12,7 +12,12 @@ const LocaleInlineLenke: React.FC<{ tekst: TekstElement<InlineLenke> }> = ({ tek
                 typeof tekstElement === 'string' ? (
                     <span key={indeks}>{tekstElement}</span>
                 ) : (
-                    <Link inlineText href={tekstElement.url} key={indeks}>
+                    <Link
+                        inlineText
+                        href={tekstElement.url}
+                        key={indeks}
+                        variant={tekstElement.variant}
+                    >
                         {tekstElement.tekst}
                     </Link>
                 )

--- a/src/frontend/context/SøknadContext.tsx
+++ b/src/frontend/context/SøknadContext.tsx
@@ -17,7 +17,7 @@ const [SøknadProvider, useSøknad] = createUseContext(() => {
     const [barnMedBarnepass, settBarnMedBarnepass] = useState<Barnepass[]>([]);
     const [dokumentasjon, settDokumentasjon] = useState<DokumentasjonFelt[]>([]);
 
-    const [innsentTidspunkt, settInnsentTidspunkt] = useState<Date>();
+    const [innsentTidspunkt, settInnsentTidspunkt] = useState<string>();
 
     return {
         harBekreftet,

--- a/src/frontend/context/SøknadContext.tsx
+++ b/src/frontend/context/SøknadContext.tsx
@@ -17,6 +17,8 @@ const [SøknadProvider, useSøknad] = createUseContext(() => {
     const [barnMedBarnepass, settBarnMedBarnepass] = useState<Barnepass[]>([]);
     const [dokumentasjon, settDokumentasjon] = useState<DokumentasjonFelt[]>([]);
 
+    const [innsentTidspunkt, settInnsentTidspunkt] = useState<Date>();
+
     return {
         harBekreftet,
         settHarBekreftet,
@@ -28,6 +30,8 @@ const [SøknadProvider, useSøknad] = createUseContext(() => {
         settAktivitet,
         dokumentasjon,
         settDokumentasjon,
+        innsentTidspunkt,
+        settInnsentTidspunkt,
     };
 });
 

--- a/src/frontend/typer/søknad.ts
+++ b/src/frontend/typer/søknad.ts
@@ -15,3 +15,7 @@ export interface Periode {
     fom: string;
     tom: string;
 }
+
+export interface Kvittering {
+    mottattTidspunkt: string;
+}

--- a/src/frontend/typer/tekst.ts
+++ b/src/frontend/typer/tekst.ts
@@ -10,6 +10,7 @@ export type LesMer<T> = {
 type Lenke = {
     tekst: string;
     url: string;
+    variant?: 'action' | 'neutral' | 'subtle';
 };
 
 export type InlineLenke = (string | Lenke)[];

--- a/src/frontend/utils/formatering.ts
+++ b/src/frontend/utils/formatering.ts
@@ -1,4 +1,4 @@
-import { parseISO } from 'date-fns';
+import { parseISO, format } from 'date-fns';
 
 import { Adresse } from '../typer/person';
 
@@ -21,11 +21,10 @@ export const formaterIsoDato = (dato: string): string => {
     return parseISO(dato).toLocaleDateString('no-NO', datoFormat);
 };
 
-export const formaterDatoTid = (dato?: Date): string | undefined => {
-    return (
-        dato &&
-        dato.toLocaleDateString('no-NO', datoFormat) +
-            ', klokken ' +
-            dato.toLocaleTimeString('no-NO', { hour: '2-digit', minute: '2-digit' })
-    );
+export const formaterIsoDatoTid = (dato: string): string => {
+    return format(parseISO(dato), "dd.MM.yyyy 'kl'.HH:mm");
+};
+
+export const formaterNullableIsoDatoTid = (dato?: string): string | undefined => {
+    return dato && formaterIsoDatoTid(dato);
 };

--- a/src/frontend/utils/formatering.ts
+++ b/src/frontend/utils/formatering.ts
@@ -20,3 +20,12 @@ export const hentFornavn = (navn: string) => {
 export const formaterIsoDato = (dato: string): string => {
     return parseISO(dato).toLocaleDateString('no-NO', datoFormat);
 };
+
+export const formaterDatoTid = (dato?: Date): string | undefined => {
+    return (
+        dato &&
+        dato.toLocaleDateString('no-NO', datoFormat) +
+            ', klokken ' +
+            dato.toLocaleTimeString('no-NO', { hour: '2-digit', minute: '2-digit' })
+    );
+};


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Var ønske om: 
- Kvittering skal inneholde mottatt tidspunkt
- Tekstendringer
- Noen lenker skal være nøytrale så de har fått "variant" som ikke må settes og da blir de automatisk blå

|FØR|ETTER|
|---|---|
|![image](https://github.com/navikt/tilleggsstonader-soknad/assets/46678893/3290679f-4b9d-47d9-9e60-93843a0fb638)|![image](https://github.com/navikt/tilleggsstonader-soknad/assets/46678893/20854026-52a1-4c1d-84e6-bda12ce09112)|