### PR TITLE
Opphold 1 - fjerner tidligere opphold og legger til utils

### DIFF
--- a/src/frontend/barnetilsyn/steg/2-hovedytelse/ArbeidOgOpphold/ArbeidOgOppholdUtenforNorge.tsx
+++ b/src/frontend/barnetilsyn/steg/2-hovedytelse/ArbeidOgOpphold/ArbeidOgOppholdUtenforNorge.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import { ArbeidOgOpphold } from '../../../../typer/søknad';
+
+interface Props {
+    arbeidOgOpphold: ArbeidOgOpphold;
+    settArbeidOgOpphold: React.Dispatch<React.SetStateAction<ArbeidOgOpphold>>;
+}
+
+const ArbeidOgOppholdUtenforNorge2: React.FC<Props> = () => {
+    return <></>;
+};
+
+export default ArbeidOgOppholdUtenforNorge2;

--- a/src/frontend/barnetilsyn/steg/2-hovedytelse/Hovedytelse.tsx
+++ b/src/frontend/barnetilsyn/steg/2-hovedytelse/Hovedytelse.tsx
@@ -1,26 +1,27 @@
 import { useState } from 'react';
 
-import { Heading, VStack } from '@navikt/ds-react';
+import { Heading } from '@navikt/ds-react';
 
+import ArbeidOgOppholdUtenforNorge from './ArbeidOgOpphold/ArbeidOgOppholdUtenforNorge';
 import { skalTaStillingTilOppholdINorge } from './taStillingTilOpphold';
 import { Ytelse } from './typer';
+import { validerHovedytelse } from './validering';
 import { PellePanel } from '../../../components/PellePanel/PellePanel';
 import Side from '../../../components/Side';
 import LocaleCheckboxGroup from '../../../components/Teksthåndtering/LocaleCheckboxGroup';
-import LocaleInlineLenke from '../../../components/Teksthåndtering/LocaleInlineLenke';
-import LocaleRadioGroup from '../../../components/Teksthåndtering/LocaleRadioGroup';
-import { LocaleReadMore } from '../../../components/Teksthåndtering/LocaleReadMore';
 import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
-import { UnderspørsmålContainer } from '../../../components/UnderspørsmålContainer';
 import { useSpråk } from '../../../context/SpråkContext';
 import { useSøknad } from '../../../context/SøknadContext';
-import { EnumFelt, EnumFlereValgFelt } from '../../../typer/skjema';
+import { EnumFlereValgFelt } from '../../../typer/skjema';
 import { Stønadstype } from '../../../typer/stønadstyper';
-import { JaNei } from '../../../typer/søknad';
-import { inneholderFeil, Valideringsfeil } from '../../../typer/validering';
+import { ArbeidOgOpphold } from '../../../typer/søknad';
+import { inneholderFeil } from '../../../typer/validering';
 import { hovedytelseInnhold } from '../../tekster/hovedytelse';
 
-const teksterOppholdINorge = hovedytelseInnhold.oppholdINorge;
+const defaultArbeidOgOpphold: ArbeidOgOpphold = {
+    oppholdUtenforNorgeSiste12mnd: [],
+    oppholdUtenforNorgeNeste12mnd: [],
+};
 
 const Hovedytelse = () => {
     const { locale } = useSpråk();
@@ -30,85 +31,27 @@ const Hovedytelse = () => {
         hovedytelse?.ytelse
     );
 
-    const [boddSammenhengende, settBoddSammenhengende] = useState<EnumFelt<JaNei> | undefined>(
-        hovedytelse?.boddSammenhengende
+    const [arbeidOgOpphold, settArbeidOgOpphold] = useState<ArbeidOgOpphold>(
+        hovedytelse?.arbeidOgOpphold || defaultArbeidOgOpphold
     );
-    const [planleggerBoINorgeNeste12mnd, settPlanleggerBoINorgeNeste12mnd] = useState<
-        EnumFelt<JaNei> | undefined
-    >(hovedytelse?.planleggerBoINorgeNeste12mnd);
 
     const skalTaStillingTilOpphold = ytelse ? skalTaStillingTilOppholdINorge(ytelse) : false;
 
     const kanFortsette = (ytelse?: EnumFlereValgFelt<Ytelse>): boolean => {
-        let feil: Valideringsfeil = {};
-
-        if (ytelse === undefined || ytelse.verdier.length === 0) {
-            feil = {
-                ...feil,
-                ytelse: { id: '1', melding: hovedytelseInnhold.hovedytelse_feilmelding[locale] },
-            };
-        }
-
-        if (skalTaStillingTilOpphold && boddSammenhengende === undefined) {
-            feil = {
-                ...feil,
-                boddSammenhengende: {
-                    id: '2',
-                    melding: teksterOppholdINorge.feilmelding_boddSammenhengende[locale],
-                },
-            };
-        }
-        if (
-            skalTaStillingTilOpphold &&
-            boddSammenhengende?.verdi === 'NEI' &&
-            planleggerBoINorgeNeste12mnd === undefined
-        ) {
-            feil = {
-                ...feil,
-                planleggerBoINorgeNeste12mnd: {
-                    id: '3',
-                    melding: teksterOppholdINorge.feilmelding_planleggerBoINorgeNeste12mnd[locale],
-                },
-            };
-        }
+        const feil = validerHovedytelse(ytelse, arbeidOgOpphold, locale);
         settValideringsfeil(feil);
         return !inneholderFeil(feil);
     };
 
     const oppdaterSkalTaStillingTilOpphold = (ytelse: EnumFlereValgFelt<Ytelse>) => {
         if (!skalTaStillingTilOppholdINorge(ytelse)) {
-            settBoddSammenhengende(undefined);
-            settPlanleggerBoINorgeNeste12mnd(undefined);
+            settArbeidOgOpphold(defaultArbeidOgOpphold);
             settValideringsfeil({});
         } else {
             settValideringsfeil((prevState) => ({ ...prevState, ytelse: undefined }));
         }
     };
 
-    const oppdaterBoddSammenhengende = (verdi: EnumFelt<JaNei>) => {
-        settBoddSammenhengende(verdi);
-        if (verdi.verdi === 'JA') {
-            settPlanleggerBoINorgeNeste12mnd(undefined);
-            settValideringsfeil((prevState) => ({
-                ...prevState,
-                boddSammenhengende: undefined,
-                planleggerBoINorgeNeste12mnd: undefined,
-            }));
-        } else {
-            settValideringsfeil((prevState) => ({
-                ...prevState,
-                boddSammenhengende: undefined,
-            }));
-        }
-    };
-
-    const oppdaterPlanleggerBoINorge = (verdi: EnumFelt<JaNei>) => {
-        settValideringsfeil((prevState) => ({
-            ...prevState,
-            planleggerBoINorgeNeste12mnd: undefined,
-        }));
-        settPlanleggerBoINorgeNeste12mnd(verdi);
-    };
     return (
         <Side
             stønadstype={Stønadstype.BARNETILSYN}
@@ -117,8 +60,7 @@ const Hovedytelse = () => {
                 if (ytelse !== undefined) {
                     settHovedytelse({
                         ytelse: ytelse,
-                        boddSammenhengende: boddSammenhengende,
-                        planleggerBoINorgeNeste12mnd: planleggerBoINorgeNeste12mnd,
+                        arbeidOgOpphold: arbeidOgOpphold,
                     });
                 }
             }}
@@ -140,41 +82,10 @@ const Hovedytelse = () => {
                 error={valideringsfeil?.ytelse?.melding}
             />
             {skalTaStillingTilOpphold && (
-                <UnderspørsmålContainer>
-                    <VStack gap="6">
-                        <Heading size="medium">
-                            <LocaleTekst tekst={hovedytelseInnhold.oppholdINorge.tittel} />
-                        </Heading>
-                        <PellePanel>
-                            <LocaleInlineLenke
-                                tekst={hovedytelseInnhold.oppholdINorge.guide_innhold}
-                            />
-                        </PellePanel>
-                        <LocaleRadioGroup
-                            id={valideringsfeil.boddSammenhengende?.id}
-                            tekst={hovedytelseInnhold.oppholdINorge.radio_boddSammenhengende}
-                            value={boddSammenhengende?.verdi}
-                            onChange={oppdaterBoddSammenhengende}
-                            error={valideringsfeil.boddSammenhengende?.melding}
-                        >
-                            <LocaleReadMore
-                                tekst={hovedytelseInnhold.oppholdINorge.lesMer_boddSammenhengende}
-                            />
-                        </LocaleRadioGroup>
-                        {boddSammenhengende?.verdi === 'NEI' && (
-                            <LocaleRadioGroup
-                                id={valideringsfeil.planleggerBoINorgeNeste12mnd?.id}
-                                tekst={
-                                    hovedytelseInnhold.oppholdINorge
-                                        .radio_planleggerBoINorgeNeste12mnd
-                                }
-                                value={planleggerBoINorgeNeste12mnd?.verdi}
-                                onChange={oppdaterPlanleggerBoINorge}
-                                error={valideringsfeil?.planleggerBoINorgeNeste12mnd?.melding}
-                            />
-                        )}
-                    </VStack>
-                </UnderspørsmålContainer>
+                <ArbeidOgOppholdUtenforNorge
+                    arbeidOgOpphold={arbeidOgOpphold}
+                    settArbeidOgOpphold={settArbeidOgOpphold}
+                />
             )}
         </Side>
     );

--- a/src/frontend/barnetilsyn/steg/2-hovedytelse/validering.ts
+++ b/src/frontend/barnetilsyn/steg/2-hovedytelse/validering.ts
@@ -1,0 +1,49 @@
+import { skalTaStillingTilOppholdINorge } from './taStillingTilOpphold';
+import { Ytelse } from './typer';
+import { EnumFlereValgFelt } from '../../../typer/skjema';
+import { ArbeidOgOpphold } from '../../../typer/søknad';
+import { Locale } from '../../../typer/tekst';
+import { Valideringsfeil } from '../../../typer/validering';
+import { hovedytelseInnhold } from '../../tekster/hovedytelse';
+
+/**
+ * For å ha unike feilid på felter
+ */
+export enum FeilIdDinSituasjon {
+    YTELSE = '1',
+    JOBBER_I_ANNET_LAND = '2',
+    JOBBER_I_ANNET_LAND_HVILKET_LAND = '3',
+    MOTTAR_DU_PENGESTØTTE = '4',
+    MOTTAR_DU_PENGESTØTTE_HVILKET_LAND = '5',
+    HAR_OPPHOLD_SISTE_12_MND = '6',
+    OPPHOLD_SISTE_12_MND = '7',
+    HAR_OPPHOLD_NESTE_12_MND = '8',
+    OPPHOLD_NESTE_12_MND = '9',
+}
+
+export const validerHovedytelse = (
+    ytelse: EnumFlereValgFelt<Ytelse> | undefined,
+    opphold: ArbeidOgOpphold,
+    locale: Locale
+): Valideringsfeil => {
+    let feil: Valideringsfeil = {};
+
+    if (ytelse === undefined || ytelse.verdier.length === 0) {
+        feil = {
+            ...feil,
+            ytelse: {
+                id: FeilIdDinSituasjon.YTELSE,
+                melding: hovedytelseInnhold.hovedytelse_feilmelding[locale],
+            },
+        };
+    }
+
+    const skalTaStillingTilOpphold = ytelse ? skalTaStillingTilOppholdINorge(ytelse) : false;
+    if (skalTaStillingTilOpphold) {
+        feil = {
+            ...feil,
+            //...validerArbeidOgOpphold(opphold, locale),
+        };
+    }
+    return feil;
+};

--- a/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
@@ -105,8 +105,6 @@ const DinSituasjon: React.FC<{ hovedytelse: Hovedytelse | undefined }> = ({ hove
     const ytelser = hovedytelse && verdiFelterTilTekstElement(hovedytelse.ytelse.verdier);
     const ytelseslabel = hovedytelse?.ytelse.label;
 
-    const boddSammenhengende = hovedytelse?.boddSammenhengende;
-    const planleggerBoINorgeNeste12mnd = hovedytelse?.planleggerBoINorgeNeste12mnd;
     // TODO: Hent ut svar om arbeid i eller utenfor norge også. Radiofeltene finnes ikke per nå.
 
     return (
@@ -118,7 +116,7 @@ const DinSituasjon: React.FC<{ hovedytelse: Hovedytelse | undefined }> = ({ hove
             }}
         >
             {ytelser && <LocalePunktliste innhold={ytelser} tittel={{ nb: ytelseslabel || '' }} />}
-            {boddSammenhengende && (
+            {/*boddSammenhengende && ( TODO fiks denne
                 <>
                     <Label>{boddSammenhengende.label}</Label>
                     <BodyShort spacing>{boddSammenhengende.svarTekst}</BodyShort>
@@ -129,7 +127,7 @@ const DinSituasjon: React.FC<{ hovedytelse: Hovedytelse | undefined }> = ({ hove
                     <Label>{planleggerBoINorgeNeste12mnd.label}</Label>
                     <BodyShort spacing>{planleggerBoINorgeNeste12mnd.svarTekst}</BodyShort>
                 </>
-            )}
+            )*/}
         </AccordionItem>
     );
 };

--- a/src/frontend/barnetilsyn/tekster/hovedytelse.ts
+++ b/src/frontend/barnetilsyn/tekster/hovedytelse.ts
@@ -1,6 +1,4 @@
-import { jaNeiAlternativer } from '../../tekster/felles';
-import { JaNei } from '../../typer/søknad';
-import { CheckboxGruppe, InlineLenke, LesMer, Radiogruppe, TekstElement } from '../../typer/tekst';
+import { CheckboxGruppe, TekstElement } from '../../typer/tekst';
 import { Ytelse } from '../steg/2-hovedytelse/typer';
 
 interface HovedytelseInnhold {
@@ -8,15 +6,6 @@ interface HovedytelseInnhold {
     guide_innhold: TekstElement<string>;
     checkbox_hovedytelse: CheckboxGruppe<Ytelse>;
     hovedytelse_feilmelding: TekstElement<string>;
-    oppholdINorge: {
-        tittel: TekstElement<string>;
-        guide_innhold: TekstElement<InlineLenke>;
-        radio_boddSammenhengende: Radiogruppe<JaNei>;
-        lesMer_boddSammenhengende: LesMer<string[]>;
-        feilmelding_boddSammenhengende: TekstElement<string>;
-        radio_planleggerBoINorgeNeste12mnd: Radiogruppe<JaNei>;
-        feilmelding_planleggerBoINorgeNeste12mnd: TekstElement<string>;
-    };
 }
 
 export const YtelseTilTekst: Record<Ytelse, TekstElement<string>> = {
@@ -48,50 +37,5 @@ export const hovedytelseInnhold: HovedytelseInnhold = {
     },
     hovedytelse_feilmelding: {
         nb: 'Du må huke av for minst én ytelse eller situasjon som passer for deg',
-    },
-    oppholdINorge: {
-        tittel: {
-            nb: 'Opphold i Norge',
-        },
-        guide_innhold: {
-            nb: [
-                'Vi spør om dette fordi vi må vite om du du oppfyller ',
-                {
-                    tekst: 'kravene til medlemskap i folketrygden',
-                    url: 'https://www.nav.no/no/person/flere-tema/arbeid-og-opphold-i-norge/relatert-informasjon/medlemskap-i-folketrygden',
-                    variant: 'neutral',
-                },
-                ' (åpnes i ny fane).',
-            ],
-        },
-        radio_boddSammenhengende: {
-            header: {
-                nb: 'Har du bodd sammenhengende i Norge de siste 12 månedene?',
-            },
-            alternativer: jaNeiAlternativer,
-        },
-        feilmelding_boddSammenhengende: {
-            nb: 'Du må svare på om du har bodd sammenhengende i Norge det siste året.',
-        },
-        lesMer_boddSammenhengende: {
-            header: {
-                nb: 'Hva menes med å bo sammenhengende?',
-            },
-            innhold: {
-                nb: [
-                    'Med dette mener vi at du ikke har bodd i andre land enn Norge.',
-                    'Ferier utenfor Norge i under 4 uker regnes ikke som å ha bodd i andre land.',
-                ],
-            },
-        },
-        radio_planleggerBoINorgeNeste12mnd: {
-            header: {
-                nb: 'Planlegger du å bo i Norge i de neste 12 månedene?',
-            },
-            alternativer: jaNeiAlternativer,
-        },
-        feilmelding_planleggerBoINorgeNeste12mnd: {
-            nb: 'Du må svare på om du planlegger å bo i Norge de neste 12 mnd.',
-        },
     },
 };

--- a/src/frontend/components/BlåVenstreRammeContainer.ts
+++ b/src/frontend/components/BlåVenstreRammeContainer.ts
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+import { ABlue500 } from '@navikt/ds-tokens/dist/tokens';
+
+export const BlåVenstreRammeContainer = styled.div`
+    border-left: 5px solid ${ABlue500};
+    padding: 0.5rem;
+`;

--- a/src/frontend/components/UnderspørsmålContainer.ts
+++ b/src/frontend/components/UnderspørsmålContainer.ts
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
 
-import { AGray100 } from '@navikt/ds-tokens/dist/tokens';
+import { AGray50 } from '@navikt/ds-tokens/dist/tokens';
 
 export const UnderspørsmålContainer = styled.div`
-    background: ${AGray100};
+    background: ${AGray50};
     padding: 1rem;
 `;

--- a/src/frontend/tekster/felles.ts
+++ b/src/frontend/tekster/felles.ts
@@ -11,6 +11,7 @@ export interface FellesInnhold {
     neste: TekstElement<string>;
     forrige: TekstElement<string>;
     banner_bt: TekstElement<string>;
+    velg_land: TekstElement<string>;
 }
 
 export const fellesTekster: FellesInnhold = {
@@ -38,6 +39,9 @@ export const fellesTekster: FellesInnhold = {
     },
     banner_bt: {
         nb: 'Søknad om støtte til pass av barn',
+    },
+    velg_land: {
+        nb: 'Velg land',
     },
 };
 

--- a/src/frontend/typer/skjema.ts
+++ b/src/frontend/typer/skjema.ts
@@ -13,6 +13,12 @@ export interface EnumFlereValgFelt<T> {
     alternativer: string[];
 }
 
+export interface SelectFelt {
+    label: string;
+    verdi: string;
+    svarTekst: string;
+}
+
 export interface VerdiFelt<T> {
     verdi: T;
     label: string;

--- a/src/frontend/typer/søknad.ts
+++ b/src/frontend/typer/søknad.ts
@@ -1,10 +1,31 @@
-import { EnumFelt, EnumFlereValgFelt } from './skjema';
+import { EnumFelt, EnumFlereValgFelt, SelectFelt, VerdiFelt } from './skjema';
 import { Ytelse } from '../barnetilsyn/steg/2-hovedytelse/typer';
 
 export interface Hovedytelse {
     ytelse: EnumFlereValgFelt<Ytelse>;
-    boddSammenhengende: EnumFelt<JaNei> | undefined;
-    planleggerBoINorgeNeste12mnd: EnumFelt<JaNei> | undefined;
+    arbeidOgOpphold: ArbeidOgOpphold;
+}
+
+export interface ArbeidOgOpphold {
+    jobberIAnnetLandEnnNorge?: EnumFelt<JaNei>;
+    hvilketLandJobberIAnnetLandEnnNorge?: VerdiFelt<string>;
+    mottarDuPengestøtteFraAnnetLand?: EnumFlereValgFelt<MottarPengestøtteTyper>;
+    hvilketLandMottarDuPengestøtteFra?: VerdiFelt<string>;
+
+    harDuOppholdUtenforNorgeSiste12mnd?: EnumFelt<JaNei>;
+    oppholdUtenforNorgeSiste12mnd: OppholdUtenforNorge[];
+
+    harDuOppholdUtenforNorgeNeste12mnd?: EnumFelt<JaNei>;
+    oppholdUtenforNorgeNeste12mnd: OppholdUtenforNorge[];
+}
+
+export interface OppholdUtenforNorge {
+    _id: number; // for å kunne lenke og vise riktig feilmelding - lagres ikke i bakend
+    lagret: boolean;
+    land?: SelectFelt;
+    årsak?: EnumFlereValgFelt<ÅrsakOppholdUtenforNorge>;
+    fom?: VerdiFelt<string>;
+    tom?: VerdiFelt<string>;
 }
 
 export interface Aktivitet {
@@ -12,6 +33,16 @@ export interface Aktivitet {
 }
 
 export type JaNei = 'JA' | 'NEI';
+
+export type MottarPengestøtteTyper = 'SYKEPENGER' | 'PENSJON' | 'ANNEN_PENGESTØTTE' | 'MOTTAR_IKKE';
+
+export type ÅrsakOppholdUtenforNorge =
+    | 'JOBB'
+    | 'STUDIER'
+    | 'MEDISINSK_BEHANDLING'
+    | 'FERIE'
+    | 'FAMILIE_BESØK'
+    | 'ANNET';
 
 export interface Periode {
     fom: string;

--- a/src/frontend/typer/søknad.ts
+++ b/src/frontend/typer/søknad.ts
@@ -7,15 +7,15 @@ export interface Hovedytelse {
 }
 
 export interface ArbeidOgOpphold {
-    jobberIAnnetLandEnnNorge?: EnumFelt<JaNei>;
-    hvilketLandJobberIAnnetLandEnnNorge?: VerdiFelt<string>;
-    mottarDuPengestøtteFraAnnetLand?: EnumFlereValgFelt<MottarPengestøtteTyper>;
-    hvilketLandMottarDuPengestøtteFra?: VerdiFelt<string>;
+    jobberIAnnetLand?: EnumFelt<JaNei>;
+    jobbAnnetLand?: VerdiFelt<string>;
+    harPengestøtteAnnetLand?: EnumFlereValgFelt<MottarPengestøtteTyper>;
+    pengestøtteAnnetLand?: VerdiFelt<string>;
 
-    harDuOppholdUtenforNorgeSiste12mnd?: EnumFelt<JaNei>;
+    harOppholdUtenforNorgeSiste12mnd?: EnumFelt<JaNei>;
     oppholdUtenforNorgeSiste12mnd: OppholdUtenforNorge[];
 
-    harDuOppholdUtenforNorgeNeste12mnd?: EnumFelt<JaNei>;
+    harOppholdUtenforNorgeNeste12mnd?: EnumFelt<JaNei>;
     oppholdUtenforNorgeNeste12mnd: OppholdUtenforNorge[];
 }
 

--- a/src/frontend/typer/tekst.ts
+++ b/src/frontend/typer/tekst.ts
@@ -28,6 +28,12 @@ export type Radiogruppe<T> = {
     alternativer: { label: TekstElement<string>; value: T }[];
 };
 
+export type Selectgruppe = {
+    header: TekstElement<string>;
+    beskrivelse?: TekstElement<string>;
+    alternativer: { label: TekstElement<string>; value: string }[];
+};
+
 export type CheckboxGruppe<T extends string> = {
     header: TekstElement<string>;
     beskrivelse?: TekstElement<string>;

--- a/src/frontend/utils/dato.ts
+++ b/src/frontend/utils/dato.ts
@@ -1,5 +1,17 @@
+import { isAfter, isEqual, parseISO } from 'date-fns';
+
 export const erSnartNyttSkoleår = () => {
     const nåværendeMåned = new Date().getMonth() + 1;
 
     return nåværendeMåned >= 6 && nåværendeMåned <= 8;
+};
+
+export const tilDato = (dato: string | Date): Date =>
+    typeof dato === 'string' ? parseISO(dato) : dato;
+
+export const erDatoEtterEllerLik = (fra: string, til: string): boolean => {
+    const datoFra = tilDato(fra);
+    const datoTil = tilDato(til);
+
+    return isEqual(datoFra, datoTil) || isAfter(datoTil, datoFra);
 };

--- a/src/frontend/utils/formatering.ts
+++ b/src/frontend/utils/formatering.ts
@@ -10,6 +10,9 @@ export const formaterIsoDato = (dato: string): string => {
     return parseISO(dato).toLocaleDateString('no-NO', datoFormat);
 };
 
+export const formaterNullableIsoDato = (dato: string | undefined): string | undefined =>
+    dato && formaterIsoDato(dato);
+
 export const formaterIsoDatoTid = (dato: string): string => {
     return format(parseISO(dato), "dd.MM.yyyy 'kl'.HH:mm");
 };

--- a/src/frontend/utils/typer.ts
+++ b/src/frontend/utils/typer.ts
@@ -2,6 +2,8 @@ export function manglerVerdi<T>(verdi: T | undefined | null) {
     return verdi === undefined || verdi === null;
 }
 
+export const harVerdi = (str: string | undefined | null): boolean => !!str && str.trim() !== '';
+
 export function valuerOrThrow<T>(
     verdi: T | undefined | null,
     message: string = 'Mangler verdi'


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
For å gjøre klart for å legge til håndtering av "nytt opphold" så splittes den endringen opp i flere PR's.
Denne PR fjerner litt som vi ikke skal ha lengre og legger til noen utils

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-20010

### Alle disse er koblet sammen: 
* https://github.com/navikt/tilleggsstonader-soknad/pull/266
* https://github.com/navikt/tilleggsstonader-soknad/pull/267
* https://github.com/navikt/tilleggsstonader-soknad/pull/268
* https://github.com/navikt/tilleggsstonader-soknad/pull/269
