### PR TITLE
Ferdigstille aktiviteter 4

### DIFF
--- a/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
+++ b/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
-import { Alert, Heading, VStack } from '@navikt/ds-react';
+import { Alert, Heading, List, VStack } from '@navikt/ds-react';
 
 import { AnnenArbeidsrettetAktivitet } from './AnnenArbeidsrettetAktivitet';
 import ArbeidsrettedeAktiviteter from './ArbeidsrettedeAktiviteter';
@@ -15,6 +15,7 @@ import { feilAnnenAktivitet, feilLønnetAktivitet, feilValgtAktivitet } from './
 import { hentArbeidsrettedeAktiviteter } from '../../../api/api';
 import { PellePanel } from '../../../components/PellePanel/PellePanel';
 import Side from '../../../components/Side';
+import LocaleInlineLenke from '../../../components/Teksthåndtering/LocaleInlineLenke';
 import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
 import LocaleTekstAvsnitt from '../../../components/Teksthåndtering/LocaleTekstAvsnitt';
 import { UnderspørsmålContainer } from '../../../components/UnderspørsmålContainer';
@@ -214,12 +215,23 @@ const Aktivitet = () => {
                     </VStack>
                 </UnderspørsmålContainer>
             )}
-            {utdanning?.verdi === 'NEI' && (
+            {annenAktivitet?.verdi === AnnenAktivitetType.INGEN_AKTIVITET && (
                 <Alert variant={'info'}>
                     <Heading size="small">
-                        <LocaleTekst tekst={aktivitetTekster.feil_utdanning_infoalert_title} />
+                        <LocaleTekst tekst={aktivitetTekster.ingen_aktivitet_infoalert_title} />
                     </Heading>
-                    <LocaleTekstAvsnitt tekst={aktivitetTekster.feil_utdanning_infoalert_innhold} />
+                    <LocaleTekstAvsnitt
+                        tekst={aktivitetTekster.ingen_aktivitet_infoalert_innhold.del1}
+                    />
+                    <List>
+                        {aktivitetTekster.ingen_aktivitet_infoalert_innhold.del2_lenker.map(
+                            (lenke, indeks) => (
+                                <List.Item key={indeks}>
+                                    <LocaleInlineLenke tekst={lenke} />
+                                </List.Item>
+                            )
+                        )}
+                    </List>
                 </Alert>
             )}
         </Side>

--- a/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
+++ b/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
@@ -32,9 +32,6 @@ import { aktivitetTekster } from '../../tekster/aktivitet';
 const Aktivitet = () => {
     const { locale } = useSpråk();
     const { aktivitet, settAktivitet, valideringsfeil, settValideringsfeil } = useSøknad();
-    const [utdanning, settUtdanning] = useState<EnumFelt<JaNei> | undefined>(
-        aktivitet ? aktivitet.utdanning : undefined
-    );
     const [valgteAktiviteter, settValgteAktiviteter] = useState<
         EnumFlereValgFelt<string> | undefined
     >(aktivitet ? aktivitet.aktiviteter : undefined);
@@ -60,14 +57,11 @@ const Aktivitet = () => {
     }, []);
 
     const oppdaterAktivitetISøknad = () => {
-        if (utdanning !== undefined) {
-            settAktivitet({
-                utdanning: utdanning,
-                aktiviteter: valgteAktiviteter,
-                annenAktivitet: annenAktivitet,
-                lønnetAktivitet: lønnetAktivitet,
-            });
-        }
+        settAktivitet({
+            aktiviteter: valgteAktiviteter,
+            annenAktivitet: annenAktivitet,
+            lønnetAktivitet: lønnetAktivitet,
+        });
     };
 
     const nullstillLønnetAktivitet = (
@@ -143,12 +137,6 @@ const Aktivitet = () => {
     const kanFortsette = (): boolean => {
         let feil: Valideringsfeil = {};
         const verdierValgteAktiviteter = valgteAktiviteter?.verdier ?? [];
-        if (utdanning === undefined) {
-            feil = {
-                ...feil,
-                barnepassPgaUtdanning: { id: '1', melding: 'Du må velge et alternativ' },
-            };
-        }
         if (skalViseArbeidsrettedeAktiviteter && verdierValgteAktiviteter.length === 0) {
             feil = feilValgtAktivitet(feil, locale);
         }

--- a/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
+++ b/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
@@ -15,8 +15,6 @@ import { feilAnnenAktivitet, feilLønnetAktivitet, feilValgtAktivitet } from './
 import { hentArbeidsrettedeAktiviteter } from '../../../api/api';
 import { PellePanel } from '../../../components/PellePanel/PellePanel';
 import Side from '../../../components/Side';
-import LocaleRadioGroup from '../../../components/Teksthåndtering/LocaleRadioGroup';
-import { LocaleReadMore } from '../../../components/Teksthåndtering/LocaleReadMore';
 import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
 import LocaleTekstAvsnitt from '../../../components/Teksthåndtering/LocaleTekstAvsnitt';
 import { UnderspørsmålContainer } from '../../../components/UnderspørsmålContainer';
@@ -216,21 +214,6 @@ const Aktivitet = () => {
                     </VStack>
                 </UnderspørsmålContainer>
             )}
-            <LocaleRadioGroup
-                id={valideringsfeil.barnepassPgaUtdanning?.id}
-                tekst={aktivitetTekster.radio_utdanning}
-                value={utdanning?.verdi || ''}
-                onChange={(verdi) => {
-                    settUtdanning(verdi);
-                    settValideringsfeil((prevState) => ({
-                        ...prevState,
-                        barnepassPgaUtdanning: undefined,
-                    }));
-                }}
-                error={valideringsfeil.barnepassPgaUtdanning?.melding}
-            >
-                <LocaleReadMore tekst={aktivitetTekster.radio_utdanning_lesmer} />
-            </LocaleRadioGroup>
             {utdanning?.verdi === 'NEI' && (
                 <Alert variant={'info'}>
                     <Heading size="small">

--- a/src/frontend/barnetilsyn/tekster/aktivitet.ts
+++ b/src/frontend/barnetilsyn/tekster/aktivitet.ts
@@ -14,8 +14,8 @@ interface AktivitetInnhold {
     radio_annet_lesmer: LesMer<InlineLenke>;
     radio_annet_feilmelding: TekstElement<string>;
     tittel: TekstElement<string>;
-    feil_utdanning_infoalert_title: TekstElement<string>;
-    feil_utdanning_infoalert_innhold: TekstElement<string[]>;
+    ingen_aktivitet_infoalert_title: TekstElement<string>;
+    ingen_aktivitet_infoalert_innhold: IngenAktivitet;
     lønnet_tiltak_infoalert_innhold: TekstElement<string[]>;
     radio_lønnet_tiltak_feilmelding: TekstElement<string>;
     radio_fortsatt_søke: Radiogruppe<JaNei>;
@@ -34,6 +34,10 @@ interface HvilkenAktivitet {
         del2_lenker: TekstElement<InlineLenke>[];
         del3: TekstElement<InlineLenke>;
     };
+}
+interface IngenAktivitet {
+    del1: TekstElement<string[]>;
+    del2_lenker: TekstElement<InlineLenke>[];
 }
 
 export const AktivitetTypeTilTekst: Record<AnnenAktivitetType, TekstElement<string>> = {
@@ -157,11 +161,38 @@ export const aktivitetTekster: AktivitetInnhold = {
             ],
         },
     },
-    feil_utdanning_infoalert_title: { nb: 'Ingen arbeidsrettet aktivitet?' },
-    feil_utdanning_infoalert_innhold: {
-        nb: [
-            'Du kan fortsatt søke, men det kan hende du får avslag.',
-            'Merk deg at medisinsk behandling ikke gir rett til støtte for pass av barn.',
+    ingen_aktivitet_infoalert_title: { nb: 'Ingen arbeidsrettet aktivitet?' },
+    ingen_aktivitet_infoalert_innhold: {
+        del1: {
+            nb: [
+                'Du kan fortsatt søke, men du kan få avslag.',
+                'Merk deg at medisinsk behandling ikke gir rett til støtte for pass av barn.',
+                'Er du enslig forsørger/gjenlevende og i arbeid, er det andre søknader du skal fylle ut: ',
+            ],
+        },
+        del2_lenker: [
+            {
+                nb: [
+                    'for ',
+                    {
+                        tekst: 'enslig mor/far',
+                        url: 'https://www.nav.no/barnetilsyn-enslig',
+                        variant: 'neutral',
+                    },
+                    ' (åpnes i ny fane)',
+                ],
+            },
+            {
+                nb: [
+                    'for ',
+                    {
+                        tekst: 'gjenlevende',
+                        url: 'https://www.nav.no/barnetilsyn-gjenlevende',
+                        variant: 'neutral',
+                    },
+                    ' (åpnes i ny fane)',
+                ],
+            },
         ],
     },
     radio_fortsatt_søke: {

--- a/src/frontend/barnetilsyn/tekster/aktivitet.ts
+++ b/src/frontend/barnetilsyn/tekster/aktivitet.ts
@@ -9,8 +9,6 @@ interface AktivitetInnhold {
     checkbox_velge_aktivitet_feilmelding: TekstElement<string>;
     radio_annet: Radiogruppe<AnnenAktivitetType>;
     radio_annet_uten_registeraktivitet: Radiogruppe<AnnenAktivitetType>;
-    radio_utdanning: Radiogruppe<JaNei>;
-    radio_utdanning_lesmer: LesMer<string[]>;
     radio_annet_lesmer: LesMer<InlineLenke>;
     radio_annet_feilmelding: TekstElement<string>;
     tittel: TekstElement<string>;
@@ -145,21 +143,6 @@ export const aktivitetTekster: AktivitetInnhold = {
     },
     radio_lønnet_tiltak_feilmelding: {
         nb: 'Du må svare på om du mottar lønn.',
-    },
-    radio_utdanning: {
-        header: {
-            nb: 'Deltar du på eller skal du begynne på et arbeidsrettet tiltak eller en utredning?',
-        },
-        alternativer: JaNeiTilTekst,
-    },
-    radio_utdanning_lesmer: {
-        header: { nb: 'Hva betyr tiltak og utredning?' },
-        innhold: {
-            nb: [
-                'Tiltak avtales mellom deg og din veileder og skal hjelpe deg med å komme inn i eller tilbake til arbeidslivet. Et tiltak kan for eksempel være utdanning, kurs eller arbeidstrening.',
-                'Arbeidsrettet utredning er en prosess der dine ferdigheter og muligheter til å utføre arbeid blir vurdert og kartlagt.',
-            ],
-        },
     },
     ingen_aktivitet_infoalert_title: { nb: 'Ingen arbeidsrettet aktivitet?' },
     ingen_aktivitet_infoalert_innhold: {

--- a/src/frontend/typer/søknad.ts
+++ b/src/frontend/typer/søknad.ts
@@ -30,7 +30,6 @@ export interface OppholdUtenforNorge {
 }
 
 export interface Aktivitet {
-    utdanning: EnumFelt<JaNei>;
     aktiviteter: EnumFlereValgFelt<string> | undefined;
     annenAktivitet: EnumFelt<AnnenAktivitetType> | undefined;
     lønnetAktivitet: EnumFelt<JaNei> | undefined;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

- Fjerner Utdanning som egen variabel i lokal state på Aktiviteter siden. 
- Fjerner ubrukte tekster
- Fjerner Radio-Gruppe som ikke lenger skal inngå i løsningen
- Oppdaterer valideringsregler til å speile endringene over
- Oppdaterer visning av "info-alert" til å vises når bruker huker av for "INGEN_AKTIVITET". Se bilder under:

###FØR

![Skjermbilde 2024-04-23 kl  13 20 39](https://github.com/navikt/tilleggsstonader-soknad/assets/28704275/eba34665-0d9b-4a8e-b88b-a9b277403464)


### ETTER

![Skjermbilde 2024-04-23 kl  13 21 04](https://github.com/navikt/tilleggsstonader-soknad/assets/28704275/5411fb49-3834-4c2b-998b-3a31e6e3991f)

