### PR TITLE
Gradert søker skal bli sendt til gammel søknad

### DIFF
--- a/src/frontend/components/SøknadRouting/SøknadRouting.tsx
+++ b/src/frontend/components/SøknadRouting/SøknadRouting.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Alert } from '@navikt/ds-react';
 
-import Environment from '../../api/Environment';
+import { sendSøkerTilGammelSøknad } from './sendSøkerTilGammelSøknad';
 import { RoutingState, useRouting } from '../../api/useRouting';
 import { Stønadstype } from '../../typer/stønadstyper';
 
@@ -20,7 +20,7 @@ const SøknadRouting: React.FC<{ stønadstype: Stønadstype; children: React.Rea
         case RoutingState.FEILET:
             return <Alert variant="error">Noe gikk galt! Prøv å laste siden på nytt.</Alert>;
         case RoutingState.GAMMEL:
-            window.location.href = Environment().urlGammelSøknad;
+            sendSøkerTilGammelSøknad();
             return null;
     }
 };

--- a/src/frontend/components/SøknadRouting/sendSøkerTilGammelSøknad.ts
+++ b/src/frontend/components/SøknadRouting/sendSøkerTilGammelSøknad.ts
@@ -1,0 +1,5 @@
+import Environment from '../../api/Environment';
+
+export const sendSøkerTilGammelSøknad = () => {
+    window.location.href = Environment().urlGammelSøknad;
+};

--- a/src/frontend/context/PersonContext.tsx
+++ b/src/frontend/context/PersonContext.tsx
@@ -8,7 +8,7 @@ import { sendSøkerTilGammelSøknad } from '../components/SøknadRouting/sendSø
 import { initiellPerson } from '../mock/initiellPerson';
 import { Person } from '../typer/person';
 
-const erFeilOgSkalRouteTilGammelSøknad = (req: AxiosError<{ detail: string }, unknown>) => {
+const erFeilOgSkalRouteTilGammelSøknad = (req: AxiosError<{ detail?: string }, unknown>) => {
     return req?.response?.data?.detail === 'ROUTING_GAMMEL_SØKNAD';
 };
 
@@ -22,12 +22,11 @@ const [PersonProvider, usePerson] = createUseContext(() => {
         hentPersonData()
             .then((resp) => settPerson(resp))
             .catch((req) => {
-                if (axios.isAxiosError(req)) {
-                    if (erFeilOgSkalRouteTilGammelSøknad(req)) {
-                        sendSøkerTilGammelSøknad();
-                    }
+                if (axios.isAxiosError(req) && erFeilOgSkalRouteTilGammelSøknad(req)) {
+                    sendSøkerTilGammelSøknad();
+                } else {
+                    settFeilmelding('Feiltet henting av personopplysninger'); // TODO noe bedre håndtering?
                 }
-                settFeilmelding('Feiltet henting av personopplysninger'); // TODO noe bedre håndtering?
             })
             .finally(() => settHarLastetPerson(true));
     }, []);

--- a/src/frontend/context/PersonContext.tsx
+++ b/src/frontend/context/PersonContext.tsx
@@ -20,15 +20,17 @@ const [PersonProvider, usePerson] = createUseContext(() => {
 
     useEffect(() => {
         hentPersonData()
-            .then((resp) => settPerson(resp))
+            .then((resp) => {
+                settPerson(resp);
+                settHarLastetPerson(true);
+            })
             .catch((req) => {
                 if (axios.isAxiosError(req) && erFeilOgSkalRouteTilGammelSøknad(req)) {
                     sendSøkerTilGammelSøknad();
                 } else {
                     settFeilmelding('Feiltet henting av personopplysninger'); // TODO noe bedre håndtering?
                 }
-            })
-            .finally(() => settHarLastetPerson(true));
+            });
     }, []);
 
     return { harLastetPerson, feilmelding, person, settPerson };

--- a/src/frontend/index.tsx
+++ b/src/frontend/index.tsx
@@ -21,9 +21,6 @@ const root = createRoot(rootElement!);
 
 const AppRoutes = () => {
     const { harLastetPerson, feilmelding } = usePerson();
-    if (!harLastetPerson) {
-        return null;
-    }
     if (feilmelding) {
         return (
             <BrowserRouter basename={process.env.PUBLIC_URL}>
@@ -32,6 +29,9 @@ const AppRoutes = () => {
                 </Routes>
             </BrowserRouter>
         );
+    }
+    if (!harLastetPerson) {
+        return null;
     }
     return (
         <BrowserRouter basename={process.env.PUBLIC_URL}>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

I tilfelle søker eller barn er gradert så skal de sendes til ny søknad. Dette løses med at backend kaster en 400-feil, med teksten `ROUTING_GAMMEL_SØKNAD`.
Då blir søker sendt til gammel søknad på lik måte som når den sjekker routing av søker. 

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-20361

Koblet til 
https://github.com/navikt/tilleggsstonader-soknad-api/commit/79389b004b7a70de7166778263d316a08ee470b0