### PR TITLE
🆘  Vedlegg - error summary og markering av felter hvor dokumentasjon ikke er lastet opp

### DIFF
--- a/src/frontend/barnetilsyn/steg/6-vedlegg/Vedlegg.tsx
+++ b/src/frontend/barnetilsyn/steg/6-vedlegg/Vedlegg.tsx
@@ -95,6 +95,7 @@ const Vedlegg = () => {
                             toggleHarSendtInnTidligere={() => toggleHarSendtInnTidligere(dok)}
                             leggTilDokument={(dokument: Dokument) => leggTilDokument(dok, dokument)}
                             slettDokument={(dokument) => slettDokument(dok, dokument)}
+                            visFeilmelding={dokumentasjonSomMangler.includes(dok)}
                         />
                     </section>
                 ))}

--- a/src/frontend/barnetilsyn/tekster/vedlegg.ts
+++ b/src/frontend/barnetilsyn/tekster/vedlegg.ts
@@ -26,6 +26,10 @@ interface VedleggInnhold {
     };
 }
 
+interface VedleggFeilmeldinger {
+    overskrift: TekstElement<string>;
+}
+
 const formatKvalitetAccordian: VedleggInnhold['accordians']['format_kvalitet'] = {
     tittel: {
         nb: 'Format og kvalitet på vedlegg',
@@ -128,5 +132,11 @@ export const typerVedleggTekster: TekstTypeVedlegg = {
         krav_til_dokumentasjon: {
             nb: 'Legeerklæringen/uttalelsen fra helsepersonell må inneholde barnets navn og gjelde for perioden du søker om støtte til pass for.',
         },
+    },
+};
+
+export const vedleggFeilmeldinger: VedleggFeilmeldinger = {
+    overskrift: {
+        nb: 'Du må laste opp dokumentasjon for følgende felter før du kan gå videre:',
     },
 };

--- a/src/frontend/barnetilsyn/tekster/vedlegg.ts
+++ b/src/frontend/barnetilsyn/tekster/vedlegg.ts
@@ -28,6 +28,7 @@ interface VedleggInnhold {
 
 interface VedleggFeilmeldinger {
     overskrift: TekstElement<string>;
+    dokument_mangler: TekstElement<string>;
 }
 
 const formatKvalitetAccordian: VedleggInnhold['accordians']['format_kvalitet'] = {
@@ -139,4 +140,5 @@ export const vedleggFeilmeldinger: VedleggFeilmeldinger = {
     overskrift: {
         nb: 'Du må laste opp dokumentasjon for følgende felter før du kan gå videre:',
     },
+    dokument_mangler: { nb: 'Du må laste opp et dokument før du kan gå videre.' },
 };

--- a/src/frontend/components/Filopplaster/VedleggFelt.tsx
+++ b/src/frontend/components/Filopplaster/VedleggFelt.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { BodyLong, Heading, VStack } from '@navikt/ds-react';
+import { Alert, BodyLong, Heading, VStack } from '@navikt/ds-react';
 import { ASurfaceSubtle } from '@navikt/ds-tokens/dist/tokens';
 
 import Filopplaster from './Filopplaster';
+import { vedleggFeilmeldinger } from '../../barnetilsyn/tekster/vedlegg';
 import { filopplastingTekster } from '../../tekster/filopplasting';
 import { Dokument, DokumentasjonFelt } from '../../typer/skjema';
 import { Vedlegg } from '../../typer/tekst';
@@ -24,6 +25,7 @@ const VedleggFelt: React.FC<{
     toggleHarSendtInnTidligere: () => void;
     leggTilDokument: (vedlegg: Dokument) => void;
     slettDokument: (vedlegg: Dokument) => void;
+    visFeilmelding: boolean;
 }> = ({
     tittel,
     vedlegg,
@@ -31,9 +33,10 @@ const VedleggFelt: React.FC<{
     toggleHarSendtInnTidligere,
     leggTilDokument,
     slettDokument,
+    visFeilmelding,
 }) => {
     return (
-        <Container>
+        <Container $visFeilmelding={visFeilmelding}>
             <Heading size="small">{tittel}</Heading>
             <BodyLong>
                 <LocaleTekst tekst={vedlegg.beskrivelse} />
@@ -52,6 +55,12 @@ const VedleggFelt: React.FC<{
                 leggTilDokument={leggTilDokument}
                 slettDokument={slettDokument}
             />
+
+            {visFeilmelding && (
+                <Alert variant="error">
+                    <LocaleTekst tekst={vedleggFeilmeldinger.dokument_mangler} />
+                </Alert>
+            )}
         </Container>
     );
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Man må laste opp vedlegg i alle felter og da må bruker få vite hva de mangler. Både gjennom et sammendrag og markering ved hvert felt. 

**PS: ** har ikke tatt hensyn til huket av på sendt inn tidligere siden dette uansett skal fjernes.

### Feil ved løsningen
Startet på dette og tenkte at det var bare å liste opp, men liker ikke måten det gjøres på. Hit me med gode ideer. Dette mener jeg skurrer: 

- `ErrorSummary.Item` er lenker, men de går ikke noe sted. Må sette href men til hva? 
- Nå er feil bare en liste, ville gjerne hatt en map/object/record hvor key var href, men dokumentasjon har ingen id? Burde jeg lage en random uuid? Bruke kombo av vedleggtype + barnid? (Burde aldri overlappe)
- Ingen anelse hvordan feilmeldingen egentlig skal se ut på hver felt så tok enkel løsning. Kan vurdere å gjøre hele feltet rødt med rød ramme osv men blir veldig dramatisk. Gadd ikke å gjøre noe "fancy" før det evt. er gått opp med Marie.
- Trenger vi dette fokus greiene når summary er rett over knappen? Den scroller til elementet men det er i synsfelt, men endrer også kanskje fokus for tastaturbrukere? Det er i såfall nice
 
<img width="574" alt="image" src="https://github.com/navikt/tilleggsstonader-soknad/assets/46678893/6b152cfc-3efe-4dc6-992f-a1174edc6c78">
