### PR TITLE
Mapper kode fra meldingmelding til TekstElement for bedre feilmelding…

### DIFF
--- a/src/frontend/components/Filopplaster/Filopplaster.tsx
+++ b/src/frontend/components/Filopplaster/Filopplaster.tsx
@@ -6,6 +6,7 @@ import { UploadIcon } from '@navikt/aksel-icons';
 import { Alert, Button, VStack } from '@navikt/ds-react';
 import { ABlue50, ABlue500 } from '@navikt/ds-tokens/dist/tokens';
 
+import { utledFeilmelding } from './feilmeldingOpplasting';
 import FilVisning from './Fil';
 import { MAX_FILSTØRRELSE, TILLATE_FILTYPER } from './utils';
 import { lastOppVedlegg } from '../../api/api';
@@ -52,13 +53,8 @@ const Filopplaster: React.FC<{
             settLaster(true);
             lastOppVedlegg(fil)
                 .then((id) => leggTilDokument({ id: id, navn: fil.name }))
-                .catch(() => {
-                    settFeilmelding(
-                        hentBeskjedMedEttParameter(
-                            fil.name,
-                            teksterFeilmeldinger.feiletOpplasting[locale]
-                        )
-                    );
+                .catch((err) => {
+                    settFeilmelding(utledFeilmelding(err, fil, locale));
                 })
                 .finally(() => settLaster(false));
         }

--- a/src/frontend/components/Filopplaster/feilmeldingOpplasting.ts
+++ b/src/frontend/components/Filopplaster/feilmeldingOpplasting.ts
@@ -1,0 +1,51 @@
+import axios from 'axios';
+
+import { teksterFeilmeldinger } from '../../tekster/filopplasting';
+import { Locale, TekstElement } from '../../typer/tekst';
+import { hentBeskjedMedEttParameter } from '../../utils/tekster';
+
+export enum FeilmeldingerFraDokument {
+    IMAGE_DIMENSIONS_TOO_SMALL = 'IMAGE_DIMENSIONS_TOO_SMALL',
+    IMAGE_TOO_LARGE = 'IMAGE_TOO_LARGE',
+}
+
+const harMappingForFeilmelding = (melding?: string): melding is FeilmeldingerFraDokument =>
+    Object.values(FeilmeldingerFraDokument).some((feilmelding) => feilmelding === melding);
+
+const REGEX_FEIL = /^CODE=(.*)$/;
+
+/**
+ * Familie-dokument returnerer feil med meldingen `CODE=IMAGE_DIMENSIONS_TOO_SMALL`
+ * Henter ut koden
+ */
+const mapTilFeilmeldingTekst = (req: unknown): TekstElement<string> | undefined => {
+    if (axios.isAxiosError(req)) {
+        const melding = req?.response?.data;
+        const matches = REGEX_FEIL.exec(melding || '');
+        if (matches?.length && matches?.length > 0) {
+            const feilmelding = matches[1];
+            if (harMappingForFeilmelding(feilmelding)) {
+                return teksterFeilmeldinger.feilmeldinger.fra_dokument[feilmelding];
+            }
+        }
+    }
+    return undefined;
+};
+
+/**
+ * Legger til detaljer om feilmeldingen hvis melding i response
+ * inneholder type som er definiert i FeilmeldingerFraDokument
+ * @param err axiosrequest som feilet
+ * @param fil som man laster opp
+ * @param locale valgt språk
+ */
+export const utledFeilmelding = (err: unknown, fil: File, locale: Locale) => {
+    const tekstElementDetaljerFeilmelding = mapTilFeilmeldingTekst(err);
+    const detaljertFeilmelding = tekstElementDetaljerFeilmelding
+        ? hentBeskjedMedEttParameter(fil.name, tekstElementDetaljerFeilmelding[locale])
+        : '';
+    return (
+        hentBeskjedMedEttParameter(fil.name, teksterFeilmeldinger.feilmeldinger.generisk[locale]) +
+        detaljertFeilmelding
+    );
+};

--- a/src/frontend/tekster/filopplasting.ts
+++ b/src/frontend/tekster/filopplasting.ts
@@ -1,3 +1,4 @@
+import { FeilmeldingerFraDokument } from '../components/Filopplaster/feilmeldingOpplasting';
 import { MAKS_FILSTØRRELSE_FORMATTERT } from '../components/Filopplaster/utils';
 import { TekstElement } from '../typer/tekst';
 
@@ -14,11 +15,15 @@ export const filopplastingTekster: FilopplastingInnhold = {
         nb: 'Krav til dokumentasjonen',
     },
 };
+
 export const teksterFeilmeldinger: {
     enFil: TekstElement<string>;
     maksstørrelse: TekstElement<string>;
     filtype: TekstElement<string>;
-    feiletOpplasting: TekstElement<string>;
+    feilmeldinger: {
+        generisk: TekstElement<string>;
+        fra_dokument: Record<FeilmeldingerFraDokument, TekstElement<string>>;
+    };
 } = {
     enFil: {
         nb: `Må laste opp en og en fil`,
@@ -29,7 +34,17 @@ export const teksterFeilmeldinger: {
     filtype: {
         nb: '"[0]" – Ugyldig filtype.',
     },
-    feiletOpplasting: {
-        nb: 'Feilet opplasting av "[0]".',
+    feilmeldinger: {
+        generisk: {
+            nb: 'Feilet opplasting av "[0]". ', // Space på slutten fordi det kommer en mer spesifik feilmelding etterpå
+        },
+        fra_dokument: {
+            IMAGE_DIMENSIONS_TOO_SMALL: {
+                nb: 'Bilde du har forsøkt å laste opp er for lite. Bilde må være større enn 400x400 piksler.',
+            },
+            IMAGE_TOO_LARGE: {
+                nb: 'Fil er for stor.',
+            },
+        },
     },
 };


### PR DESCRIPTION
… når eks bildet er for lite

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-20286

### Hvorfor er denne endringen nødvendig? ✨
Vi får noen feilkoder fra familie-dokument som er fint å mappe for å gjøre det mulig å gi en bedre feilmelding.

I tilfelle feil vises 
<img width="646" alt="Screenshot 2024-04-14 at 20 43 03" src="https://github.com/navikt/tilleggsstonader-soknad/assets/937168/6e8309c7-a2cd-4f88-8100-4dbcc44e17bd">

I tilfelle vi har mappet feilkoden vises den samme feilmeldingen men også med mer informasjon
<img width="658" alt="Screenshot 2024-04-14 at 20 41 56" src="https://github.com/navikt/tilleggsstonader-soknad/assets/937168/0514586d-6955-4dc2-b26a-7f7de3e37ce0">

