### PR TITLE
List opp vedlegg som mangler opplasting i modal

### DIFF
--- a/src/frontend/barnetilsyn/steg/6-vedlegg/Vedlegg.tsx
+++ b/src/frontend/barnetilsyn/steg/6-vedlegg/Vedlegg.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 import { styled } from 'styled-components';
 
@@ -11,6 +11,7 @@ import {
     opprettDokumentasjonsfelt,
     toggleHarSendtInn,
 } from './utils';
+import VedleggManglerModal from './VedleggManglerModal';
 import VedleggFelt from '../../../components/Filopplaster/VedleggFelt';
 import { PellePanel } from '../../../components/PellePanel/PellePanel';
 import Side from '../../../components/Side';
@@ -33,6 +34,9 @@ const VedleggContainer = styled.div`
 const Vedlegg = () => {
     const { locale } = useSpråk();
     const { dokumentasjon, settDokumentasjon, dokumentasjonsbehov } = useSøknad();
+
+    const ref = useRef<HTMLDialogElement>(null);
+    const [ikkeOpplastedeDokumenter, settIkkeOpplastedeDokumenter] = React.useState<string[]>([]);
 
     useEffect(() => {
         settDokumentasjon((prevState) =>
@@ -58,8 +62,23 @@ const Vedlegg = () => {
         settDokumentasjon((prevState) => toggleHarSendtInn(prevState, dokumentasjonFelt));
     };
 
+    const validerSteg = () => {
+        const manglerOpplasting = dokumentasjon
+            .filter((dok) => dok.opplastedeVedlegg.length === 0)
+            .map((dok) => dok.label);
+
+        settIkkeOpplastedeDokumenter(manglerOpplasting);
+
+        if (manglerOpplasting.length > 0) {
+            ref.current?.showModal();
+            return false;
+        }
+
+        return true;
+    };
+
     return (
-        <Side stønadstype={Stønadstype.BARNETILSYN}>
+        <Side stønadstype={Stønadstype.BARNETILSYN} validerSteg={validerSteg}>
             <Heading size={'medium'}>
                 <LocaleTekst tekst={vedleggTekster.tittel} />
             </Heading>
@@ -82,6 +101,7 @@ const Vedlegg = () => {
                     </section>
                 ))}
             </VedleggContainer>
+            <VedleggManglerModal innerRef={ref} dokumenterSomMangler={ikkeOpplastedeDokumenter} />
         </Side>
     );
 };

--- a/src/frontend/barnetilsyn/steg/6-vedlegg/VedleggManglerModal.tsx
+++ b/src/frontend/barnetilsyn/steg/6-vedlegg/VedleggManglerModal.tsx
@@ -1,0 +1,51 @@
+import { RefObject } from 'react';
+
+import { useNavigate } from 'react-router-dom';
+
+import { BodyLong, Button, HStack, Heading, List, Modal } from '@navikt/ds-react';
+
+import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
+import { useSpråk } from '../../../context/SpråkContext';
+import { vedleggModalTekster } from '../../tekster/vedlegg';
+
+interface Props {
+    innerRef: RefObject<HTMLDialogElement>;
+    dokumenterSomMangler: string[];
+}
+const VedleggManglerModal: React.FC<Props> = ({ innerRef, dokumenterSomMangler }) => {
+    const { locale } = useSpråk();
+    const navigate = useNavigate();
+
+    return (
+        <Modal ref={innerRef} header={{ heading: vedleggModalTekster.heading[locale] }}>
+            <Modal.Body>
+                <HStack gap="6">
+                    <List title={vedleggModalTekster.punktliste_tittel[locale]}>
+                        {dokumenterSomMangler.map((dokument, indeks) => (
+                            <List.Item key={indeks}>{dokument}</List.Item>
+                        ))}
+                    </List>
+                    <BodyLong>
+                        <LocaleTekst tekst={vedleggModalTekster.ekstra_info1} />
+                    </BodyLong>
+                    <BodyLong>
+                        <LocaleTekst tekst={vedleggModalTekster.ekstra_info2} />
+                    </BodyLong>
+                    <Heading size="small" as="h2">
+                        <LocaleTekst tekst={vedleggModalTekster.vil_du_fortsette} />
+                    </Heading>
+                </HStack>
+            </Modal.Body>
+            <Modal.Footer>
+                <Button type="button" onClick={() => navigate('/barnetilsyn/oppsummering')}>
+                    <LocaleTekst tekst={vedleggModalTekster.fortsettKnapp} />
+                </Button>
+                <Button type="button" variant="secondary" onClick={() => innerRef.current?.close()}>
+                    <LocaleTekst tekst={vedleggModalTekster.avbrytKnapp} />
+                </Button>
+            </Modal.Footer>
+        </Modal>
+    );
+};
+
+export default VedleggManglerModal;

--- a/src/frontend/barnetilsyn/tekster/vedlegg.ts
+++ b/src/frontend/barnetilsyn/tekster/vedlegg.ts
@@ -82,6 +82,30 @@ export const vedleggTekster: VedleggInnhold = {
     },
 };
 
+interface VedleggManglerModalInnhold {
+    heading: TekstElement<string>;
+    punktliste_tittel: TekstElement<string>;
+    ekstra_info1: TekstElement<string>;
+    ekstra_info2: TekstElement<string>;
+    vil_du_fortsette: TekstElement<string>;
+    fortsettKnapp: TekstElement<string>;
+    avbrytKnapp: TekstElement<string>;
+}
+
+export const vedleggModalTekster: VedleggManglerModalInnhold = {
+    heading: { nb: 'Vedlegg mangler' },
+    punktliste_tittel: { nb: 'Vi kan ikke se at du har lagt ved:' },
+    ekstra_info1: {
+        nb: 'Vi kan ikke starte saksbehandlingen før vi har all dokumentasjon fra deg.',
+    },
+    ekstra_info2: {
+        nb: 'Har du ikke alle vedleggene i dag, kan du ettersende digitalt eller per post, innen 14 dager.',
+    },
+    vil_du_fortsette: { nb: 'Vil du fortsatt sende søknaden nå? ' },
+    fortsettKnapp: { nb: 'Ja, gå til neste side' },
+    avbrytKnapp: { nb: 'Nei, gå tilbake til vedlegg' },
+};
+
 export const typerVedleggTekster: TekstTypeVedlegg = {
     [Vedleggstype.UTGIFTER_PASS_SFO_AKS_BARNEHAGE]: {
         tittel: {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skal liste opp alle vedlegg som mangler i en modal ([skisser](https://www.figma.com/file/WFmyvUL1MaVf3rlCQfdiWz/S%C3%B8knad-st%C3%B8nad-til-pass-av-barn---tilleggsst%C3%B8nad?type=design&node-id=2393-10946&mode=design&t=5rkZGfNkcwK4HUKB-4)).
Droppet å legge til noe sjekk om det er huket av for sendt inn tidligere siden dette skal fjernes. 

<img width="950" alt="image" src="https://github.com/navikt/tilleggsstonader-soknad/assets/46678893/e8afff06-7342-4dde-8db5-d294a34a1127">
