### PR TITLE
Lagt til eslint-plugin-unused-imports for å automatisk fjerne ubrukte…

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,7 +14,7 @@
         "ecmaVersion": 2020,
         "sourceType": "module"
     },
-    "plugins": ["@typescript-eslint", "jsx-a11y", "prettier", "react-hooks", "import"],
+    "plugins": ["@typescript-eslint", "jsx-a11y", "prettier", "react-hooks", "import", "unused-imports"],
     "rules": {
         "import/extensions": [
             "off",
@@ -26,6 +26,7 @@
                 "tsx": "never"
             }
         ],
+        "unused-imports/no-unused-imports": "error",
         "@typescript-eslint/ban-ts-ignore": "off",
         "@typescript-eslint/ban-ts-comment": "off",
         "prettier/prettier": "warn",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint-plugin-jsx-a11y": "6.6.0",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-unused-imports": "^3.1.0",
     "html-webpack-plugin": "^5.6.0",
     "husky": "^9.0.10",
     "lint-staged": "^15.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3162,6 +3162,18 @@ eslint-plugin-react-hooks@^4.6.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
   integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==
 
+eslint-plugin-unused-imports@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-3.1.0.tgz#db015b569d3774e17a482388c95c17bd303bc602"
+  integrity sha512-9l1YFCzXKkw1qtAru1RWUtG2EVDZY0a0eChKXcL+EZ5jitG7qxdctu4RnvhOJHv4xfmUf7h+JJPINlVpGhZMrw==
+  dependencies:
+    eslint-rule-composer "^0.3.0"
+
+eslint-rule-composer@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
+  integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
+
 eslint-scope@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"


### PR DESCRIPTION
… imports ved commit.

Sørger for at importer forblir konsekvente uansett hvem som skriver dem og hvilke preferanser de har.

Liknende pr som https://github.com/navikt/tilleggsstonader-sak-frontend/pull/217