### PR TITLE
Vis read more med info om å legge til flere barn om man ikke er enslig

### DIFF
--- a/src/frontend/barnetilsyn/steg/4-dine-barn/DineBarn.tsx
+++ b/src/frontend/barnetilsyn/steg/4-dine-barn/DineBarn.tsx
@@ -1,19 +1,21 @@
-import { Alert, BodyShort, Checkbox, Heading, Label } from '@navikt/ds-react';
+import { Alert, BodyLong, BodyShort, Checkbox, Heading, Label } from '@navikt/ds-react';
 
 import { PellePanel } from '../../../components/PellePanel/PellePanel';
 import Side from '../../../components/Side';
 import LocaleInlineLenke from '../../../components/Teksthåndtering/LocaleInlineLenke';
+import { LocaleReadMoreMedChildren } from '../../../components/Teksthåndtering/LocaleReadMore';
 import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
 import { usePerson } from '../../../context/PersonContext';
 import { useSøknad } from '../../../context/SøknadContext';
 import { Stønadstype } from '../../../typer/stønadstyper';
 import { formaterIsoDato } from '../../../utils/formatering';
+import { harKunValgtEnsligSomHovedytelse } from '../../../utils/hovedytelse';
 import { dineBarnTekster } from '../../tekster/dineBarn';
 import { harBarnUnder2år, harValgtBarnOver9år } from '../5-barnepass/utils';
 
 const DineBarn = () => {
     const { person, toggleSkalHaBarnepass } = usePerson();
-    const { settDokumentasjon } = useSøknad();
+    const { settDokumentasjon, hovedytelse } = useSøknad();
 
     const fjernDokumentasjonsFeltForBarnSomErFjernet = () => {
         const identer = person.barn
@@ -60,11 +62,26 @@ const DineBarn = () => {
                     </Alert>
                 )}
             </div>
-
             {harBarnUnder2år(person.barn) && (
                 <Alert variant="info">
                     <LocaleTekst tekst={dineBarnTekster.alert_kontantstøtte} />
                 </Alert>
+            )}
+            {!harKunValgtEnsligSomHovedytelse(hovedytelse?.ytelse) && (
+                <LocaleReadMoreMedChildren
+                    header={dineBarnTekster.søke_for_andre_barn_les_mer_header}
+                >
+                    <BodyLong spacing>
+                        <LocaleInlineLenke
+                            tekst={dineBarnTekster.søke_for_andre_barn_les_mer_innhold1}
+                        />
+                    </BodyLong>
+                    <BodyLong>
+                        <LocaleInlineLenke
+                            tekst={dineBarnTekster.søke_for_andre_barn_les_mer_innhold2}
+                        />
+                    </BodyLong>
+                </LocaleReadMoreMedChildren>
             )}
         </Side>
     );

--- a/src/frontend/barnetilsyn/tekster/dineBarn.ts
+++ b/src/frontend/barnetilsyn/tekster/dineBarn.ts
@@ -8,14 +8,21 @@ interface DineBarnInnhold {
         innhold: TekstElement<string>;
     };
     alert_kontantstøtte: TekstElement<string>;
+    søke_for_andre_barn_les_mer_header: TekstElement<string>;
+    søke_for_andre_barn_les_mer_innhold1: TekstElement<InlineLenke>;
+    søke_for_andre_barn_les_mer_innhold2: TekstElement<InlineLenke>;
 }
 
 export const dineBarnTekster: DineBarnInnhold = {
     guide_innhold: {
         nb: [
-            'Vi henter opplysninger om barn fra folkeregisteret. Du kan ikke legge til barn her. Hvis du vil melde fra om feil, må du gjøre det på ',
-            { tekst: 'skatteetaten.no', url: 'https://www.skatteetaten.no/', variant: 'neutral' },
-            '.',
+            'Vi henter opplysninger om barn fra folkeregisteret. Du kan ikke legge til biologiske eller adopterte barn her.  Hvis noe er feil, må du ',
+            {
+                tekst: 'melde fra til folkeregisteret',
+                url: 'https://www.skatteetaten.no/person/folkeregister/',
+                variant: 'neutral',
+            },
+            ' (åpnes i ny fane).',
         ],
     },
     hvilke_barn_spm: { nb: 'Hvilke barn søker du om støtte til pass for?' },
@@ -29,5 +36,30 @@ export const dineBarnTekster: DineBarnInnhold = {
     },
     alert_kontantstøtte: {
         nb: 'Fordi du har barn under 2 år, kommer vi til å sjekke om det utbetales kontantstøtte for barnet. Hvis det utbetales kontantstøtte trekker vi det fra utgiftene dine når vi beregner hva du skal få i støtte til pass av barn.',
+    },
+    søke_for_andre_barn_les_mer_header: {
+        nb: 'Hva gjør jeg hvis vil søke for barn som ikke vises her?',
+    },
+    søke_for_andre_barn_les_mer_innhold1: {
+        nb: [
+            'Hvis du ønsker å søke om støtte til pass av fosterbarn eller andre barn du har omsorg for, må du fylle ut ',
+            {
+                tekst: 'papirsøknad',
+                url: 'https://tjenester.nav.no/soknadtilleggsstonader/app/start',
+                variant: 'neutral',
+            },
+            ' (åpnes i ny fane).',
+        ],
+    },
+    søke_for_andre_barn_les_mer_innhold2: {
+        nb: [
+            'Vi henter opplysninger om dine barn fra folkeregisteret. Du kan derfor ikke legge til biologiske eller adopterte barn her.  Hvis noe er feil, må du ',
+            {
+                tekst: 'melde fra til folkeregisteret',
+                url: 'https://www.skatteetaten.no/person/folkeregister/',
+                variant: 'neutral',
+            },
+            ' (åpnes i ny fane).',
+        ],
     },
 };

--- a/src/frontend/utils/hovedytelse.ts
+++ b/src/frontend/utils/hovedytelse.ts
@@ -1,0 +1,12 @@
+import { Ytelse } from '../barnetilsyn/steg/2-hovedytelse/typer';
+import { EnumFlereValgFelt } from '../typer/skjema';
+
+export const harKunValgtEnsligSomHovedytelse = (
+    valgteHovedytelser?: EnumFlereValgFelt<Ytelse>
+): boolean => {
+    return (
+        !!valgteHovedytelser &&
+        valgteHovedytelser.verdier.length === 1 &&
+        valgteHovedytelser.verdier[0].verdi === 'OVERGANGSSTØNAD'
+    );
+};


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Alle som ikke er _kun enslig_ har lov til å søke om barn som ikke er biologiske/adoptert. Dette støtter vi ikke, men vi må vise dem informasjon om papirsøknad (les mer nederst på siden): 

<img width="829" alt="image" src="https://github.com/navikt/tilleggsstonader-soknad/assets/46678893/89e45ba9-c7cd-415d-b604-00d9e87504f8">
