### PR TITLE
Oppdatert feilmeldinger på barnepass med navn til barn

### DIFF
--- a/src/frontend/barnetilsyn/steg/5-barnepass/BarnOver9År.tsx
+++ b/src/frontend/barnetilsyn/steg/5-barnepass/BarnOver9År.tsx
@@ -6,9 +6,11 @@ import LocaleRadioGroup from '../../../components/Teksthåndtering/LocaleRadioGr
 import { LocaleReadMoreMedChildren } from '../../../components/Teksthåndtering/LocaleReadMore';
 import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
 import { UnderspørsmålContainer } from '../../../components/UnderspørsmålContainer';
+import { useSpråk } from '../../../context/SpråkContext';
 import { Barn, ÅrsakBarnepass } from '../../../typer/barn';
 import { EnumFelt } from '../../../typer/skjema';
 import { JaNei } from '../../../typer/søknad';
+import { hentBeskjedMedEttParameter } from '../../../utils/tekster';
 import { barnepassTekster } from '../../tekster/barnepass';
 
 interface Props {
@@ -23,6 +25,7 @@ const BarnOver9År: React.FC<Props> = ({
     oppdaterBarnMedBarnepass,
     visFeilmeldinger,
 }) => {
+    const { locale } = useSpråk();
     const oppdaterStartetIFemte = (val: EnumFelt<JaNei>) => {
         oppdaterBarnMedBarnepass({
             ...passInfo,
@@ -41,7 +44,10 @@ const BarnOver9År: React.FC<Props> = ({
                 error={
                     visFeilmeldinger &&
                     passInfo.startetIFemte === undefined &&
-                    'Du må velge et alternativ'
+                    hentBeskjedMedEttParameter(
+                        barn.fornavn,
+                        barnepassTekster.startet_femte_feilmelding[locale]
+                    )
                 }
             >
                 <LocaleReadMoreMedChildren header={barnepassTekster.startet_femte_readmore_header}>
@@ -62,7 +68,10 @@ const BarnOver9År: React.FC<Props> = ({
                             visFeilmeldinger &&
                             passInfo.startetIFemte !== undefined &&
                             passInfo.årsak === undefined &&
-                            'Du må velge et alternativ'
+                            hentBeskjedMedEttParameter(
+                                barn.fornavn,
+                                barnepassTekster.årsak_ekstra_pass_feilmelding[locale]
+                            )
                         }
                     />
                     {passInfo.årsak?.verdi === ÅrsakBarnepass.TRENGER_MER_PASS_ENN_JEVNALDRENDE && (

--- a/src/frontend/barnetilsyn/steg/5-barnepass/BarnepassSpørsmål.tsx
+++ b/src/frontend/barnetilsyn/steg/5-barnepass/BarnepassSpørsmål.tsx
@@ -5,7 +5,9 @@ import { BarnepassIntern } from './typer';
 import { er9ellerEldre } from './utils';
 import LocaleRadioGroup from '../../../components/Teksthåndtering/LocaleRadioGroup';
 import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
+import { useSpråk } from '../../../context/SpråkContext';
 import { Barn, PassType } from '../../../typer/barn';
+import { hentBeskjedMedEttParameter } from '../../../utils/tekster';
 import { barnepassTekster } from '../../tekster/barnepass';
 
 interface Props {
@@ -21,6 +23,7 @@ const BarnepassSpørsmål: React.FC<Props> = ({
     oppdaterBarnMedBarnepass,
     visFeilmelding,
 }) => {
+    const { locale } = useSpråk();
     return (
         <VStack gap={'6'}>
             <LocaleRadioGroup
@@ -28,7 +31,14 @@ const BarnepassSpørsmål: React.FC<Props> = ({
                 argument0={barn.fornavn}
                 value={barnepass.type?.verdi || ''}
                 onChange={(passType) => oppdaterBarnMedBarnepass({ ...barnepass, type: passType })}
-                error={visFeilmelding && barnepass.type === undefined && 'Du må velge et alernativ'}
+                error={
+                    visFeilmelding &&
+                    barnepass.type === undefined &&
+                    hentBeskjedMedEttParameter(
+                        barn.fornavn,
+                        barnepassTekster.hvem_passer_feilmelding[locale]
+                    )
+                }
             />
             {barnepass.type?.verdi === PassType.ANDRE && (
                 <Alert variant="info">

--- a/src/frontend/barnetilsyn/tekster/barnepass.ts
+++ b/src/frontend/barnetilsyn/tekster/barnepass.ts
@@ -10,11 +10,14 @@ interface BarnepassInnhold {
         tittel: TekstElement<string>;
         innhold: TekstElement<string>;
     };
+    hvem_passer_feilmelding: TekstElement<string>;
     startet_femte_radio: Radiogruppe<JaNei>;
+    startet_femte_feilmelding: TekstElement<string>;
     startet_femte_readmore_header: TekstElement<string>;
     startet_femte_readmore_innhold: TekstElement<string>;
     startet_femte_readmore_punktliste: TekstElement<string[]>;
     årsak_ekstra_pass_radio: Radiogruppe<ÅrsakBarnepass>;
+    årsak_ekstra_pass_feilmelding: TekstElement<string>;
     mer_pleie_alert: {
         tittel: TekstElement<string>;
         innhold: TekstElement<string>;
@@ -70,6 +73,9 @@ export const barnepassTekster: BarnepassInnhold = {
             nb: 'Ved privat barnepass regnes du som arbeidsgiver. Vi kommer til å be deg om å legge ved avtalen du har med barnepasseren og kvittering for betaling.',
         },
     },
+    hvem_passer_feilmelding: {
+        nb: 'Du må velge hva slags pass [0] har.',
+    },
     startet_femte_radio: {
         header: { nb: 'Har [0] startet i 5. klasse når tiltaket ditt starter?' },
         alternativer: [
@@ -82,6 +88,9 @@ export const barnepassTekster: BarnepassInnhold = {
                 label: { nb: 'Nei' },
             },
         ],
+    },
+    startet_femte_feilmelding: {
+        nb: 'Du må svare på om [0] har begynt i 5. klasse.',
     },
     startet_femte_readmore_header: {
         nb: 'Som hovedregel gis det bare støtte for pass av barn til og med 4. klasse.',
@@ -110,6 +119,9 @@ export const barnepassTekster: BarnepassInnhold = {
                 label: ÅrsakEkstraPassTilTekst.INGEN_AV_DISSE,
             },
         ],
+    },
+    årsak_ekstra_pass_feilmelding: {
+        nb: 'Du må velge en årsak til at [0] trenger pass etter 5. klasse.',
     },
     mer_pleie_alert: {
         tittel: {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Er det kun jeg som synes det burde være tilstrekkelig å ha den forrige teksten som ble vist? `'Du må velge et alternativ'` 👀 
Burde man sende med locale som param? 

<img width="539" alt="image" src="https://github.com/navikt/tilleggsstonader-soknad/assets/937168/e215214d-6ad3-4dcf-af69-5690eeb60626">

https://www.figma.com/file/WFmyvUL1MaVf3rlCQfdiWz/S%C3%B8knad-st%C3%B8nad-til-pass-av-barn---tilleggsst%C3%B8nad?type=design&node-id=2609-51458&mode=design&t=YkkA7lWeIk4EefMy-4