### PR TITLE
Legger til maintag med maincontent

### DIFF
--- a/src/frontend/index.tsx
+++ b/src/frontend/index.tsx
@@ -44,11 +44,13 @@ const AppRoutes = () => {
     );
 };
 root.render(
-    <SpråkProvider>
-        <SøknadProvider>
-            <PersonProvider>
-                <AppRoutes />
-            </PersonProvider>
-        </SøknadProvider>
-    </SpråkProvider>
+    <main id={'maincontent'} tabIndex={-1}>
+        <SpråkProvider>
+            <SøknadProvider>
+                <PersonProvider>
+                    <AppRoutes />
+                </PersonProvider>
+            </SøknadProvider>
+        </SpråkProvider>
+    </main>
 );


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

"Hopp til hovedinnhold" skal hoppe over dekoratøren og inn på "vårt" innhold.

Testa i dev, funker fint. 

![image](https://github.com/navikt/tilleggsstonader-soknad/assets/17157469/033e8ec8-8f5b-418b-9398-ddc5e12b4d0c)
