### PR TITLE
Trenger role=alert på feilmelding for å leses opp når den populeres.

### DIFF
--- a/src/frontend/components/Filopplaster/Filopplaster.tsx
+++ b/src/frontend/components/Filopplaster/Filopplaster.tsx
@@ -33,6 +33,15 @@ const Filopplaster: React.FC<{
     const [feilmelding, settFeilmelding] = useState<string>();
     const [laster, settLaster] = useState<boolean>(false);
 
+    /**
+     * Hack for å få skjermlesere til å trigge feilmelding etter at annet blir lest opp for å trigge opplesing av feilmelding
+     */
+    const settFeilmeldingMedDelay = (feilmelding: string) => {
+        setTimeout(() => {
+            settFeilmelding(feilmelding);
+        }, 1500);
+    };
+
     const lastOppValgteFiler = (event: React.ChangeEvent<HTMLInputElement>) => {
         const filer = event.target.files;
         if (filer?.length !== 1) {
@@ -42,11 +51,11 @@ const Filopplaster: React.FC<{
         const fil = filer[0];
 
         if (fil.size > MAX_FILSTØRRELSE) {
-            settFeilmelding(
+            settFeilmeldingMedDelay(
                 hentBeskjedMedEttParameter(fil.name, teksterFeilmeldinger.maksstørrelse[locale])
             );
         } else if (!TILLATE_FILTYPER.includes(fil.type)) {
-            settFeilmelding(
+            settFeilmeldingMedDelay(
                 hentBeskjedMedEttParameter(fil.name, teksterFeilmeldinger.filtype[locale])
             );
         } else {

--- a/src/frontend/components/Filopplaster/Filopplaster.tsx
+++ b/src/frontend/components/Filopplaster/Filopplaster.tsx
@@ -55,9 +55,7 @@ const Filopplaster: React.FC<{
             lastOppVedlegg(fil)
                 .then((id) => leggTilDokument({ id: id, navn: fil.name }))
                 .catch((err) => {
-                    setTimeout(() => {
-                        settFeilmelding(utledFeilmelding(err, fil, locale));
-                    }, 500);
+                    settFeilmelding(utledFeilmelding(err, fil, locale));
                 })
                 .finally(() => settLaster(false));
         }
@@ -73,9 +71,6 @@ const Filopplaster: React.FC<{
                 />
             ))}
             <Container>
-                <div hidden={!feilmelding} role="alert">
-                    <Alert variant="error">{feilmelding}</Alert>
-                </div>
                 <Button
                     onClick={() => hiddenFileInput.current?.click()}
                     icon={<UploadIcon />}
@@ -93,6 +88,12 @@ const Filopplaster: React.FC<{
                     ref={hiddenFileInput}
                     style={{ display: 'none' }}
                 />
+
+                {feilmelding && (
+                    <div role="alert" aria-live="assertive">
+                        <Alert variant="error">{feilmelding}</Alert>
+                    </div>
+                )}
             </Container>
         </>
     );

--- a/src/frontend/components/Filopplaster/Filopplaster.tsx
+++ b/src/frontend/components/Filopplaster/Filopplaster.tsx
@@ -55,7 +55,9 @@ const Filopplaster: React.FC<{
             lastOppVedlegg(fil)
                 .then((id) => leggTilDokument({ id: id, navn: fil.name }))
                 .catch((err) => {
-                    settFeilmelding(utledFeilmelding(err, fil, locale));
+                    setTimeout(() => {
+                        settFeilmelding(utledFeilmelding(err, fil, locale));
+                    }, 500);
                 })
                 .finally(() => settLaster(false));
         }
@@ -71,7 +73,9 @@ const Filopplaster: React.FC<{
                 />
             ))}
             <Container>
-                {feilmelding && <Alert variant="error">{feilmelding}</Alert>}
+                <div hidden={!feilmelding} role="alert">
+                    <Alert variant="error">{feilmelding}</Alert>
+                </div>
                 <Button
                     onClick={() => hiddenFileInput.current?.click()}
                     icon={<UploadIcon />}


### PR DESCRIPTION
Setter timeout på vising av feilmelding, ellers blir ikke feilmeldingen opplest på Mac pga at lukking av fil-velgeren tar all fokus av noen grunn

### Hvorfor er denne endringen nødvendig? ✨
Idag leses ikke feilmeldingen opp av skjermlesere i Mac. Når vinduet lukkes for å velge filer så leses saker om å fokus på knappen opp. Av den grunnen settes en timeout som var anbefaling fra UU-test.

Dette burde nog kunne fjernes når vi tar i bruk https://aksel.nav.no/komponenter/core/fileupload

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-20400