### PR TITLE
♻️ Endrer tekster for RadioGroup til å være record likt LocaleCheckboxGr…

### DIFF
--- a/src/frontend/barnetilsyn/tekster/aktivitet.ts
+++ b/src/frontend/barnetilsyn/tekster/aktivitet.ts
@@ -1,4 +1,4 @@
-import { jaNeiAlternativer } from '../../tekster/felles';
+import { JaNeiTilTekst } from '../../tekster/felles';
 import { AnnenAktivitetType } from '../../typer/aktivitet';
 import { JaNei } from '../../typer/søknad';
 import { InlineLenke, LesMer, Radiogruppe, TekstElement } from '../../typer/tekst';
@@ -61,13 +61,13 @@ export const aktivitetTekster: AktivitetInnhold = {
         header: {
             nb: 'Mottar du lønn gjennom et tiltak?',
         },
-        alternativer: jaNeiAlternativer,
+        alternativer: JaNeiTilTekst,
     },
     radio_utdanning: {
         header: {
             nb: 'Deltar du på eller skal du begynne på et arbeidsrettet tiltak eller en utredning?',
         },
-        alternativer: jaNeiAlternativer,
+        alternativer: JaNeiTilTekst,
     },
     radio_utdanning_lesmer: {
         header: { nb: 'Hva betyr tiltak og utredning?' },
@@ -89,7 +89,7 @@ export const aktivitetTekster: AktivitetInnhold = {
         header: {
             nb: 'Vil du fortsatt søke nå?',
         },
-        alternativer: jaNeiAlternativer,
+        alternativer: JaNeiTilTekst,
     },
     radio_annet_lesmer: {
         header: { nb: 'Søke lengre tilbake enn 3 måneder?' },
@@ -107,23 +107,6 @@ export const aktivitetTekster: AktivitetInnhold = {
     },
     radio_annet: {
         header: { nb: 'Hvilken annen type arbeidsrettet aktivitet har du?' },
-        alternativer: [
-            {
-                value: AnnenAktivitetType.TILTAK,
-                label: AktivitetTypeTilTekst.TILTAK,
-            },
-            {
-                value: AnnenAktivitetType.UTDANNING,
-                label: AktivitetTypeTilTekst.UTDANNING,
-            },
-            {
-                value: AnnenAktivitetType.ARBEIDSSØKER,
-                label: AktivitetTypeTilTekst.ARBEIDSSØKER,
-            },
-            {
-                value: AnnenAktivitetType.INGEN_AKTIVITET,
-                label: AktivitetTypeTilTekst.INGEN_AKTIVITET,
-            },
-        ],
+        alternativer: AktivitetTypeTilTekst,
     },
 };

--- a/src/frontend/barnetilsyn/tekster/barnepass.ts
+++ b/src/frontend/barnetilsyn/tekster/barnepass.ts
@@ -1,3 +1,4 @@
+import { JaNeiTilTekst } from '../../tekster/felles';
 import { PassType, ÅrsakBarnepass } from '../../typer/barn';
 import { JaNei } from '../../typer/søknad';
 import { Radiogruppe, TekstElement } from '../../typer/tekst';
@@ -54,16 +55,7 @@ export const barnepassTekster: BarnepassInnhold = {
     },
     hvem_passer_radio: {
         header: { nb: 'Hvem skal passe [0]?' },
-        alternativer: [
-            {
-                value: PassType.BARNEHAGE_SFO_AKS,
-                label: PassTypeTilTekst.BARNEHAGE_SFO_AKS,
-            },
-            {
-                value: PassType.PRIVAT,
-                label: PassTypeTilTekst.PRIVAT,
-            },
-        ],
+        alternativer: PassTypeTilTekst,
     },
     hvem_passer_andre_alert: {
         tittel: {
@@ -78,16 +70,7 @@ export const barnepassTekster: BarnepassInnhold = {
     },
     startet_femte_radio: {
         header: { nb: 'Har [0] startet i 5.-klasse når tiltaket ditt starter?' },
-        alternativer: [
-            {
-                value: 'JA',
-                label: { nb: 'Ja' },
-            },
-            {
-                value: 'NEI',
-                label: { nb: 'Nei' },
-            },
-        ],
+        alternativer: JaNeiTilTekst,
     },
     startet_femte_feilmelding: {
         nb: 'Du må svare på om [0] har begynt i 5. klasse.',
@@ -107,20 +90,7 @@ export const barnepassTekster: BarnepassInnhold = {
         header: {
             nb: 'Hva er årsaken til at [0] trenger pass etter at han har begynt i 5.-klasse?',
         },
-        alternativer: [
-            {
-                value: ÅrsakBarnepass.TRENGER_MER_PASS_ENN_JEVNALDRENDE,
-                label: ÅrsakEkstraPassTilTekst.TRENGER_MER_PASS_ENN_JEVNALDRENDE,
-            },
-            {
-                value: ÅrsakBarnepass.MYE_BORTE_ELLER_UVANLIG_ARBEIDSTID,
-                label: ÅrsakEkstraPassTilTekst.MYE_BORTE_ELLER_UVANLIG_ARBEIDSTID,
-            },
-            {
-                value: ÅrsakBarnepass.INGEN_AV_DISSE,
-                label: ÅrsakEkstraPassTilTekst.INGEN_AV_DISSE,
-            },
-        ],
+        alternativer: ÅrsakEkstraPassTilTekst,
     },
     årsak_ekstra_pass_feilmelding: {
         nb: 'Du må velge en årsak til at [0] trenger pass etter 5. klasse.',

--- a/src/frontend/barnetilsyn/tekster/opphold.ts
+++ b/src/frontend/barnetilsyn/tekster/opphold.ts
@@ -1,4 +1,4 @@
-import { jaNeiAlternativer } from '../../tekster/felles';
+import { JaNeiTilTekst } from '../../tekster/felles';
 import { JaNei, MottarPengestøtteTyper, ÅrsakOppholdUtenforNorge } from '../../typer/søknad';
 import { CheckboxGruppe, InlineLenke, Radiogruppe, TekstElement } from '../../typer/tekst';
 
@@ -76,7 +76,7 @@ export const jobberIAnnetLandInnhold: JobberIAnnetLandInnhold = {
         header: {
             nb: 'Jobber du i et annet land enn Norge?',
         },
-        alternativer: jaNeiAlternativer,
+        alternativer: JaNeiTilTekst,
     },
     feilmnelding_jobber_annet_land: {
         nb: 'Du må svare på om du jobber i et annet land enn Norge.',
@@ -248,7 +248,7 @@ export const oppholdUtenforNorgeInnhold: OppholdUtenforNorgeInnhold = {
         beskrivelse: {
             nb: 'Opphold under 5 uker trenger du ikke opplyse om.',
         },
-        alternativer: jaNeiAlternativer,
+        alternativer: JaNeiTilTekst,
     },
     feilmelding_radioSiste12mnd: {
         nb: 'Du må svare på om du har oppholdt deg utenfor Norge.',
@@ -262,7 +262,7 @@ export const oppholdUtenforNorgeInnhold: OppholdUtenforNorgeInnhold = {
         beskrivelse: {
             nb: 'Opphold under 5 uker trenger du ikke opplyse om.',
         },
-        alternativer: jaNeiAlternativer,
+        alternativer: JaNeiTilTekst,
     },
     feilmelding_radioNeste12mnd: {
         nb: 'Du må ta stilling til om du planlegger opphold utenfor Norge de neste 12 månedene.',

--- a/src/frontend/components/Teksthåndtering/LocaleRadioGroup.tsx
+++ b/src/frontend/components/Teksthåndtering/LocaleRadioGroup.tsx
@@ -4,17 +4,17 @@ import { Radio, RadioGroup, RadioGroupProps as AkselRadioGroupProps } from '@nav
 
 import { useSpråk } from '../../context/SpråkContext';
 import { EnumFelt } from '../../typer/skjema';
-import { Radiogruppe } from '../../typer/tekst';
+import { Radiogruppe, TekstElement } from '../../typer/tekst';
 import { hentBeskjedMedEttParameter } from '../../utils/tekster';
 
-interface RadioGroupProps<T>
+interface RadioGroupProps<T extends string>
     extends Omit<AkselRadioGroupProps, 'legend' | 'description' | 'children'> {
     tekst: Radiogruppe<T>;
     onChange: (enumFelt: EnumFelt<T>) => void;
     children?: React.ReactNode;
     argument0?: string;
 }
-function LocaleRadioGroup<T>({
+function LocaleRadioGroup<T extends string>({
     children,
     tekst,
     argument0,
@@ -28,12 +28,14 @@ function LocaleRadioGroup<T>({
         : tekst.header[locale];
 
     const onChangeEnumVerdi = (value: T) => {
-        const svarTekst = tekst.alternativer.find((alternativ) => alternativ.value === value);
+        const svarTekst = tekst.alternativer[value];
         onChange({
             label: legend,
             verdi: value,
-            alternativer: tekst.alternativer.map((alternativ) => alternativ.label[locale]),
-            svarTekst: svarTekst?.label[locale] || '',
+            alternativer: Object.values(tekst.alternativer).map(
+                (alternativ) => (alternativ as TekstElement<string>)[locale]
+            ),
+            svarTekst: svarTekst[locale] || '',
         });
     };
 
@@ -50,9 +52,9 @@ function LocaleRadioGroup<T>({
             {...props}
         >
             {children}
-            {tekst.alternativer.map((alternativ, indeks) => (
-                <Radio value={alternativ.value} key={indeks}>
-                    {alternativ.label[locale]}
+            {Object.entries(tekst.alternativer).map(([value, tekst]) => (
+                <Radio value={value} key={value}>
+                    {(tekst as TekstElement<string>)[locale]}
                 </Radio>
             ))}
         </RadioGroup>

--- a/src/frontend/tekster/felles.ts
+++ b/src/frontend/tekster/felles.ts
@@ -65,14 +65,3 @@ export const JaNeiTilTekst: Record<JaNei, TekstElement<string>> = {
         nb: 'Nei',
     },
 };
-
-export const jaNeiAlternativer: { value: JaNei; label: TekstElement<string> }[] = [
-    {
-        value: 'JA',
-        label: JaNeiTilTekst.JA,
-    },
-    {
-        value: 'NEI',
-        label: JaNeiTilTekst.NEI,
-    },
-];

--- a/src/frontend/typer/tekst.ts
+++ b/src/frontend/typer/tekst.ts
@@ -28,12 +28,6 @@ export type Radiogruppe<T extends string> = {
     alternativer: Alternativer<T>;
 };
 
-export type Selectgruppe = {
-    header: TekstElement<string>;
-    beskrivelse?: TekstElement<string>;
-    alternativer: Alternativer<string>;
-};
-
 export type CheckboxGruppe<T extends string> = {
     header: TekstElement<string>;
     beskrivelse?: TekstElement<string>;

--- a/src/frontend/typer/tekst.ts
+++ b/src/frontend/typer/tekst.ts
@@ -22,22 +22,22 @@ export type Punktliste = {
     innhold: TekstElement<string[]>;
 };
 
-export type Radiogruppe<T> = {
+export type Radiogruppe<T extends string> = {
     header: TekstElement<string>;
     beskrivelse?: TekstElement<string>;
-    alternativer: { label: TekstElement<string>; value: T }[];
+    alternativer: Alternativer<T>;
 };
 
 export type Selectgruppe = {
     header: TekstElement<string>;
     beskrivelse?: TekstElement<string>;
-    alternativer: { label: TekstElement<string>; value: string }[];
+    alternativer: Alternativer<string>;
 };
 
 export type CheckboxGruppe<T extends string> = {
     header: TekstElement<string>;
     beskrivelse?: TekstElement<string>;
-    alternativer: Record<T, TekstElement<string>>;
+    alternativer: Alternativer<T>;
 };
 
 export type Vedlegg = {
@@ -46,3 +46,5 @@ export type Vedlegg = {
     beskrivelse: TekstElement<string>;
     krav_til_dokumentasjon?: TekstElement<string | string[]>;
 };
+
+export type Alternativer<T extends string> = Record<T, TekstElement<string>>;


### PR DESCRIPTION
…oup for å ikke trenge typeTilTekst + liste med alternativer

### Hvorfor er denne endringen nødvendig? ✨
LocaleCheckboxGroup forholder seg til en `Record<T, TekstElement<string>>` mens LocaleRadioGroup forholder seg til en liste `{ label: TekstElement<string>; value: T }[]`

Har endret sånn at begge forholder seg til en Record. Det gjør at de blir mer like og man trenger ikke å definiere både en 
`AktivitetTypeTilTekst` og en liste med alternativer, der man kanskje glømmer å ta med et alternativ

Bygger videre på 
* https://github.com/navikt/tilleggsstonader-soknad/pull/302