### PR TITLE
Person adresse formatert

### DIFF
--- a/src/frontend/barnetilsyn/Forside.tsx
+++ b/src/frontend/barnetilsyn/Forside.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 
-import { useNavigate } from 'react-router';
-import { useLocation } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import { styled } from 'styled-components';
 
 import {
@@ -27,7 +26,6 @@ import { usePerson } from '../context/PersonContext';
 import { useSøknad } from '../context/SøknadContext';
 import { fellesTekster } from '../tekster/felles';
 import { erSnartNyttSkoleår } from '../utils/dato';
-import { hentFornavn } from '../utils/formatering';
 import { hentNesteRoute } from '../utils/routes';
 
 const KnappeContainer = styled(BodyShort)`
@@ -59,7 +57,7 @@ const Forside: React.FC = () => {
                 <Label>
                     <LocaleTekst
                         tekst={forsideTekster.veileder_tittel}
-                        argument0={hentFornavn(person.navn)}
+                        argument0={person.fornavn}
                     />
                 </Label>
                 <BodyShort>

--- a/src/frontend/barnetilsyn/steg/1-personalia/Personalia.tsx
+++ b/src/frontend/barnetilsyn/steg/1-personalia/Personalia.tsx
@@ -6,7 +6,6 @@ import { LocaleReadMoreMedLenke } from '../../../components/Teksthåndtering/Loc
 import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
 import { usePerson } from '../../../context/PersonContext';
 import { Stønadstype } from '../../../typer/stønadstyper';
-import { formaterAdresse } from '../../../utils/formatering';
 import { personaliaTekster } from '../../tekster/personalia';
 
 const Personalia = () => {
@@ -24,7 +23,7 @@ const Personalia = () => {
                 <Label>
                     <LocaleTekst tekst={personaliaTekster.adresse_label} />
                 </Label>
-                <BodyShort>{formaterAdresse(person.adresse)}</BodyShort>
+                <BodyShort>{person.adresse}</BodyShort>
                 <LocaleReadMoreMedLenke tekst={personaliaTekster.adresse_lesmer} />
             </div>
             <div>

--- a/src/frontend/barnetilsyn/steg/4-dine-barn/DineBarn.tsx
+++ b/src/frontend/barnetilsyn/steg/4-dine-barn/DineBarn.tsx
@@ -50,7 +50,7 @@ const DineBarn = () => {
                         checked={barn.skalHaBarnepass ?? false}
                         onChange={() => toggleSkalHaBarnepass(barn.ident)}
                     >
-                        {barn.navn}, født {formaterIsoDato(barn.fødselsdato)}
+                        {barn.visningsnavn}, født {formaterIsoDato(barn.fødselsdato)}
                     </Checkbox>
                 ))}
                 {person.barn.some((barn) => barn.skalHaBarnepass && er9ellerEldre(barn)) && (

--- a/src/frontend/barnetilsyn/steg/5-barnepass/BarnOver9År.tsx
+++ b/src/frontend/barnetilsyn/steg/5-barnepass/BarnOver9År.tsx
@@ -8,7 +8,6 @@ import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
 import { Barn, ÅrsakBarnepass } from '../../../typer/barn';
 import { EnumFelt } from '../../../typer/skjema';
 import { JaNei } from '../../../typer/søknad';
-import { hentFornavn } from '../../../utils/formatering';
 import { barnepassTekster } from '../../tekster/barnepass';
 
 interface Props {
@@ -35,7 +34,7 @@ const BarnOver9År: React.FC<Props> = ({
         <>
             <LocaleRadioGroup
                 tekst={barnepassTekster.startet_femte_radio}
-                argument0={hentFornavn(barn.navn)}
+                argument0={barn.fornavn}
                 value={passInfo.startetIFemte?.verdi ?? ''}
                 onChange={oppdaterStartetIFemte}
                 error={
@@ -55,7 +54,7 @@ const BarnOver9År: React.FC<Props> = ({
                 <>
                     <LocaleRadioGroup
                         tekst={barnepassTekster.årsak_ekstra_pass_radio}
-                        argument0={hentFornavn(barn.navn)}
+                        argument0={barn.fornavn}
                         value={passInfo.årsak?.verdi || ''}
                         onChange={(val) => oppdaterBarnMedBarnepass({ ...passInfo, årsak: val })}
                         error={

--- a/src/frontend/barnetilsyn/steg/5-barnepass/BarnepassSpørsmål.tsx
+++ b/src/frontend/barnetilsyn/steg/5-barnepass/BarnepassSpørsmål.tsx
@@ -7,7 +7,6 @@ import LocaleInlineLenke from '../../../components/Teksthåndtering/LocaleInline
 import LocaleRadioGroup from '../../../components/Teksthåndtering/LocaleRadioGroup';
 import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
 import { Barn, PassType } from '../../../typer/barn';
-import { hentFornavn } from '../../../utils/formatering';
 import { barnepassTekster } from '../../tekster/barnepass';
 
 interface Props {
@@ -25,10 +24,10 @@ const BarnepassSpørsmål: React.FC<Props> = ({
 }) => {
     return (
         <>
-            <Heading size="medium">{barn.navn}</Heading>
+            <Heading size="medium">{barn.visningsnavn}</Heading>
             <LocaleRadioGroup
                 tekst={barnepassTekster.hvem_passer_radio}
-                argument0={hentFornavn(barn.navn)}
+                argument0={barn.fornavn}
                 value={barnepass.type?.verdi || ''}
                 onChange={(passType) => oppdaterBarnMedBarnepass({ ...barnepass, type: passType })}
                 error={visFeilmelding && barnepass.type === undefined && 'Du må velge et alernativ'}

--- a/src/frontend/barnetilsyn/steg/5-barnepass/barnepassDokumentUtil.ts
+++ b/src/frontend/barnetilsyn/steg/5-barnepass/barnepassDokumentUtil.ts
@@ -102,7 +102,10 @@ const lagDokumentasjonsfelt = (
     type: Vedleggstype,
     locale: Locale
 ): DokumentasjonFelt => {
-    const tittel = hentBeskjedMedEttParameter(barn.navn, typerVedleggTekster[type].tittel[locale]);
+    const tittel = hentBeskjedMedEttParameter(
+        barn.visningsnavn,
+        typerVedleggTekster[type].tittel[locale]
+    );
     return {
         type: type,
         label: tittel,

--- a/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
@@ -29,7 +29,7 @@ import { DokumentasjonFelt } from '../../../typer/skjema';
 import { Stønadstype } from '../../../typer/stønadstyper';
 import { Hovedytelse } from '../../../typer/søknad';
 import { TekstElement } from '../../../typer/tekst';
-import { formaterAdresse, formaterIsoDato, hentFornavn } from '../../../utils/formatering';
+import { formaterIsoDato, hentFornavn } from '../../../utils/formatering';
 import { verdiFelterTilTekstElement } from '../../../utils/tekster';
 import { RouteTilPath } from '../../routing/routesBarnetilsyn';
 import {
@@ -87,7 +87,7 @@ const OmDeg: React.FC<{ person: Person }> = ({ person }) => (
                 <Label>
                     <LocaleTekst tekst={personaliaTekster.adresse_label} />
                 </Label>
-                <BodyShort>{formaterAdresse(person.adresse)}</BodyShort>
+                <BodyShort>{person.adresse}</BodyShort>
                 <LocaleReadMoreMedLenke tekst={personaliaTekster.adresse_lesmer} />
             </div>
             <div>

--- a/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
@@ -29,7 +29,7 @@ import { DokumentasjonFelt } from '../../../typer/skjema';
 import { Stønadstype } from '../../../typer/stønadstyper';
 import { Hovedytelse } from '../../../typer/søknad';
 import { TekstElement } from '../../../typer/tekst';
-import { formaterIsoDato, hentFornavn } from '../../../utils/formatering';
+import { formaterIsoDato } from '../../../utils/formatering';
 import { verdiFelterTilTekstElement } from '../../../utils/tekster';
 import { RouteTilPath } from '../../routing/routesBarnetilsyn';
 import {
@@ -197,7 +197,7 @@ const DineBarn: React.FC<{ person: Person }> = ({ person }) => (
             .filter((barn) => barn.skalHaBarnepass)
             .map((barn) => (
                 <BodyShort key={barn.ident}>
-                    {barn.navn}, født {formaterIsoDato(barn.fødselsdato)}
+                    {barn.visningsnavn}, født {formaterIsoDato(barn.fødselsdato)}
                 </BodyShort>
             ))}
     </AccordionItem>
@@ -208,7 +208,7 @@ const BarnOver9År: React.FC<{ barn: Barn; barnepass: Barnepass }> = ({ barn, ba
         <Label>
             <LocaleTekst
                 tekst={barnepassTekster.startet_femte_radio.header}
-                argument0={hentFornavn(barn.navn)}
+                argument0={barn.fornavn}
             />
         </Label>
         <BodyShort>
@@ -219,7 +219,7 @@ const BarnOver9År: React.FC<{ barn: Barn; barnepass: Barnepass }> = ({ barn, ba
                 <Label>
                     <LocaleTekst
                         tekst={barnepassTekster.årsak_ekstra_pass_radio.header}
-                        argument0={hentFornavn(barn.navn)}
+                        argument0={barn.fornavn}
                     />
                 </Label>
                 <BodyShort>
@@ -249,7 +249,7 @@ const BarnMedBarnepass: React.FC<{ person: Person; barnMedBarnepass: Barnepass[]
                         <Label>
                             <LocaleTekst
                                 tekst={barnepassTekster.hvem_passer_radio.header}
-                                argument0={hentFornavn(barn.navn)}
+                                argument0={barn.fornavn}
                             />
                         </Label>
                         <BodyShort>

--- a/src/frontend/mock/initiellPerson.ts
+++ b/src/frontend/mock/initiellPerson.ts
@@ -2,11 +2,7 @@ import { Person } from '../typer/person';
 
 export const initiellPerson: Person = {
     navn: '',
-    adresse: {
-        adresse: '',
-        postnummer: '',
-        poststed: '',
-    },
+    adresse: '',
     telefonnr: '',
     epost: '',
     kontonr: '',

--- a/src/frontend/mock/initiellPerson.ts
+++ b/src/frontend/mock/initiellPerson.ts
@@ -1,7 +1,8 @@
 import { Person } from '../typer/person';
 
 export const initiellPerson: Person = {
-    navn: '',
+    fornavn: '',
+    visningsnavn: '',
     adresse: '',
     telefonnr: '',
     epost: '',

--- a/src/frontend/typer/barn.ts
+++ b/src/frontend/typer/barn.ts
@@ -5,7 +5,8 @@ export interface Barn {
     ident: string;
     alder: number;
     fødselsdato: string;
-    navn: string;
+    fornavn: string;
+    visningsnavn: string;
     skalHaBarnepass: boolean;
 }
 

--- a/src/frontend/typer/person.ts
+++ b/src/frontend/typer/person.ts
@@ -2,15 +2,9 @@ import { Barn } from './barn';
 
 export interface Person {
     navn: string;
-    adresse: Adresse;
+    adresse: string;
     telefonnr: string;
     epost: string;
     kontonr: string;
     barn: Barn[];
-}
-
-export interface Adresse {
-    adresse: string;
-    postnummer: string;
-    poststed: string;
 }

--- a/src/frontend/typer/person.ts
+++ b/src/frontend/typer/person.ts
@@ -1,7 +1,8 @@
 import { Barn } from './barn';
 
 export interface Person {
-    navn: string;
+    fornavn: string;
+    visningsnavn: string;
     adresse: string;
     telefonnr: string;
     epost: string;

--- a/src/frontend/utils/formatering.ts
+++ b/src/frontend/utils/formatering.ts
@@ -1,16 +1,10 @@
-import { parseISO, format, formatISO } from 'date-fns';
-
-import { Adresse } from '../typer/person';
+import { format, formatISO, parseISO } from 'date-fns';
 
 export const datoFormat = {
     day: '2-digit',
     month: '2-digit',
     year: 'numeric',
 } as const;
-
-export const formaterAdresse = (adresse: Adresse) => {
-    return `${adresse.adresse}, ${adresse.postnummer} ${adresse.poststed}`;
-};
 
 // TODO: Må ta hensyn til dobbeltnavn
 export const hentFornavn = (navn: string) => {

--- a/src/frontend/utils/formatering.ts
+++ b/src/frontend/utils/formatering.ts
@@ -6,11 +6,6 @@ export const datoFormat = {
     year: 'numeric',
 } as const;
 
-// TODO: Må ta hensyn til dobbeltnavn
-export const hentFornavn = (navn: string) => {
-    return navn.split(' ')[0];
-};
-
 export const formaterIsoDato = (dato: string): string => {
     return parseISO(dato).toLocaleDateString('no-NO', datoFormat);
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Gjør appen prodklar og fjerner todos

* Endrer til å gi frontend en formatert adresse, på lik måte som det er gjort i Enslig forsørger. Denne bruker vegadresse/matrikkeladresse 
* Sender med fornavn for at frontend enklere skal kunne vise fornavn, uten noen `navn.split(' ')[0]`

https://favro.com/organization/98c34fb974ce445eac854de0/8a5276563da0f059dccd52a0?card=NAV-18322

* https://github.com/navikt/tilleggsstonader-soknad-api/pull/87