### PR TITLE
Error summary

### DIFF
--- a/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
+++ b/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
@@ -12,24 +12,26 @@ import { useSøknad } from '../../../context/SøknadContext';
 import { EnumFelt } from '../../../typer/skjema';
 import { Stønadstype } from '../../../typer/stønadstyper';
 import { JaNei } from '../../../typer/søknad';
+import { inneholderFeil, Valideringsfeil } from '../../../typer/validering';
 import { aktivitetTekster } from '../../tekster/aktivitet';
 
 const Aktivitet = () => {
-    const { aktivitet, settAktivitet } = useSøknad();
+    const { aktivitet, settAktivitet, valideringsfeil, settValideringsfeil } = useSøknad();
 
     const [utdanning, settUtdanning] = useState<EnumFelt<JaNei> | undefined>(
         aktivitet ? aktivitet.utdanning : undefined
     );
 
-    const [feil, settFeil] = useState('');
-
     const kanFortsette = (barnepassPgaUtdanning?: JaNei): boolean => {
+        let feil: Valideringsfeil = {};
         if (barnepassPgaUtdanning === undefined) {
-            settFeil('Du må velge et alternativ');
-            return false;
+            feil = {
+                ...feil,
+                barnepassPgaUtdanning: { id: '1', melding: 'Du må velge et alternativ' },
+            };
         }
-
-        return true;
+        settValideringsfeil(feil);
+        return !inneholderFeil(feil);
     };
 
     const oppdaterAktivitetISøknad = () => {
@@ -51,13 +53,14 @@ const Aktivitet = () => {
                 <LocaleTekst tekst={aktivitetTekster.guide_innhold} />
             </PellePanel>
             <LocaleRadioGroup
+                id={valideringsfeil.barnepassPgaUtdanning?.id}
                 tekst={aktivitetTekster.radio_utdanning}
                 value={utdanning?.verdi || ''}
                 onChange={(verdi) => {
                     settUtdanning(verdi);
-                    settFeil('');
+                    settValideringsfeil({});
                 }}
-                error={feil}
+                error={valideringsfeil.barnepassPgaUtdanning?.melding}
             >
                 <LocaleReadMore tekst={aktivitetTekster.radio_utdanning_lesmer} />
             </LocaleRadioGroup>

--- a/src/frontend/barnetilsyn/steg/4-dine-barn/DineBarn.tsx
+++ b/src/frontend/barnetilsyn/steg/4-dine-barn/DineBarn.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Alert, BodyShort, BodyLong, Checkbox, CheckboxGroup, Heading } from '@navikt/ds-react';
 
@@ -24,6 +24,12 @@ const DineBarn = () => {
     const { settDokumentasjon, hovedytelse, valideringsfeil, settValideringsfeil } = useSøknad();
 
     const [personbarn, settPersonbarn] = useState<Barn[]>(person.barn);
+
+    useEffect(() => {
+        if (inneholderFeil(valideringsfeil) && personbarn.some((barn) => barn.skalHaBarnepass)) {
+            settValideringsfeil({});
+        }
+    }, [valideringsfeil, personbarn, settValideringsfeil]);
 
     const toggleSkalHaBarnepass = (ident: string) => {
         settPersonbarn((prevBarn) =>

--- a/src/frontend/barnetilsyn/steg/4-dine-barn/DineBarn.tsx
+++ b/src/frontend/barnetilsyn/steg/4-dine-barn/DineBarn.tsx
@@ -12,6 +12,7 @@ import { useSpråk } from '../../../context/SpråkContext';
 import { useSøknad } from '../../../context/SøknadContext';
 import { Barn } from '../../../typer/barn';
 import { Stønadstype } from '../../../typer/stønadstyper';
+import { inneholderFeil, Valideringsfeil } from '../../../typer/validering';
 import { formaterIsoDato } from '../../../utils/formatering';
 import { harKunValgtEnsligSomHovedytelse } from '../../../utils/hovedytelse';
 import { dineBarnTekster } from '../../tekster/dineBarn';
@@ -20,11 +21,9 @@ import { harBarnUnder2år, harValgtBarnOver9år } from '../5-barnepass/utils';
 const DineBarn = () => {
     const { locale } = useSpråk();
     const { person, settPerson } = usePerson();
-    const { settDokumentasjon, hovedytelse } = useSøknad();
+    const { settDokumentasjon, hovedytelse, valideringsfeil, settValideringsfeil } = useSøknad();
 
     const [personbarn, settPersonbarn] = useState<Barn[]>(person.barn);
-
-    const [feilmeldingHarValgtBarn, settFeilmeldingHarValgtBarn] = useState<string>();
 
     const toggleSkalHaBarnepass = (ident: string) => {
         settPersonbarn((prevBarn) =>
@@ -44,11 +43,15 @@ const DineBarn = () => {
     };
 
     const kanFortsette = (personbarn: Barn[]): boolean => {
+        let feil: Valideringsfeil = {};
         if (!personbarn.some((barn) => barn.skalHaBarnepass)) {
-            settFeilmeldingHarValgtBarn(dineBarnTekster.hvilke_barn_feilmelding[locale]);
-            return false;
+            feil = {
+                ...feil,
+                hvilkeBarn: { id: '1', melding: dineBarnTekster.hvilke_barn_feilmelding[locale] },
+            };
         }
-        return true;
+        settValideringsfeil(feil);
+        return !inneholderFeil(feil);
     };
 
     const oppdaterSøknad = () => {
@@ -70,8 +73,9 @@ const DineBarn = () => {
             </PellePanel>
             <div>
                 <CheckboxGroup
+                    id={valideringsfeil.hvilkeBarn?.id}
                     legend={dineBarnTekster.hvilke_barn_spm[locale]}
-                    error={feilmeldingHarValgtBarn}
+                    error={valideringsfeil.hvilkeBarn?.melding}
                 >
                     {personbarn.map((barn) => (
                         <Checkbox

--- a/src/frontend/barnetilsyn/steg/5-barnepass/Barnepass.tsx
+++ b/src/frontend/barnetilsyn/steg/5-barnepass/Barnepass.tsx
@@ -5,7 +5,7 @@ import { Heading, VStack } from '@navikt/ds-react';
 import { oppdaterDokumentasjonFeltForBarnMedPass } from './barnepassDokumentUtil';
 import BarnepassSpørsmål from './BarnepassSpørsmål';
 import { BarnepassIntern } from './typer';
-import { finnBarn, validerBarnepass } from './utils';
+import { valider } from './utils';
 import { PellePanel } from '../../../components/PellePanel/PellePanel';
 import Side from '../../../components/Side';
 import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
@@ -14,13 +14,20 @@ import { useSpråk } from '../../../context/SpråkContext';
 import { useSøknad } from '../../../context/SøknadContext';
 import { Barnepass } from '../../../typer/barn';
 import { Stønadstype } from '../../../typer/stønadstyper';
+import { inneholderFeil } from '../../../typer/validering';
 import { valuerOrThrow } from '../../../utils/typer';
 import { barnepassTekster } from '../../tekster/barnepass';
 
 const Barnepass = () => {
     const { person } = usePerson();
     const { locale } = useSpråk();
-    const { barnMedBarnepass, settBarnMedBarnepass, settDokumentasjon } = useSøknad();
+    const {
+        barnMedBarnepass,
+        settBarnMedBarnepass,
+        settDokumentasjon,
+        valideringsfeil,
+        settValideringsfeil,
+    } = useSøknad();
 
     const [barnMedPass, settBarnMedPass] = useState<BarnepassIntern[]>(
         person.barn
@@ -32,7 +39,13 @@ const Barnepass = () => {
                     }
             )
     );
-    const [visFeilmelding, settVisFeilmelding] = useState<boolean>(false);
+
+    const nullstillValideringsfeil = (key: string) => {
+        settValideringsfeil((prevState) => ({
+            ...prevState,
+            [key]: undefined,
+        }));
+    };
 
     const oppdaterBarnMedBarnepass = (oppdatertBarn: BarnepassIntern) => {
         settBarnMedPass((prevBarn) =>
@@ -40,22 +53,14 @@ const Barnepass = () => {
         );
     };
 
-    const kanGåVidere = () => {
-        const validerteBarn = barnMedPass.filter((barn) =>
-            validerBarnepass(barn, finnBarn(person.barn, barn.ident))
-        );
-
-        if (validerteBarn.length !== barnMedPass.length) {
-            settVisFeilmelding(true);
-            return false;
-        }
-        return true;
+    const kanGåVidere = (): boolean => {
+        const validerteBarn = valider(barnMedPass, person.barn, locale);
+        settValideringsfeil(validerteBarn);
+        return !inneholderFeil(validerteBarn);
     };
 
     const oppdaterSøknad = () => {
-        const barnepasses = barnMedPass.filter((barn) =>
-            validerBarnepass(barn, finnBarn(person.barn, barn.ident))
-        ) as Barnepass[];
+        const barnepasses = barnMedPass as Barnepass[];
         settBarnMedBarnepass(barnepasses);
         settDokumentasjon((prevState) =>
             oppdaterDokumentasjonFeltForBarnMedPass(barnepasses, person.barn, prevState, locale)
@@ -83,7 +88,8 @@ const Barnepass = () => {
                         )}
                         barnepass={barn}
                         oppdaterBarnMedBarnepass={oppdaterBarnMedBarnepass}
-                        visFeilmelding={visFeilmelding}
+                        valideringsfeil={valideringsfeil}
+                        nullstillValideringsfeil={nullstillValideringsfeil}
                     />
                 ))}
             </VStack>

--- a/src/frontend/barnetilsyn/steg/5-barnepass/BarnepassSpørsmål.tsx
+++ b/src/frontend/barnetilsyn/steg/5-barnepass/BarnepassSpørsmål.tsx
@@ -2,43 +2,40 @@ import { Alert, Heading, VStack } from '@navikt/ds-react';
 
 import BarnOver9År from './BarnOver9År';
 import { BarnepassIntern } from './typer';
-import { er9ellerEldre } from './utils';
+import { er9ellerEldre, errorKeyHvemPasser } from './utils';
 import LocaleRadioGroup from '../../../components/Teksthåndtering/LocaleRadioGroup';
 import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
-import { useSpråk } from '../../../context/SpråkContext';
 import { Barn, PassType } from '../../../typer/barn';
-import { hentBeskjedMedEttParameter } from '../../../utils/tekster';
+import { Valideringsfeil } from '../../../typer/validering';
 import { barnepassTekster } from '../../tekster/barnepass';
 
 interface Props {
     barn: Barn;
     barnepass: BarnepassIntern;
     oppdaterBarnMedBarnepass: (oppdatertBarn: BarnepassIntern) => void;
-    visFeilmelding: boolean;
+    valideringsfeil: Valideringsfeil;
+    nullstillValideringsfeil: (key: string) => void;
 }
 
 const BarnepassSpørsmål: React.FC<Props> = ({
     barn,
     barnepass,
     oppdaterBarnMedBarnepass,
-    visFeilmelding,
+    valideringsfeil,
+    nullstillValideringsfeil,
 }) => {
-    const { locale } = useSpråk();
     return (
         <VStack gap={'6'}>
             <LocaleRadioGroup
+                id={valideringsfeil[errorKeyHvemPasser(barn)]?.id}
                 tekst={barnepassTekster.hvem_passer_radio}
                 argument0={barn.fornavn}
                 value={barnepass.type?.verdi || ''}
-                onChange={(passType) => oppdaterBarnMedBarnepass({ ...barnepass, type: passType })}
-                error={
-                    visFeilmelding &&
-                    barnepass.type === undefined &&
-                    hentBeskjedMedEttParameter(
-                        barn.fornavn,
-                        barnepassTekster.hvem_passer_feilmelding[locale]
-                    )
-                }
+                onChange={(passType) => {
+                    oppdaterBarnMedBarnepass({ ...barnepass, type: passType });
+                    nullstillValideringsfeil(errorKeyHvemPasser(barn));
+                }}
+                error={valideringsfeil[errorKeyHvemPasser(barn)]?.melding}
             />
             {barnepass.type?.verdi === PassType.ANDRE && (
                 <Alert variant="info">
@@ -53,7 +50,8 @@ const BarnepassSpørsmål: React.FC<Props> = ({
                     barn={barn}
                     passInfo={barnepass}
                     oppdaterBarnMedBarnepass={oppdaterBarnMedBarnepass}
-                    visFeilmeldinger={visFeilmelding}
+                    valideringsfeil={valideringsfeil}
+                    nullstillValideringsfeil={nullstillValideringsfeil}
                 />
             )}
         </VStack>

--- a/src/frontend/barnetilsyn/steg/5-barnepass/utils.ts
+++ b/src/frontend/barnetilsyn/steg/5-barnepass/utils.ts
@@ -1,15 +1,59 @@
 import { BarnepassIntern } from './typer';
-import { Barn, Barnepass } from '../../../typer/barn';
+import { Barn } from '../../../typer/barn';
+import { Locale } from '../../../typer/tekst';
+import { Valideringsfeil } from '../../../typer/validering';
+import { hentBeskjedMedEttParameter } from '../../../utils/tekster';
+import { barnepassTekster } from '../../tekster/barnepass';
 
-export const validerBarnepass = (barn: BarnepassIntern, barnPerson: Barn): barn is Barnepass => {
-    if (!barn.type) {
-        return false;
-    } else if (er9ellerEldre(barnPerson) && barn.startetIFemte === undefined) {
-        return false;
-    } else if (barn.startetIFemte?.verdi === 'JA' && !barn.årsak) {
-        return false;
-    }
-    return true;
+export const errorKeyHvemPasser = (barn: Barn) => `${barn.ident}_hvemPasser`;
+export const errorKeyStartetFemte = (barn: Barn) => `${barn.ident}_startetFemte`;
+export const errorKeyÅrsak = (barn: Barn) => `${barn.ident}_årsak`;
+
+export const valider = (
+    barnMedPass: BarnepassIntern[],
+    personbarn: Barn[],
+    locale: Locale
+): Valideringsfeil => {
+    return barnMedPass.reduce((acc, barn, indeks) => {
+        const barnPerson = finnBarn(personbarn, barn.ident);
+        if (!barn.type) {
+            acc = {
+                ...acc,
+                [errorKeyHvemPasser(barnPerson)]: {
+                    id: `${indeks}-0`,
+                    melding: hentBeskjedMedEttParameter(
+                        barnPerson.fornavn,
+                        barnepassTekster.hvem_passer_feilmelding[locale]
+                    ),
+                },
+            };
+        }
+        if (er9ellerEldre(barnPerson) && barn.startetIFemte === undefined) {
+            acc = {
+                ...acc,
+                [errorKeyStartetFemte(barnPerson)]: {
+                    id: `${indeks}-1`,
+                    melding: hentBeskjedMedEttParameter(
+                        barnPerson.fornavn,
+                        barnepassTekster.startet_femte_feilmelding[locale]
+                    ),
+                },
+            };
+        }
+        if (barn.startetIFemte?.verdi === 'JA' && !barn.årsak) {
+            acc = {
+                ...acc,
+                [errorKeyÅrsak(barnPerson)]: {
+                    id: `${indeks}-2`,
+                    melding: hentBeskjedMedEttParameter(
+                        barnPerson.fornavn,
+                        barnepassTekster.årsak_ekstra_pass_feilmelding[locale]
+                    ),
+                },
+            };
+        }
+        return acc;
+    }, {} as Valideringsfeil);
 };
 
 export const finnBarn = (barn: Barn[], ident: string): Barn => {

--- a/src/frontend/components/Side.tsx
+++ b/src/frontend/components/Side.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import { useLocation, useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
@@ -71,6 +71,9 @@ const Side: React.FC<Props> = ({ stønadstype, children, validerSteg, oppdaterS�
     const [sendInnFeil, settSendInnFeil] = useState<boolean>(false);
 
     const harValideringsfeil = inneholderFeil(valideringsfeil);
+    useEffect(() => {
+        errorRef.current && errorRef.current.focus();
+    }, [harValideringsfeil]);
 
     const routes = hentRoutes(stønadstype);
     const nåværendePath = location.pathname;

--- a/src/frontend/context/SøknadContext.tsx
+++ b/src/frontend/context/SøknadContext.tsx
@@ -5,6 +5,7 @@ import createUseContext from 'constate';
 import { Barnepass } from '../typer/barn';
 import { DokumentasjonFelt } from '../typer/skjema';
 import { Aktivitet, Hovedytelse } from '../typer/søknad';
+import { Valideringsfeil } from '../typer/validering';
 
 const [SøknadProvider, useSøknad] = createUseContext(() => {
     SøknadProvider.displayName = 'SØKNAD_PROVIDER';
@@ -19,6 +20,8 @@ const [SøknadProvider, useSøknad] = createUseContext(() => {
 
     const [innsentTidspunkt, settInnsentTidspunkt] = useState<string>();
 
+    const [valideringsfeil, settValideringsfeil] = useState<Valideringsfeil>({});
+
     return {
         harBekreftet,
         settHarBekreftet,
@@ -32,6 +35,8 @@ const [SøknadProvider, useSøknad] = createUseContext(() => {
         settDokumentasjon,
         innsentTidspunkt,
         settInnsentTidspunkt,
+        valideringsfeil,
+        settValideringsfeil,
     };
 });
 

--- a/src/frontend/tekster/felles.ts
+++ b/src/frontend/tekster/felles.ts
@@ -7,6 +7,7 @@ export interface FellesInnhold {
     vi_stoler_feilmelding: TekstElement<string>;
     send_inn_søknad: TekstElement<string>;
     send_inn_søknad_feil: TekstElement<string>;
+    tittel_error_summary: TekstElement<string>;
     neste: TekstElement<string>;
     forrige: TekstElement<string>;
     banner_bt: TekstElement<string>;
@@ -25,6 +26,9 @@ export const fellesTekster: FellesInnhold = {
     },
     send_inn_søknad_feil: {
         nb: 'Innsending feilet, prøv på nytt.',
+    },
+    tittel_error_summary: {
+        nb: 'For å gå videre må du rette opp følgende:',
     },
     neste: {
         nb: 'Neste',

--- a/src/frontend/typer/validering.ts
+++ b/src/frontend/typer/validering.ts
@@ -1,0 +1,10 @@
+/**
+ * @param key er nøkkelen for å identifisere selve feilen
+ * eks kan key brukes til {`aktivitet`: {id: '1', melding: '...'}}
+ */
+export interface Valideringsfeil {
+    [key: string]: { id: string; melding: string } | undefined;
+}
+
+export const inneholderFeil = (valideringError: Valideringsfeil) =>
+    Object.values(valideringError).filter((error) => error).length > 0;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

* Scroller opp til ErrorSummary når man sender inn og det finnes feil
* Hver error får en unik lenke til riktig feilmelding
  * For barn så blir dette eks http://localhost:8080/tilleggsstonader/soknad/barnetilsyn/barnepass#1-2 for feilet til barn 2, spm 2 (årsak til barnepass). 
  * Her kan vi diskutere om man i stedet burde ha `#1-arsakbarnepass`, men Marie hadde ikke noen direkt kommentarer på det

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-20012

https://aksel.nav.no/komponenter/core/errorsummary
https://aksel.nav.no/god-praksis/artikler/skjemavalidering
> Feil i oppsummeringsboksen bør forsvinne i det brukeren korrigerer inndataen sin. Etter at brukeren har korrigert alle feilene, må brukeren sende inn skjemaet på nytt for å få skjemaet validert på nytt.

#### Din situasjon
<img width="678" alt="image" src="https://github.com/navikt/tilleggsstonader-soknad/assets/937168/8860c235-5813-4cee-ac0c-086dede3e1ed">

#### Aktivitet
Teksten er ikke oppdatert ennå.
<img width="659" alt="image" src="https://github.com/navikt/tilleggsstonader-soknad/assets/937168/fefc08cb-ae0d-480f-b374-3c6c3eb1fccc">

#### Dine barn
<img width="666" alt="image" src="https://github.com/navikt/tilleggsstonader-soknad/assets/937168/9bb0155c-04fa-4290-a891-a30a7a8019c3">

#### Pass av barn
<img width="461" alt="image" src="https://github.com/navikt/tilleggsstonader-soknad/assets/937168/a7a0a09c-52d6-41fb-93a4-0c18e409bb89">

