### PR TITLE
Autofokuser på stegindikatoren når søker bytter steg

### DIFF
--- a/src/frontend/components/Side.tsx
+++ b/src/frontend/components/Side.tsx
@@ -113,7 +113,7 @@ const Side: React.FC<Props> = ({ st√∏nadstype, children, validerSteg, oppdaterS√
             <StegIndikator
                 gjeldendeSteg={aktivtStegIndex}
                 antallStegTotalt={routes.length - 2}
-                autofocus
+                autofokoserSkjermleser
             />
             {harValideringsfeil && (
                 <ErrorSummary heading={fellesTekster.tittel_error_summary[locale]} ref={errorRef}>

--- a/src/frontend/components/Side.tsx
+++ b/src/frontend/components/Side.tsx
@@ -141,12 +141,12 @@ const Side: React.FC<Props> = ({ stønadstype, children, validerSteg, oppdaterS�
                         <LocaleTekst tekst={fellesTekster.neste} />
                     </Button>
                 )}
-                {sendInnFeil && (
-                    <Alert variant={'error'} className="feilmelding">
-                        <LocaleTekst tekst={fellesTekster.send_inn_søknad_feil} />
-                    </Alert>
-                )}
             </KnappeContainerMedFeilmelding>
+            {sendInnFeil && (
+                <Alert variant={'error'}>
+                    <LocaleTekst tekst={fellesTekster.send_inn_søknad_feil} />
+                </Alert>
+            )}
         </Container>
     );
 };

--- a/src/frontend/components/Side.tsx
+++ b/src/frontend/components/Side.tsx
@@ -38,12 +38,6 @@ export const Container = styled.div`
     }
 `;
 
-const StegIndikator = styled.div`
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-`;
-
 const KnappeContainerMedFeilmelding = styled.div`
     display: grid;
     grid-template-columns: 1fr 1fr;
@@ -116,11 +110,11 @@ const Side: React.FC<Props> = ({ st√∏nadstype, children, validerSteg, oppdaterS√
 
     return (
         <Container>
-            <StegIndikator>
-                <BodyShort size="small">
-                    Steg {aktivtStegIndex} av {routes.length - 2}
-                </BodyShort>
-            </StegIndikator>
+            <StegIndikator
+                gjeldendeSteg={aktivtStegIndex}
+                antallStegTotalt={routes.length - 2}
+                autofocus
+            />
             {harValideringsfeil && (
                 <ErrorSummary heading={fellesTekster.tittel_error_summary[locale]} ref={errorRef}>
                     {Object.entries(valideringsfeil).map(

--- a/src/frontend/components/Side.tsx
+++ b/src/frontend/components/Side.tsx
@@ -3,9 +3,10 @@ import React, { useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 
-import { Alert, BodyShort, Button, ErrorSummary, VStack } from '@navikt/ds-react';
+import { Alert, Button, ErrorSummary, VStack } from '@navikt/ds-react';
 import { ABreakpointMd } from '@navikt/ds-tokens/dist/tokens';
 
+import { StegIndikator } from './StegIndikator';
 import LocaleTekst from './Teksthåndtering/LocaleTekst';
 import { sendInnSøknad } from '../api/api';
 import { ERouteBarnetilsyn } from '../barnetilsyn/routing/routesBarnetilsyn';
@@ -47,10 +48,6 @@ const KnappeContainerMedFeilmelding = styled.div`
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 1rem;
-
-    .feilmelding {
-        grid-column: 1 / span 2;
-    }
 `;
 
 const Side: React.FC<Props> = ({ stønadstype, children, validerSteg, oppdaterSøknad }) => {

--- a/src/frontend/components/StegIndikator.tsx
+++ b/src/frontend/components/StegIndikator.tsx
@@ -1,0 +1,31 @@
+import React, { useEffect, useRef } from 'react';
+
+import { BodyShort } from '@navikt/ds-react';
+
+export function StegIndikator(props: {
+    gjeldendeSteg: string | number;
+    antallStegTotalt: string | number;
+    autofocus?: boolean;
+}) {
+    const stegindikatorRef = useRef<HTMLParagraphElement>(null);
+
+    const fokuserPåStegindikatoren = () => {
+        if (stegindikatorRef.current) {
+            stegindikatorRef.current.focus();
+        }
+    };
+
+    useEffect(() => {
+        if (props.autofocus) {
+            fokuserPåStegindikatoren();
+        }
+    }, [props.autofocus]);
+
+    const stegteller = `Steg ${props.gjeldendeSteg} av ${props.antallStegTotalt}`;
+
+    return (
+        <BodyShort role="status" tabIndex={-1} ref={stegindikatorRef}>
+            {stegteller}
+        </BodyShort>
+    );
+}

--- a/src/frontend/components/StegIndikator.tsx
+++ b/src/frontend/components/StegIndikator.tsx
@@ -5,7 +5,7 @@ import { BodyShort } from '@navikt/ds-react';
 export function StegIndikator(props: {
     gjeldendeSteg: string | number;
     antallStegTotalt: string | number;
-    autofocus?: boolean;
+    autofokoserSkjermleser?: boolean;
 }) {
     const stegindikatorRef = useRef<HTMLParagraphElement>(null);
 
@@ -16,10 +16,10 @@ export function StegIndikator(props: {
     };
 
     useEffect(() => {
-        if (props.autofocus) {
+        if (props.autofokoserSkjermleser) {
             fokuserPåStegindikatoren();
         }
-    }, [props.autofocus]);
+    }, [props.autofokoserSkjermleser]);
 
     const tekst = `Steg ${props.gjeldendeSteg} av ${props.antallStegTotalt}`;
 

--- a/src/frontend/components/StegIndikator.tsx
+++ b/src/frontend/components/StegIndikator.tsx
@@ -21,11 +21,13 @@ export function StegIndikator(props: {
         }
     }, [props.autofocus]);
 
-    const stegteller = `Steg ${props.gjeldendeSteg} av ${props.antallStegTotalt}`;
+    const tekst = `Steg ${props.gjeldendeSteg} av ${props.antallStegTotalt}`;
 
     return (
-        <BodyShort role="status" tabIndex={-1} ref={stegindikatorRef}>
-            {stegteller}
-        </BodyShort>
+        <span>
+            <BodyShort role="status" tabIndex={-1} ref={stegindikatorRef}>
+                {tekst}
+            </BodyShort>
+        </span>
     );
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Fokuserer på "Steg x av y" ved hopping mellom steg. Enklere for folk på skjermleser å se hvor de befinner seg i flyten. 

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-20280)
![image](https://github.com/navikt/tilleggsstonader-soknad/assets/17157469/26cc1dbe-f386-4d77-bc75-fbc6abbe4e25)
