### PR TITLE
Alert box ved valg av barn over 10 år

### DIFF
--- a/src/frontend/barnetilsyn/steg/4-dine-barn/DineBarn.tsx
+++ b/src/frontend/barnetilsyn/steg/4-dine-barn/DineBarn.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Label } from '@navikt/ds-react';
+import { Alert, BodyShort, Checkbox, Heading, Label } from '@navikt/ds-react';
 
 import { PellePanel } from '../../../components/PellePanel/PellePanel';
 import Side from '../../../components/Side';
@@ -7,6 +7,7 @@ import { usePerson } from '../../../context/PersonContext';
 import { Stønadstype } from '../../../typer/stønadstyper';
 import { formaterIsoDato } from '../../../utils/formatering';
 import { dineBarnTekster } from '../../tekster/dineBarn';
+import { er9ellerEldre } from '../5-barnepass/utils';
 
 const DineBarn = () => {
     const { person, toggleSkalHaBarnepass } = usePerson();
@@ -30,6 +31,16 @@ const DineBarn = () => {
                         {barn.navn}, født {formaterIsoDato(barn.fødselsdato)}
                     </Checkbox>
                 ))}
+                {person.barn.some((barn) => barn.skalHaBarnepass && er9ellerEldre(barn)) && (
+                    <Alert variant="info">
+                        <Heading size="small">
+                            <LocaleTekst tekst={dineBarnTekster.alert_barn_over_9.tittel} />
+                        </Heading>
+                        <BodyShort size="medium">
+                            <LocaleTekst tekst={dineBarnTekster.alert_barn_over_9.innhold} />
+                        </BodyShort>
+                    </Alert>
+                )}
             </div>
         </Side>
     );

--- a/src/frontend/barnetilsyn/tekster/dineBarn.ts
+++ b/src/frontend/barnetilsyn/tekster/dineBarn.ts
@@ -4,6 +4,10 @@ interface DineBarnInnhold {
     steg_tittel: TekstElement<string>;
     guide_innhold: TekstElement<string>;
     hvilke_barn_spm: TekstElement<string>;
+    alert_barn_over_9: {
+        tittel: TekstElement<string>;
+        innhold: TekstElement<string>;
+    };
 }
 
 export const dineBarnTekster: DineBarnInnhold = {
@@ -14,4 +18,12 @@ export const dineBarnTekster: DineBarnInnhold = {
         nb: 'Vi henter opplysninger om barn fra folkeregisteret. Hvis du vil gjøre endringer, må du gjøre det på skatteetaten.no.',
     },
     hvilke_barn_spm: { nb: 'Hvilke barn søker du om støtte til pass for?' },
+    alert_barn_over_9: {
+        tittel: {
+            nb: 'Som hovedregel gis det bare støtte til pass av barn til og med 4. klasse',
+        },
+        innhold: {
+            nb: 'Unntaket er hvis ditt barn trenger mer pass eller pleie enn jevnaldrende eller hvis du har ett tiltak/utdanning hvor du må være borte i lengre perioder eller på andre tidspunkter enn en vanlig arbeidsdag. Dette må dokumenteres.',
+        },
+    },
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skal vise info om støtte til barn over X år.

Bygger videre på 
* https://github.com/navikt/tilleggsstonader-soknad/pull/204

❗ I skissene står det over 10 år, på neste side brukes `>=9` år, så er litt usikker på hva som faktiskt er riktig sjekk her. Venter på svar på slack https://nav-it.slack.com/archives/C05TU86SU8Y/p1708168110908599

<img width="674" alt="image" src="https://github.com/navikt/tilleggsstonader-soknad/assets/937168/95b89a52-beb9-45e3-b85c-32b1023440a2">

https://favro.com/organization/98c34fb974ce445eac854de0/8a5276563da0f059dccd52a0?card=NAV-18093