### PR TITLE
Skal gjenbruke svar fra søknadstate i harBekreftet hvis man går tilba…

### DIFF
--- a/src/frontend/barnetilsyn/Forside.tsx
+++ b/src/frontend/barnetilsyn/Forside.tsx
@@ -124,9 +124,10 @@ const Forside: React.FC = () => {
                         <LocaleTekst tekst={fellesTekster.vi_stoler_feilmelding} />
                     )
                 }
+                value={[harBekreftet]}
             >
                 <Checkbox
-                    value={harBekreftet}
+                    value={true}
                     onChange={(e) => {
                         settHarBekreftet(e.target.checked);
                         settSkalViseFeilmelding(false);


### PR DESCRIPTION
…ke til førstesiden

### Hvorfor er denne endringen nødvendig? ✨
Når man gikk tilbake til førstesiden kunde man gå til andre siden på nytt då `harBekreftet` i søknadstaten var oppfylt, men man viste at den ikke var avhuket