### PR TITLE
Legg til alert om sjekk av kontantstøtte ved barn under 2 år

### DIFF
--- a/src/frontend/barnetilsyn/steg/4-dine-barn/DineBarn.tsx
+++ b/src/frontend/barnetilsyn/steg/4-dine-barn/DineBarn.tsx
@@ -9,7 +9,7 @@ import { useSøknad } from '../../../context/SøknadContext';
 import { Stønadstype } from '../../../typer/stønadstyper';
 import { formaterIsoDato } from '../../../utils/formatering';
 import { dineBarnTekster } from '../../tekster/dineBarn';
-import { er9ellerEldre } from '../5-barnepass/utils';
+import { harBarnUnder2år, harValgtBarnOver9år } from '../5-barnepass/utils';
 
 const DineBarn = () => {
     const { person, toggleSkalHaBarnepass } = usePerson();
@@ -49,7 +49,7 @@ const DineBarn = () => {
                         {barn.visningsnavn}, født {formaterIsoDato(barn.fødselsdato)}
                     </Checkbox>
                 ))}
-                {person.barn.some((barn) => barn.skalHaBarnepass && er9ellerEldre(barn)) && (
+                {harValgtBarnOver9år(person.barn) && (
                     <Alert variant="info">
                         <Heading size="small">
                             <LocaleTekst tekst={dineBarnTekster.alert_barn_over_9.tittel} />
@@ -60,7 +60,8 @@ const DineBarn = () => {
                     </Alert>
                 )}
             </div>
-            {person.barn.some((barn) => barn.alder < 2) && (
+
+            {harBarnUnder2år(person.barn) && (
                 <Alert variant="info">
                     <LocaleTekst tekst={dineBarnTekster.alert_kontantstøtte} />
                 </Alert>

--- a/src/frontend/barnetilsyn/steg/4-dine-barn/DineBarn.tsx
+++ b/src/frontend/barnetilsyn/steg/4-dine-barn/DineBarn.tsx
@@ -60,6 +60,11 @@ const DineBarn = () => {
                     </Alert>
                 )}
             </div>
+            {person.barn.some((barn) => barn.alder < 2) && (
+                <Alert variant="info">
+                    <LocaleTekst tekst={dineBarnTekster.alert_kontantstøtte} />
+                </Alert>
+            )}
         </Side>
     );
 };

--- a/src/frontend/barnetilsyn/steg/5-barnepass/utils.ts
+++ b/src/frontend/barnetilsyn/steg/5-barnepass/utils.ts
@@ -17,3 +17,8 @@ export const finnBarn = (barn: Barn[], ident: string): Barn => {
 };
 
 export const er9ellerEldre = (barn: Barn): boolean => barn.alder >= 9;
+
+export const harValgtBarnOver9år = (barn: Barn[]): boolean =>
+    barn.some((b) => b.skalHaBarnepass && er9ellerEldre(b));
+
+export const harBarnUnder2år = (barn: Barn[]): boolean => barn.some((b) => b.alder < 2);

--- a/src/frontend/barnetilsyn/tekster/dineBarn.ts
+++ b/src/frontend/barnetilsyn/tekster/dineBarn.ts
@@ -7,6 +7,7 @@ interface DineBarnInnhold {
         tittel: TekstElement<string>;
         innhold: TekstElement<string>;
     };
+    alert_kontantstøtte: TekstElement<string>;
 }
 
 export const dineBarnTekster: DineBarnInnhold = {
@@ -25,5 +26,8 @@ export const dineBarnTekster: DineBarnInnhold = {
         innhold: {
             nb: 'Unntaket er hvis ditt barn trenger mer pass eller pleie enn jevnaldrende eller hvis du har ett tiltak/utdanning hvor du må være borte i lengre perioder eller på andre tidspunkter enn en vanlig arbeidsdag. Dette må dokumenteres.',
         },
+    },
+    alert_kontantstøtte: {
+        nb: 'Fordi du har barn under 2 år, kommer vi til å sjekke om det utbetales kontantstøtte for barnet. Hvis det utbetales kontantstøtte trekker vi det fra utgiftene dine når vi beregner hva du skal få i støtte til pass av barn.',
     },
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skal alltid vise en alert om at kontantstøtte sjekkes om det finnes barn under 2 år. Barn trenger ikke å være valgt.

<img width="829" alt="image" src="https://github.com/navikt/tilleggsstonader-soknad/assets/46678893/b14592f9-add4-4891-bf01-88b361ff38e8">
