### PR TITLE
🐛 Fjern title som leses opp av skjermleser (UU-feil)

### DIFF
--- a/src/frontend/components/Filopplaster/Filopplaster.tsx
+++ b/src/frontend/components/Filopplaster/Filopplaster.tsx
@@ -77,7 +77,7 @@ const Filopplaster: React.FC<{
                 {feilmelding && <Alert variant="error">{feilmelding}</Alert>}
                 <Button
                     onClick={() => hiddenFileInput.current?.click()}
-                    icon={<UploadIcon title="a11y-title" />}
+                    icon={<UploadIcon />}
                     disabled={laster}
                 >
                     <LocaleTekst tekst={filopplastingTekster.last_opp_fil_knapp} />


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Fikset under test med skjermleser, gjorde endringen David mente holdt. Det var ikke nødvendig å legge ved en tittel at all, men den burde ikke vært 