### PR TITLE
Legger til accept på Filopplaster for å ikke kunne velge andre filer …

### DIFF
--- a/src/frontend/barnetilsyn/tekster/vedlegg.ts
+++ b/src/frontend/barnetilsyn/tekster/vedlegg.ts
@@ -31,7 +31,7 @@ const formatKvalitetAccordian: VedleggInnhold['accordians']['format_kvalitet'] =
         nb: 'Format og kvalitet på vedlegg',
     },
     innhold: {
-        nb: 'Du kan laste opp vedlegg med filformat .png, .pdf eller .jpeg. Det er viktig at bildet har god nok oppløsning/kvalitet til at vi kan lese det. ',
+        nb: 'Du kan laste opp vedlegg med filformat .png, .pdf .jpg eller .jpeg. Det er viktig at bildet har god nok oppløsning/kvalitet til at vi kan lese det. ',
     },
 };
 

--- a/src/frontend/components/Filopplaster/Filopplaster.tsx
+++ b/src/frontend/components/Filopplaster/Filopplaster.tsx
@@ -8,7 +8,7 @@ import { ABlue50, ABlue500 } from '@navikt/ds-tokens/dist/tokens';
 
 import { utledFeilmelding } from './feilmeldingOpplasting';
 import FilVisning from './Fil';
-import { MAX_FILSTØRRELSE, TILLATE_FILTYPER } from './utils';
+import { MAX_FILSTØRRELSE, TILLATE_FILENDELSER, TILLATE_FILTYPER } from './utils';
 import { lastOppVedlegg } from '../../api/api';
 import { useSpråk } from '../../context/SpråkContext';
 import { filopplastingTekster, teksterFeilmeldinger } from '../../tekster/filopplasting';
@@ -88,6 +88,7 @@ const Filopplaster: React.FC<{
                     }}
                     ref={hiddenFileInput}
                     style={{ display: 'none' }}
+                    accept={TILLATE_FILENDELSER}
                 />
             </Container>
         </>

--- a/src/frontend/components/Filopplaster/utils.ts
+++ b/src/frontend/components/Filopplaster/utils.ts
@@ -14,9 +14,25 @@ export const MAX_FILSTØRRELSE = 1024 * 1024 * 10; // 10mb
 export const MAKS_FILSTØRRELSE_FORMATTERT = formaterFilstørrelse(MAX_FILSTØRRELSE);
 
 enum Filtyper {
-    PDF = 'application/pdf',
-    PNG = 'image/png',
-    JPG = 'image/jpg',
-    JPEG = 'image/jpeg',
+    PDF = 'PDF',
+    PNG = 'PNG',
+    JPG = 'JPG',
+    JPEG = 'JPEG',
 }
-export const TILLATE_FILTYPER: string[] = [Filtyper.PNG, Filtyper.PDF, Filtyper.JPG, Filtyper.JPEG];
+
+export const filtypeTilMime: Record<Filtyper, string> = {
+    PDF: 'application/pdf',
+    PNG: 'image/png',
+    JPG: 'image/jpg',
+    JPEG: 'image/jpeg',
+};
+
+export const filtypeTilFilendelse: Record<Filtyper, string> = {
+    PDF: '.pdf',
+    PNG: '.png',
+    JPG: '.jpg',
+    JPEG: '.jpeg',
+};
+export const TILLATE_FILTYPER: string[] = Object.values(filtypeTilMime);
+
+export const TILLATE_FILENDELSER: string = Object.values(filtypeTilFilendelse).join(',');


### PR DESCRIPTION
…enn de vi aksepterer

### Hvorfor er denne endringen nødvendig? ✨
For å prøve å unngå at man laster opp heic-filer

<img width="410" alt="image" src="https://github.com/navikt/tilleggsstonader-soknad/assets/937168/8400ba29-1572-4183-bdaf-86526f7c69d7">
