### PR TITLE
Fjerner hardkoding av Espen i beskrivelse på vedlegg

### DIFF
--- a/src/frontend/barnetilsyn/tekster/vedlegg.ts
+++ b/src/frontend/barnetilsyn/tekster/vedlegg.ts
@@ -147,7 +147,7 @@ export const typerVedleggTekster: TekstTypeVedlegg = {
             nb: 'Skriftlig uttalelse fra helsepersonell for [0]',
         },
         beskrivelse: {
-            nb: 'Legeerklæring eller annen uttalelse fra helsepersonell som beskriver Espens helsetilstand.',
+            nb: 'Legeerklæring eller annen uttalelse fra helsepersonell som beskriver helsetilstand for [0].',
         },
         krav_til_dokumentasjon: {
             nb: 'Legeerklæringen/uttalelsen fra helsepersonell må inneholde barnets navn og gjelde for perioden du søker om støtte til pass for.',

--- a/src/frontend/components/Filopplaster/VedleggFelt.tsx
+++ b/src/frontend/components/Filopplaster/VedleggFelt.tsx
@@ -6,6 +6,7 @@ import { BodyLong, Heading, VStack } from '@navikt/ds-react';
 import { ASurfaceSubtle } from '@navikt/ds-tokens/dist/tokens';
 
 import Filopplaster from './Filopplaster';
+import { usePerson } from '../../context/PersonContext';
 import { filopplastingTekster } from '../../tekster/filopplasting';
 import { Dokument, DokumentasjonFelt } from '../../typer/skjema';
 import { Vedlegg } from '../../typer/tekst';
@@ -24,11 +25,15 @@ const VedleggFelt: React.FC<{
     leggTilDokument: (vedlegg: Dokument) => void;
     slettDokument: (vedlegg: Dokument) => void;
 }> = ({ tittel, vedlegg, dokumentasjonFelt, leggTilDokument, slettDokument }) => {
+    const { person } = usePerson();
+    const barn = dokumentasjonFelt.barnId
+        ? person.barn.find((barn) => barn.ident === dokumentasjonFelt.barnId)
+        : undefined;
     return (
         <Container>
             <Heading size="small">{tittel}</Heading>
             <BodyLong>
-                <LocaleTekst tekst={vedlegg.beskrivelse} />
+                <LocaleTekst tekst={vedlegg.beskrivelse} argument0={barn?.fornavn} />
             </BodyLong>
             {vedlegg.krav_til_dokumentasjon && (
                 <LocaleReadMore


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skal ikke ha hardkodet navn i beskrivelse.
Endrer ordlyden `som beskriver Espens helsetilstand.` til `som beskriver helsetilstand for [0].` for å ikke tenke på om navnet slutter på `s` eller liknende. 

Alternativt `som beskriver [0] sin/sitt helsetilstand.`? 

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-20391

