### PR TITLE
Forslag: Flytter state som har peiling på hvilke barn som er valgte til Søknad…

### DIFF
--- a/src/frontend/barnetilsyn/steg/4-dine-barn/DineBarn.tsx
+++ b/src/frontend/barnetilsyn/steg/4-dine-barn/DineBarn.tsx
@@ -46,9 +46,9 @@ const DineBarn = () => {
         );
     };
 
-    const kanFortsette = (personbarn: string[]): boolean => {
+    const kanFortsette = (valgteBarn: string[]): boolean => {
         let feil: Valideringsfeil = {};
-        if (personbarn.length === 0) {
+        if (valgteBarn.length === 0) {
             feil = {
                 ...feil,
                 hvilkeBarn: { id: '1', melding: dineBarnTekster.hvilke_barn_feilmelding[locale] },

--- a/src/frontend/barnetilsyn/steg/4-dine-barn/DineBarn.tsx
+++ b/src/frontend/barnetilsyn/steg/4-dine-barn/DineBarn.tsx
@@ -29,23 +29,26 @@ const DineBarn = () => {
         settValideringsfeil,
     } = useSøknad();
 
-    const [personbarn, settPersonbarn] = useState<Set<string>>(valgteBarn);
+    const [personbarn, settPersonbarn] = useState<string[]>(valgteBarn);
 
     useEffect(() => {
-        if (inneholderFeil(valideringsfeil) && personbarn.size > 0) {
+        if (inneholderFeil(valideringsfeil) && personbarn.length > 0) {
             settValideringsfeil({});
         }
     }, [valideringsfeil, personbarn, settValideringsfeil]);
 
     const fjernDokumentasjonsFeltForBarnSomErFjernet = () => {
         settDokumentasjon((prevState) =>
-            prevState.filter((dokument) => !dokument.barnId || personbarn.has(dokument.barnId))
+            prevState.filter(
+                (dokument) =>
+                    !dokument.barnId || personbarn.some((ident) => dokument.barnId === ident)
+            )
         );
     };
 
-    const kanFortsette = (personbarn: Set<string>): boolean => {
+    const kanFortsette = (personbarn: string[]): boolean => {
         let feil: Valideringsfeil = {};
-        if (personbarn.size === 0) {
+        if (personbarn.length === 0) {
             feil = {
                 ...feil,
                 hvilkeBarn: { id: '1', melding: dineBarnTekster.hvilke_barn_feilmelding[locale] },
@@ -77,8 +80,8 @@ const DineBarn = () => {
                     id={valideringsfeil.hvilkeBarn?.id}
                     legend={dineBarnTekster.hvilke_barn_spm[locale]}
                     error={valideringsfeil.hvilkeBarn?.melding}
-                    value={Array.from(personbarn)}
-                    onChange={(values) => settPersonbarn(new Set(values))}
+                    value={personbarn}
+                    onChange={settPersonbarn}
                 >
                     {person.barn.map((barn) => (
                         <Checkbox key={barn.ident} value={barn.ident}>

--- a/src/frontend/barnetilsyn/steg/4-dine-barn/DineBarn.tsx
+++ b/src/frontend/barnetilsyn/steg/4-dine-barn/DineBarn.tsx
@@ -21,27 +21,27 @@ const DineBarn = () => {
     const { locale } = useSpråk();
     const { person } = usePerson();
     const {
-        valgteBarn,
-        settValgteBarn,
+        valgteBarnIdenter,
+        settValgteBarnIdenter,
         settDokumentasjon,
         hovedytelse,
         valideringsfeil,
         settValideringsfeil,
     } = useSøknad();
 
-    const [personbarn, settPersonbarn] = useState<string[]>(valgteBarn);
+    const [barnIdenter, settBarnIdenter] = useState<string[]>(valgteBarnIdenter);
 
     useEffect(() => {
-        if (inneholderFeil(valideringsfeil) && personbarn.length > 0) {
+        if (inneholderFeil(valideringsfeil) && barnIdenter.length > 0) {
             settValideringsfeil({});
         }
-    }, [valideringsfeil, personbarn, settValideringsfeil]);
+    }, [valideringsfeil, barnIdenter, settValideringsfeil]);
 
     const fjernDokumentasjonsFeltForBarnSomErFjernet = () => {
         settDokumentasjon((prevState) =>
             prevState.filter(
                 (dokument) =>
-                    !dokument.barnId || personbarn.some((ident) => dokument.barnId === ident)
+                    !dokument.barnId || barnIdenter.some((ident) => dokument.barnId === ident)
             )
         );
     };
@@ -60,13 +60,13 @@ const DineBarn = () => {
 
     const oppdaterSøknad = () => {
         fjernDokumentasjonsFeltForBarnSomErFjernet();
-        settValgteBarn(personbarn);
+        settValgteBarnIdenter(barnIdenter);
     };
 
     return (
         <Side
             stønadstype={Stønadstype.BARNETILSYN}
-            validerSteg={() => kanFortsette(personbarn)}
+            validerSteg={() => kanFortsette(barnIdenter)}
             oppdaterSøknad={oppdaterSøknad}
         >
             <Heading size="medium">
@@ -80,8 +80,8 @@ const DineBarn = () => {
                     id={valideringsfeil.hvilkeBarn?.id}
                     legend={dineBarnTekster.hvilke_barn_spm[locale]}
                     error={valideringsfeil.hvilkeBarn?.melding}
-                    value={personbarn}
-                    onChange={settPersonbarn}
+                    value={barnIdenter}
+                    onChange={settBarnIdenter}
                 >
                     {person.barn.map((barn) => (
                         <Checkbox key={barn.ident} value={barn.ident}>
@@ -89,7 +89,7 @@ const DineBarn = () => {
                         </Checkbox>
                     ))}
                 </CheckboxGroup>
-                {harValgtBarnOver9år(person.barn, personbarn) && (
+                {harValgtBarnOver9år(person.barn, barnIdenter) && (
                     <Alert variant="info">
                         <Heading size="small">
                             <LocaleTekst tekst={dineBarnTekster.alert_barn_over_9.tittel} />

--- a/src/frontend/barnetilsyn/steg/5-barnepass/Barnepass.tsx
+++ b/src/frontend/barnetilsyn/steg/5-barnepass/Barnepass.tsx
@@ -22,6 +22,7 @@ const Barnepass = () => {
     const { person } = usePerson();
     const { locale } = useSpråk();
     const {
+        valgteBarn,
         barnMedBarnepass,
         settBarnMedBarnepass,
         settDokumentasjonsbehov,
@@ -30,14 +31,12 @@ const Barnepass = () => {
     } = useSøknad();
 
     const [barnMedPass, settBarnMedPass] = useState<BarnepassIntern[]>(
-        person.barn
-            .filter((barn) => barn.skalHaBarnepass)
-            .map(
-                (barn) =>
-                    barnMedBarnepass.find((barnepass) => barnepass.ident == barn.ident) || {
-                        ident: barn.ident,
-                    }
-            )
+        Array.from(valgteBarn).map(
+            (valgtBarn) =>
+                barnMedBarnepass.find((barnepass) => barnepass.ident == valgtBarn) || {
+                    ident: valgtBarn,
+                }
+        )
     );
 
     const nullstillValideringsfeil = (key: string) => {

--- a/src/frontend/barnetilsyn/steg/5-barnepass/Barnepass.tsx
+++ b/src/frontend/barnetilsyn/steg/5-barnepass/Barnepass.tsx
@@ -31,7 +31,7 @@ const Barnepass = () => {
     } = useSøknad();
 
     const [barnMedPass, settBarnMedPass] = useState<BarnepassIntern[]>(
-        Array.from(valgteBarn).map(
+        valgteBarn.map(
             (valgtBarn) =>
                 barnMedBarnepass.find((barnepass) => barnepass.ident == valgtBarn) || {
                     ident: valgtBarn,

--- a/src/frontend/barnetilsyn/steg/5-barnepass/Barnepass.tsx
+++ b/src/frontend/barnetilsyn/steg/5-barnepass/Barnepass.tsx
@@ -22,7 +22,7 @@ const Barnepass = () => {
     const { person } = usePerson();
     const { locale } = useSpråk();
     const {
-        valgteBarn,
+        valgteBarnIdenter,
         barnMedBarnepass,
         settBarnMedBarnepass,
         settDokumentasjonsbehov,
@@ -31,10 +31,10 @@ const Barnepass = () => {
     } = useSøknad();
 
     const [barnMedPass, settBarnMedPass] = useState<BarnepassIntern[]>(
-        valgteBarn.map(
-            (valgtBarn) =>
-                barnMedBarnepass.find((barnepass) => barnepass.ident == valgtBarn) || {
-                    ident: valgtBarn,
+        valgteBarnIdenter.map(
+            (ident) =>
+                barnMedBarnepass.find((barnepass) => barnepass.ident == ident) || {
+                    ident: ident,
                 }
         )
     );

--- a/src/frontend/barnetilsyn/steg/5-barnepass/utils.ts
+++ b/src/frontend/barnetilsyn/steg/5-barnepass/utils.ts
@@ -62,7 +62,7 @@ export const finnBarn = (barn: Barn[], ident: string): Barn => {
 
 export const er9ellerEldre = (barn: Barn): boolean => barn.alder >= 9;
 
-export const harValgtBarnOver9år = (barn: Barn[], valgteBarn: Set<string>): boolean =>
-    barn.some((b) => valgteBarn.has(b.ident) && er9ellerEldre(b));
+export const harValgtBarnOver9år = (barn: Barn[], valgteBarn: string[]): boolean =>
+    barn.some((b) => valgteBarn.some((ident) => ident === b.ident) && er9ellerEldre(b));
 
 export const harBarnUnder2år = (barn: Barn[]): boolean => barn.some((b) => b.alder < 2);

--- a/src/frontend/barnetilsyn/steg/5-barnepass/utils.ts
+++ b/src/frontend/barnetilsyn/steg/5-barnepass/utils.ts
@@ -62,7 +62,7 @@ export const finnBarn = (barn: Barn[], ident: string): Barn => {
 
 export const er9ellerEldre = (barn: Barn): boolean => barn.alder >= 9;
 
-export const harValgtBarnOver9år = (barn: Barn[]): boolean =>
-    barn.some((b) => b.skalHaBarnepass && er9ellerEldre(b));
+export const harValgtBarnOver9år = (barn: Barn[], valgteBarn: Set<string>): boolean =>
+    barn.some((b) => valgteBarn.has(b.ident) && er9ellerEldre(b));
 
 export const harBarnUnder2år = (barn: Barn[]): boolean => barn.some((b) => b.alder < 2);

--- a/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
@@ -159,10 +159,7 @@ const ArbeidsrettetAktivitet: React.FC<{ aktivitet: Aktivitet | undefined }> = (
     );
 };
 
-const DineBarn: React.FC<{ person: Person; valgteBarn: Set<string> }> = ({
-    person,
-    valgteBarn,
-}) => (
+const DineBarn: React.FC<{ person: Person; valgteBarn: string[] }> = ({ person, valgteBarn }) => (
     <AccordionItem
         header={oppsummeringTekster.accordians.dine_barn.tittel}
         endreKnapp={{
@@ -174,7 +171,7 @@ const DineBarn: React.FC<{ person: Person; valgteBarn: Set<string> }> = ({
             <LocaleTekst tekst={oppsummeringTekster.accordians.dine_barn.label} />
         </Label>
         {person.barn
-            .filter((barn) => valgteBarn.has(barn.ident))
+            .filter((barn) => valgteBarn.some((ident) => ident === barn.ident))
             .map((barn) => (
                 <BodyShort key={barn.ident}>
                     {barn.visningsnavn}, født {formaterIsoDato(barn.fødselsdato)}

--- a/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
@@ -159,7 +159,10 @@ const ArbeidsrettetAktivitet: React.FC<{ aktivitet: Aktivitet | undefined }> = (
     );
 };
 
-const DineBarn: React.FC<{ person: Person }> = ({ person }) => (
+const DineBarn: React.FC<{ person: Person; valgteBarn: Set<string> }> = ({
+    person,
+    valgteBarn,
+}) => (
     <AccordionItem
         header={oppsummeringTekster.accordians.dine_barn.tittel}
         endreKnapp={{
@@ -171,7 +174,7 @@ const DineBarn: React.FC<{ person: Person }> = ({ person }) => (
             <LocaleTekst tekst={oppsummeringTekster.accordians.dine_barn.label} />
         </Label>
         {person.barn
-            .filter((barn) => barn.skalHaBarnepass)
+            .filter((barn) => valgteBarn.has(barn.ident))
             .map((barn) => (
                 <BodyShort key={barn.ident}>
                     {barn.visningsnavn}, født {formaterIsoDato(barn.fødselsdato)}
@@ -262,7 +265,7 @@ const Vedlegg: React.FC<{ dokumentasjon: DokumentasjonFelt[] }> = ({ dokumentasj
 );
 
 const Oppsummering = () => {
-    const { hovedytelse, aktivitet, barnMedBarnepass, dokumentasjon } = useSøknad();
+    const { hovedytelse, aktivitet, valgteBarn, barnMedBarnepass, dokumentasjon } = useSøknad();
     const { person } = usePerson();
     const [harBekreftet, settHarBekreftet] = useState(false);
     const [feil, settFeil] = useState<string>('');
@@ -289,7 +292,7 @@ const Oppsummering = () => {
                 <OmDeg person={person} />
                 <DinSituasjon hovedytelse={hovedytelse} />
                 <ArbeidsrettetAktivitet aktivitet={aktivitet} />
-                <DineBarn person={person} />
+                <DineBarn person={person} valgteBarn={valgteBarn} />
                 <PassAvBarn person={person} barnMedBarnepass={barnMedBarnepass} />
                 <Vedlegg dokumentasjon={dokumentasjon} />
             </Accordion>

--- a/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
@@ -159,7 +159,10 @@ const ArbeidsrettetAktivitet: React.FC<{ aktivitet: Aktivitet | undefined }> = (
     );
 };
 
-const DineBarn: React.FC<{ person: Person; valgteBarn: string[] }> = ({ person, valgteBarn }) => (
+const DineBarn: React.FC<{ person: Person; valgteBarnIdenter: string[] }> = ({
+    person,
+    valgteBarnIdenter,
+}) => (
     <AccordionItem
         header={oppsummeringTekster.accordians.dine_barn.tittel}
         endreKnapp={{
@@ -171,7 +174,7 @@ const DineBarn: React.FC<{ person: Person; valgteBarn: string[] }> = ({ person, 
             <LocaleTekst tekst={oppsummeringTekster.accordians.dine_barn.label} />
         </Label>
         {person.barn
-            .filter((barn) => valgteBarn.some((ident) => ident === barn.ident))
+            .filter((barn) => valgteBarnIdenter.some((ident) => ident === barn.ident))
             .map((barn) => (
                 <BodyShort key={barn.ident}>
                     {barn.visningsnavn}, født {formaterIsoDato(barn.fødselsdato)}
@@ -262,7 +265,8 @@ const Vedlegg: React.FC<{ dokumentasjon: DokumentasjonFelt[] }> = ({ dokumentasj
 );
 
 const Oppsummering = () => {
-    const { hovedytelse, aktivitet, valgteBarn, barnMedBarnepass, dokumentasjon } = useSøknad();
+    const { hovedytelse, aktivitet, valgteBarnIdenter, barnMedBarnepass, dokumentasjon } =
+        useSøknad();
     const { person } = usePerson();
     const [harBekreftet, settHarBekreftet] = useState(false);
     const [feil, settFeil] = useState<string>('');
@@ -289,7 +293,7 @@ const Oppsummering = () => {
                 <OmDeg person={person} />
                 <DinSituasjon hovedytelse={hovedytelse} />
                 <ArbeidsrettetAktivitet aktivitet={aktivitet} />
-                <DineBarn person={person} valgteBarn={valgteBarn} />
+                <DineBarn person={person} valgteBarnIdenter={valgteBarnIdenter} />
                 <PassAvBarn person={person} barnMedBarnepass={barnMedBarnepass} />
                 <Vedlegg dokumentasjon={dokumentasjon} />
             </Accordion>

--- a/src/frontend/context/SøknadContext.tsx
+++ b/src/frontend/context/SøknadContext.tsx
@@ -16,7 +16,7 @@ const [SøknadProvider, useSøknad] = createUseContext(() => {
 
     const [aktivitet, settAktivitet] = useState<Aktivitet>();
 
-    const [valgteBarn, settValgteBarn] = useState<Set<string>>(new Set());
+    const [valgteBarn, settValgteBarn] = useState<string[]>([]);
     const [barnMedBarnepass, settBarnMedBarnepass] = useState<Barnepass[]>([]);
 
     const [dokumentasjonsbehov, settDokumentasjonsbehov] = useState<Dokumentasjonsbehov[]>([]);
@@ -28,6 +28,7 @@ const [SøknadProvider, useSøknad] = createUseContext(() => {
     const resetSøknad = () => {
         settHovedytelse(undefined);
         settAktivitet(undefined);
+        settValgteBarn([]);
         settBarnMedBarnepass([]);
         settDokumentasjonsbehov([]);
         settDokumentasjon([]);

--- a/src/frontend/context/SøknadContext.tsx
+++ b/src/frontend/context/SøknadContext.tsx
@@ -16,6 +16,7 @@ const [SøknadProvider, useSøknad] = createUseContext(() => {
 
     const [aktivitet, settAktivitet] = useState<Aktivitet>();
 
+    const [valgteBarn, settValgteBarn] = useState<Set<string>>(new Set());
     const [barnMedBarnepass, settBarnMedBarnepass] = useState<Barnepass[]>([]);
 
     const [dokumentasjonsbehov, settDokumentasjonsbehov] = useState<Dokumentasjonsbehov[]>([]);
@@ -50,6 +51,8 @@ const [SøknadProvider, useSøknad] = createUseContext(() => {
         valideringsfeil,
         settValideringsfeil,
         resetSøknad,
+        valgteBarn,
+        settValgteBarn,
     };
 });
 

--- a/src/frontend/context/SøknadContext.tsx
+++ b/src/frontend/context/SøknadContext.tsx
@@ -16,7 +16,7 @@ const [SøknadProvider, useSøknad] = createUseContext(() => {
 
     const [aktivitet, settAktivitet] = useState<Aktivitet>();
 
-    const [valgteBarn, settValgteBarn] = useState<string[]>([]);
+    const [valgteBarnIdenter, settValgteBarnIdenter] = useState<string[]>([]);
     const [barnMedBarnepass, settBarnMedBarnepass] = useState<Barnepass[]>([]);
 
     const [dokumentasjonsbehov, settDokumentasjonsbehov] = useState<Dokumentasjonsbehov[]>([]);
@@ -28,7 +28,7 @@ const [SøknadProvider, useSøknad] = createUseContext(() => {
     const resetSøknad = () => {
         settHovedytelse(undefined);
         settAktivitet(undefined);
-        settValgteBarn([]);
+        settValgteBarnIdenter([]);
         settBarnMedBarnepass([]);
         settDokumentasjonsbehov([]);
         settDokumentasjon([]);
@@ -52,8 +52,8 @@ const [SøknadProvider, useSøknad] = createUseContext(() => {
         valideringsfeil,
         settValideringsfeil,
         resetSøknad,
-        valgteBarn,
-        settValgteBarn,
+        valgteBarnIdenter,
+        settValgteBarnIdenter,
     };
 });
 

--- a/src/frontend/typer/barn.ts
+++ b/src/frontend/typer/barn.ts
@@ -7,7 +7,6 @@ export interface Barn {
     fødselsdato: string;
     fornavn: string;
     visningsnavn: string;
-    skalHaBarnepass: boolean;
 }
 
 export interface Barnepass {


### PR DESCRIPTION
…Context for å enklere kunne resette søknad og mellomlagre

### Hvorfor er denne endringen nødvendig? ✨
Tenker det er fint hvis vi ikke blander "søknadsstate" og state på en person. 
Dette vil gjøre det enklere når vi tar i bruk flere stønader.

Gjør også dette for å enklere kunne nullstille en hel søknad. Føler også det er nødvendig til mellomlagring. 