### PR TITLE
Må restte value etter at man har prøvd å lastet opp for å kunne laste…

### DIFF
--- a/src/frontend/components/Filopplaster/Filopplaster.tsx
+++ b/src/frontend/components/Filopplaster/Filopplaster.tsx
@@ -85,6 +85,10 @@ const Filopplaster: React.FC<{
                 <input
                     type="file"
                     onChange={lastOppValgteFiler}
+                    onClick={(e) => {
+                        // @ts-ignore hack for å kunne laste opp samme fila på nytt i tilfelle opplasting feiler
+                        e.target.value = null;
+                    }}
                     ref={hiddenFileInput}
                     style={{ display: 'none' }}
                 />


### PR DESCRIPTION
… opp samme fil på nytt

### Hvorfor er denne endringen nødvendig? ✨
Hvis opplasting feiler nå så kan man ikke velge den samme fila på nytt.
For å få til dette må man resette `e.target.value` https://stackoverflow.com/questions/39484895/how-to-allow-input-type-file-to-select-the-same-file-in-react-component

Det er også nevnt at man kan bruke `onInput` men det virket ikke for meg. 

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-20511