### PR TITLE
✨ Amplitude oppsett - logging av skjemasteg og navigering

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "webpack-merge": "^5.10.0"
   },
   "dependencies": {
+    "@amplitude/analytics-browser": "^2.6.2",
     "@navikt/aksel-icons": "5.18.1",
     "@navikt/ds-css": "^5.18.1",
     "@navikt/ds-react": "^5.18.1",

--- a/src/frontend/api/amplitude.ts
+++ b/src/frontend/api/amplitude.ts
@@ -1,6 +1,6 @@
 import { init, track } from '@amplitude/analytics-browser';
 
-import { skjemanavnTilId, stønadstypeTilSkjemanavn } from '../typer/skjemanavn';
+import { Skjemanavn, skjemanavnTilId, stønadstypeTilSkjemanavn } from '../typer/skjemanavn';
 import { Stønadstype } from '../typer/stønadstyper';
 
 const APP_NAVN = 'tilleggsstonader-soknad';
@@ -67,5 +67,15 @@ export const logNavigereEvent = (
         skjemaId: skjemanavnTilId[skjemanavn],
         destinasjon: destinasjon,
         lenketekst: lenketekst,
+    });
+};
+
+export const loggAlertVist = (variant: string, tekst: string) => {
+    track('alert vist', {
+        app: APP_NAVN,
+        skjemanavn: Skjemanavn.tilsyn_barn,
+        skjemaId: skjemanavnTilId[Skjemanavn.tilsyn_barn],
+        variant: variant,
+        tekst: tekst,
     });
 };

--- a/src/frontend/api/amplitude.ts
+++ b/src/frontend/api/amplitude.ts
@@ -1,0 +1,11 @@
+import { init } from '@amplitude/analytics-browser';
+
+export const initAmplitude = () => {
+    init('default', '', {
+        useBatch: true,
+        serverUrl: 'https://amplitude.nav.no/collect-auto',
+        ingestionMetadata: {
+            sourceName: window.location.toString(),
+        },
+    });
+};

--- a/src/frontend/api/amplitude.ts
+++ b/src/frontend/api/amplitude.ts
@@ -76,3 +76,10 @@ export const loggAlertVist = (variant: string, tekst: string) => {
         tekst: tekst,
     });
 };
+
+export const loggBesøkBarnetilsyn = (url: string, sidetittel: string) => {
+    loggEventMedSkjema('besøk', Stønadstype.BARNETILSYN, {
+        url: url,
+        sidetittel: sidetittel,
+    });
+};

--- a/src/frontend/api/amplitude.ts
+++ b/src/frontend/api/amplitude.ts
@@ -1,6 +1,6 @@
 import { init, track } from '@amplitude/analytics-browser';
 
-import { Skjemanavn, skjemanavnTilId, stønadstypeTilSkjemanavn } from '../typer/skjemanavn';
+import { skjemanavnTilId, stønadstypeTilSkjemanavn } from '../typer/skjemanavn';
 import { Stønadstype } from '../typer/stønadstyper';
 
 const APP_NAVN = 'tilleggsstonader-soknad';
@@ -56,10 +56,11 @@ export const loggSkjemaFullført = (stønadstype: Stønadstype) => {
 };
 
 export const logNavigereEvent = (
-    skjemanavn: Skjemanavn,
+    stønadstype: Stønadstype,
     destinasjon: string,
     lenketekst: string
 ) => {
+    const skjemanavn = stønadstypeTilSkjemanavn[stønadstype];
     track('navigere', {
         app: APP_NAVN,
         skjemanavn: skjemanavn,

--- a/src/frontend/api/amplitude.ts
+++ b/src/frontend/api/amplitude.ts
@@ -1,6 +1,6 @@
 import { init, track } from '@amplitude/analytics-browser';
 
-import { skjemanavnTilId, stønadstypeTilSkjemanavn } from '../typer/skjemanavn';
+import { Skjemanavn, skjemanavnTilId, stønadstypeTilSkjemanavn } from '../typer/skjemanavn';
 import { Stønadstype } from '../typer/stønadstyper';
 
 const APP_NAVN = 'tilleggsstonader-soknad';
@@ -52,5 +52,19 @@ export const loggSkjemaFullført = (stønadstype: Stønadstype) => {
         app: APP_NAVN,
         skjemanavn: skjemanavn,
         skjemaId: skjemanavnTilId[skjemanavn],
+    });
+};
+
+export const logNavigereEvent = (
+    skjemanavn: Skjemanavn,
+    destinasjon: string,
+    lenketekst: string
+) => {
+    track('navigere', {
+        app: APP_NAVN,
+        skjemanavn: skjemanavn,
+        skjemaId: skjemanavnTilId[skjemanavn],
+        destinasjon: destinasjon,
+        lenketekst: lenketekst,
     });
 };

--- a/src/frontend/api/amplitude.ts
+++ b/src/frontend/api/amplitude.ts
@@ -1,9 +1,18 @@
 import { init, track } from '@amplitude/analytics-browser';
 
-import { Skjemanavn, skjemanavnTilId, stønadstypeTilSkjemanavn } from '../typer/skjemanavn';
+import { stønadstypeTilSkjemaId, stønadstypeTilSkjemanavn } from '../typer/skjemanavn';
 import { Stønadstype } from '../typer/stønadstyper';
 
 const APP_NAVN = 'tilleggsstonader-soknad';
+
+type eventType =
+    | 'skjema startet'
+    | 'skjema steg fullført'
+    | 'skjema innsending feilet'
+    | 'skjema fullført'
+    | 'navigere'
+    | 'alert vist'
+    | 'besøk';
 
 export const initAmplitude = () => {
     init('default', '', {
@@ -16,43 +25,38 @@ export const initAmplitude = () => {
     });
 };
 
+export const loggEventMedSkjema = (
+    event: eventType,
+    stønadstype: Stønadstype,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    event_properties?: any
+) => {
+    track(event, {
+        app: APP_NAVN,
+        skjemanavn: stønadstypeTilSkjemanavn[stønadstype],
+        skjemaId: stønadstypeTilSkjemaId[stønadstype],
+        ...event_properties,
+    });
+};
+
 export const loggSkjemaStartet = (stønadstype: Stønadstype) => {
-    const skjemanavn = stønadstypeTilSkjemanavn[stønadstype];
     track('skjema startet', {
         app: APP_NAVN,
-        skjemanavn: skjemanavn,
-        skjemaId: skjemanavnTilId[skjemanavn],
+        skjemanavn: stønadstypeTilSkjemanavn[stønadstype],
+        skjemaId: stønadstypeTilSkjemaId[stønadstype],
     });
 };
 
 export const loggSkjemaStegFullført = (stønadstype: Stønadstype, steg: string) => {
-    const skjemanavn = stønadstypeTilSkjemanavn[stønadstype];
-    track('skjema steg fullført', {
-        app: APP_NAVN,
-        skjemanavn: skjemanavn,
-        skjemaId: skjemanavnTilId[skjemanavn],
-        steg: steg,
-    });
+    loggEventMedSkjema('skjema steg fullført', stønadstype, { steg: steg });
 };
 
 export const loggSkjemaInnsendtFeilet = (stønadstype: Stønadstype) => {
-    const skjemanavn = stønadstypeTilSkjemanavn[stønadstype];
-
-    track('skjema innsending feilet', {
-        app: APP_NAVN,
-        skjemanavn: skjemanavn,
-        skjemaId: skjemanavnTilId[skjemanavn],
-    });
+    loggEventMedSkjema('skjema innsending feilet', stønadstype);
 };
 
 export const loggSkjemaFullført = (stønadstype: Stønadstype) => {
-    const skjemanavn = stønadstypeTilSkjemanavn[stønadstype];
-
-    track('skjema fullført', {
-        app: APP_NAVN,
-        skjemanavn: skjemanavn,
-        skjemaId: skjemanavnTilId[skjemanavn],
-    });
+    loggEventMedSkjema('skjema fullført', stønadstype);
 };
 
 export const logNavigereEvent = (
@@ -60,21 +64,14 @@ export const logNavigereEvent = (
     destinasjon: string,
     lenketekst: string
 ) => {
-    const skjemanavn = stønadstypeTilSkjemanavn[stønadstype];
-    track('navigere', {
-        app: APP_NAVN,
-        skjemanavn: skjemanavn,
-        skjemaId: skjemanavnTilId[skjemanavn],
+    loggEventMedSkjema('navigere', stønadstype, {
         destinasjon: destinasjon,
         lenketekst: lenketekst,
     });
 };
 
 export const loggAlertVist = (variant: string, tekst: string) => {
-    track('alert vist', {
-        app: APP_NAVN,
-        skjemanavn: Skjemanavn.tilsyn_barn,
-        skjemaId: skjemanavnTilId[Skjemanavn.tilsyn_barn],
+    loggEventMedSkjema('alert vist', Stønadstype.BARNETILSYN, {
         variant: variant,
         tekst: tekst,
     });

--- a/src/frontend/api/amplitude.ts
+++ b/src/frontend/api/amplitude.ts
@@ -8,7 +8,7 @@ const APP_NAVN = 'tilleggsstonader-soknad';
 export const initAmplitude = () => {
     init('default', '', {
         useBatch: true,
-
+        defaultTracking: false,
         serverUrl: 'https://amplitude.nav.no/collect-auto',
         ingestionMetadata: {
             sourceName: window.location.toString(),

--- a/src/frontend/api/amplitude.ts
+++ b/src/frontend/api/amplitude.ts
@@ -1,11 +1,56 @@
-import { init } from '@amplitude/analytics-browser';
+import { init, track } from '@amplitude/analytics-browser';
+
+import { skjemanavnTilId, stønadstypeTilSkjemanavn } from '../typer/skjemanavn';
+import { Stønadstype } from '../typer/stønadstyper';
+
+const APP_NAVN = 'tilleggsstonader-soknad';
 
 export const initAmplitude = () => {
     init('default', '', {
         useBatch: true,
+
         serverUrl: 'https://amplitude.nav.no/collect-auto',
         ingestionMetadata: {
             sourceName: window.location.toString(),
         },
+    });
+};
+
+export const loggSkjemaStartet = (stønadstype: Stønadstype) => {
+    const skjemanavn = stønadstypeTilSkjemanavn[stønadstype];
+    track('skjema startet', {
+        app: APP_NAVN,
+        skjemanavn: skjemanavn,
+        skjemaId: skjemanavnTilId[skjemanavn],
+    });
+};
+
+export const loggSkjemaStegFullført = (stønadstype: Stønadstype, steg: string) => {
+    const skjemanavn = stønadstypeTilSkjemanavn[stønadstype];
+    track('skjema steg fullført', {
+        app: APP_NAVN,
+        skjemanavn: skjemanavn,
+        skjemaId: skjemanavnTilId[skjemanavn],
+        steg: steg,
+    });
+};
+
+export const loggSkjemaInnsendtFeilet = (stønadstype: Stønadstype) => {
+    const skjemanavn = stønadstypeTilSkjemanavn[stønadstype];
+
+    track('skjema innsending feilet', {
+        app: APP_NAVN,
+        skjemanavn: skjemanavn,
+        skjemaId: skjemanavnTilId[skjemanavn],
+    });
+};
+
+export const loggSkjemaFullført = (stønadstype: Stønadstype) => {
+    const skjemanavn = stønadstypeTilSkjemanavn[stønadstype];
+
+    track('skjema fullført', {
+        app: APP_NAVN,
+        skjemanavn: skjemanavn,
+        skjemaId: skjemanavnTilId[skjemanavn],
     });
 };

--- a/src/frontend/barnetilsyn/Forside.tsx
+++ b/src/frontend/barnetilsyn/Forside.tsx
@@ -46,7 +46,7 @@ const Forside: React.FC = () => {
 
     useEffect(() => {
         const route = RoutesBarnetilsyn[0];
-        loggBesøkBarnetilsyn(route.route, route.label);
+        loggBesøkBarnetilsyn(route.path, route.label);
     }, []);
 
     const startSøknad = () => {

--- a/src/frontend/barnetilsyn/Forside.tsx
+++ b/src/frontend/barnetilsyn/Forside.tsx
@@ -16,6 +16,7 @@ import {
 
 import { RoutesBarnetilsyn } from './routing/routesBarnetilsyn';
 import { forsideTekster } from './tekster/forside';
+import { loggSkjemaStartet } from '../api/amplitude';
 import { PellePanel } from '../components/PellePanel/PellePanel';
 import { Container } from '../components/Side';
 import LocaleInlineLenke from '../components/Teksthåndtering/LocaleInlineLenke';
@@ -25,6 +26,7 @@ import LocaleTekstAvsnitt from '../components/Teksthåndtering/LocaleTekstAvsnit
 import { usePerson } from '../context/PersonContext';
 import { useSøknad } from '../context/SøknadContext';
 import { fellesTekster } from '../tekster/felles';
+import { Stønadstype } from '../typer/stønadstyper';
 import { erSnartNyttSkoleår } from '../utils/dato';
 import { hentNesteRoute } from '../utils/routes';
 
@@ -44,6 +46,7 @@ const Forside: React.FC = () => {
 
     const startSøknad = () => {
         if (harBekreftet) {
+            loggSkjemaStartet(Stønadstype.BARNETILSYN);
             const nesteRoute = hentNesteRoute(RoutesBarnetilsyn, location.pathname);
             navigate(nesteRoute.path);
         } else {

--- a/src/frontend/barnetilsyn/Forside.tsx
+++ b/src/frontend/barnetilsyn/Forside.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { useLocation, useNavigate } from 'react-router';
 import { styled } from 'styled-components';
@@ -16,7 +16,7 @@ import {
 
 import { RoutesBarnetilsyn } from './routing/routesBarnetilsyn';
 import { forsideTekster } from './tekster/forside';
-import { loggSkjemaStartet } from '../api/amplitude';
+import { loggBesøkBarnetilsyn, loggSkjemaStartet } from '../api/amplitude';
 import { PellePanel } from '../components/PellePanel/PellePanel';
 import { Container } from '../components/Side';
 import LocaleInlineLenke from '../components/Teksthåndtering/LocaleInlineLenke';
@@ -43,6 +43,11 @@ const Forside: React.FC = () => {
     const { person } = usePerson();
 
     const [skalViseFeilmelding, settSkalViseFeilmelding] = useState(false);
+
+    useEffect(() => {
+        const route = RoutesBarnetilsyn[0];
+        loggBesøkBarnetilsyn(route.route, route.label);
+    }, []);
 
     const startSøknad = () => {
         if (harBekreftet) {

--- a/src/frontend/components/Filopplaster/Filopplaster.tsx
+++ b/src/frontend/components/Filopplaster/Filopplaster.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -9,11 +9,13 @@ import { ABlue50, ABlue500 } from '@navikt/ds-tokens/dist/tokens';
 import { utledFeilmelding } from './feilmeldingOpplasting';
 import FilVisning from './Fil';
 import { MAX_FILSTØRRELSE, TILLATE_FILENDELSER, TILLATE_FILTYPER } from './utils';
+import { loggAlertVist } from '../../api/amplitude';
 import { lastOppVedlegg } from '../../api/api';
 import { useSpråk } from '../../context/SpråkContext';
 import { filopplastingTekster, teksterFeilmeldinger } from '../../tekster/filopplasting';
 import { Dokument, DokumentasjonFelt } from '../../typer/skjema';
 import { hentBeskjedMedEttParameter } from '../../utils/tekster';
+import { harVerdi } from '../../utils/typer';
 import LocaleTekst from '../Teksthåndtering/LocaleTekst';
 
 const Container = styled(VStack).attrs({ gap: '2', align: 'center' })`
@@ -69,6 +71,12 @@ const Filopplaster: React.FC<{
                 .finally(() => settLaster(false));
         }
     };
+
+    useEffect(() => {
+        if (harVerdi(feilmelding)) {
+            loggAlertVist('error', feilmelding!);
+        }
+    }, [feilmelding]);
 
     return (
         <>

--- a/src/frontend/components/Filopplaster/Filopplaster.tsx
+++ b/src/frontend/components/Filopplaster/Filopplaster.tsx
@@ -74,7 +74,7 @@ const Filopplaster: React.FC<{
 
     useEffect(() => {
         if (harVerdi(feilmelding)) {
-            loggAlertVist('error', feilmelding!);
+            loggAlertVist('error', feilmelding);
         }
     }, [feilmelding]);
 

--- a/src/frontend/components/Side.tsx
+++ b/src/frontend/components/Side.tsx
@@ -79,7 +79,7 @@ const Side: React.FC<Props> = ({ stønadstype, children, validerSteg, oppdaterS�
     const aktivtSteg: IRoute | undefined = routes[aktivtStegIndex];
 
     useEffect(() => {
-        loggBesøkBarnetilsyn(aktivtSteg.route, aktivtSteg.label);
+        loggBesøkBarnetilsyn(aktivtSteg.path, aktivtSteg.label);
     }, [aktivtSteg]);
 
     const navigerTilNesteSide = () => {

--- a/src/frontend/components/Side.tsx
+++ b/src/frontend/components/Side.tsx
@@ -9,6 +9,7 @@ import { ABreakpointMd } from '@navikt/ds-tokens/dist/tokens';
 import { StegIndikator } from './StegIndikator';
 import LocaleTekst from './Teksthåndtering/LocaleTekst';
 import {
+    loggBesøkBarnetilsyn,
     loggSkjemaFullført,
     loggSkjemaInnsendtFeilet,
     loggSkjemaStegFullført,
@@ -76,6 +77,10 @@ const Side: React.FC<Props> = ({ stønadstype, children, validerSteg, oppdaterS�
     const nåværendePath = location.pathname;
     const aktivtStegIndex = routes.findIndex((steg) => steg.path === nåværendePath);
     const aktivtSteg: IRoute | undefined = routes[aktivtStegIndex];
+
+    useEffect(() => {
+        loggBesøkBarnetilsyn(aktivtSteg.route, aktivtSteg.label);
+    }, [aktivtSteg]);
 
     const navigerTilNesteSide = () => {
         if (validerSteg && !validerSteg()) {

--- a/src/frontend/components/Side.tsx
+++ b/src/frontend/components/Side.tsx
@@ -8,6 +8,11 @@ import { ABreakpointMd } from '@navikt/ds-tokens/dist/tokens';
 
 import { StegIndikator } from './StegIndikator';
 import LocaleTekst from './Teksthåndtering/LocaleTekst';
+import {
+    loggSkjemaFullført,
+    loggSkjemaInnsendtFeilet,
+    loggSkjemaStegFullført,
+} from '../api/amplitude';
 import { sendInnSøknad } from '../api/api';
 import { ERouteBarnetilsyn } from '../barnetilsyn/routing/routesBarnetilsyn';
 import { useSpråk } from '../context/SpråkContext';
@@ -78,6 +83,7 @@ const Side: React.FC<Props> = ({ stønadstype, children, validerSteg, oppdaterS�
         }
 
         oppdaterSøknad && oppdaterSøknad();
+        loggSkjemaStegFullført(stønadstype, aktivtSteg.label);
 
         const nesteRoute = hentNesteRoute(routes, nåværendePath);
         navigate(nesteRoute.path);
@@ -108,10 +114,14 @@ const Side: React.FC<Props> = ({ stønadstype, children, validerSteg, oppdaterS�
         })
             .then((res) => {
                 settInnsentTidspunkt(res.mottattTidspunkt);
+                loggSkjemaFullført(stønadstype);
                 navigate(nesteRoute.path);
             })
             // TODO håndtering av 401?
-            .catch(() => settSendInnFeil(true))
+            .catch(() => {
+                settSendInnFeil(true);
+                loggSkjemaInnsendtFeilet(stønadstype);
+            })
             .finally(() => settSenderInn(false));
     };
 

--- a/src/frontend/components/Teksthåndtering/LocaleInlineLenke.tsx
+++ b/src/frontend/components/Teksthåndtering/LocaleInlineLenke.tsx
@@ -2,7 +2,7 @@ import { Link } from '@navikt/ds-react';
 
 import { logNavigereEvent } from '../../api/amplitude';
 import { useSpråk } from '../../context/SpråkContext';
-import { Skjemanavn } from '../../typer/skjemanavn';
+import { Stønadstype } from '../../typer/stønadstyper';
 import { InlineLenke, TekstElement } from '../../typer/tekst';
 
 const LocaleInlineLenke: React.FC<{ tekst: TekstElement<InlineLenke> }> = ({ tekst }) => {
@@ -22,7 +22,7 @@ const LocaleInlineLenke: React.FC<{ tekst: TekstElement<InlineLenke> }> = ({ tek
                         target="_blank"
                         onClick={() =>
                             logNavigereEvent(
-                                Skjemanavn.tilsyn_barn,
+                                Stønadstype.BARNETILSYN,
                                 tekstElement.url,
                                 tekstElement.tekst
                             )

--- a/src/frontend/components/Teksthåndtering/LocaleInlineLenke.tsx
+++ b/src/frontend/components/Teksthåndtering/LocaleInlineLenke.tsx
@@ -1,6 +1,8 @@
 import { Link } from '@navikt/ds-react';
 
+import { logNavigereEvent } from '../../api/amplitude';
 import { useSpråk } from '../../context/SpråkContext';
+import { Skjemanavn } from '../../typer/skjemanavn';
 import { InlineLenke, TekstElement } from '../../typer/tekst';
 
 const LocaleInlineLenke: React.FC<{ tekst: TekstElement<InlineLenke> }> = ({ tekst }) => {
@@ -18,6 +20,13 @@ const LocaleInlineLenke: React.FC<{ tekst: TekstElement<InlineLenke> }> = ({ tek
                         key={indeks}
                         variant={tekstElement.variant}
                         target="_blank"
+                        onClick={() =>
+                            logNavigereEvent(
+                                Skjemanavn.tilsyn_barn,
+                                tekstElement.url,
+                                tekstElement.tekst
+                            )
+                        }
                     >
                         {tekstElement.tekst}
                     </Link>

--- a/src/frontend/index.tsx
+++ b/src/frontend/index.tsx
@@ -4,6 +4,7 @@ import { createRoot } from 'react-dom/client';
 import '@navikt/ds-css';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 
+import { initAmplitude } from './api/amplitude';
 import { autentiseringsInterceptor } from './api/autentisering';
 import { initSentry } from './api/Sentry';
 import BarnetilsynApp from './barnetilsyn/BarnetilsynApp';
@@ -20,6 +21,9 @@ const root = createRoot(rootElement!);
 
 const AppRoutes = () => {
     const { harLastetPerson, feilmelding } = usePerson();
+
+    initAmplitude();
+
     if (feilmelding) {
         return (
             <BrowserRouter basename={process.env.PUBLIC_URL}>

--- a/src/frontend/index.tsx
+++ b/src/frontend/index.tsx
@@ -19,10 +19,10 @@ autentiseringsInterceptor();
 const rootElement = document.getElementById('app');
 const root = createRoot(rootElement!);
 
+initAmplitude();
+
 const AppRoutes = () => {
     const { harLastetPerson, feilmelding } = usePerson();
-
-    initAmplitude();
 
     if (feilmelding) {
         return (

--- a/src/frontend/typer/skjemanavn.ts
+++ b/src/frontend/typer/skjemanavn.ts
@@ -1,0 +1,13 @@
+import { Stønadstype } from './stønadstyper';
+
+export enum Skjemanavn {
+    tilsyn_barn = 'Tilsyn barn',
+}
+
+export const skjemanavnTilId: Record<Skjemanavn, string> = {
+    [Skjemanavn.tilsyn_barn]: 'NAV 11-12.15',
+};
+
+export const stønadstypeTilSkjemanavn: Record<Stønadstype, Skjemanavn> = {
+    [Stønadstype.BARNETILSYN]: Skjemanavn.tilsyn_barn,
+};

--- a/src/frontend/typer/skjemanavn.ts
+++ b/src/frontend/typer/skjemanavn.ts
@@ -1,13 +1,9 @@
 import { Stønadstype } from './stønadstyper';
 
-export enum Skjemanavn {
-    tilsyn_barn = 'Tilsyn barn',
-}
-
-export const skjemanavnTilId: Record<Skjemanavn, string> = {
-    [Skjemanavn.tilsyn_barn]: 'NAV 11-12.15',
+export const stønadstypeTilSkjemaId: Record<Stønadstype, string> = {
+    [Stønadstype.BARNETILSYN]: 'NAV 11-12.15',
 };
 
-export const stønadstypeTilSkjemanavn: Record<Stønadstype, Skjemanavn> = {
-    [Stønadstype.BARNETILSYN]: Skjemanavn.tilsyn_barn,
+export const stønadstypeTilSkjemanavn: Record<Stønadstype, string> = {
+    [Stønadstype.BARNETILSYN]: 'Pass av barn',
 };

--- a/src/frontend/utils/typer.ts
+++ b/src/frontend/utils/typer.ts
@@ -2,7 +2,8 @@ export function manglerVerdi<T>(verdi: T | undefined | null) {
     return verdi === undefined || verdi === null;
 }
 
-export const harVerdi = (str: string | undefined | null): boolean => !!str && str.trim() !== '';
+export const harVerdi = (str: string | undefined | null): str is string =>
+    !!str && str.trim() !== '';
 
 export function valuerOrThrow<T>(
     verdi: T | undefined | null,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,65 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
+"@amplitude/analytics-browser@^2.6.2":
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-browser/-/analytics-browser-2.6.2.tgz#580ad73a334d06a50c72fca713e8ee89e8ffba2f"
+  integrity sha512-NcYOnzVln/YdWeIBf8H1KpoNyaFW1zjDSVMXktxP7L7yZpGZIY3XcZVC2eax/bcEzrxe3bj77P2TAs7zsTa1Vg==
+  dependencies:
+    "@amplitude/analytics-client-common" "^2.1.3"
+    "@amplitude/analytics-core" "^2.2.4"
+    "@amplitude/analytics-types" "^2.5.0"
+    "@amplitude/plugin-page-view-tracking-browser" "^2.2.6"
+    "@amplitude/plugin-web-attribution-browser" "^2.1.7"
+    tslib "^2.4.1"
+
+"@amplitude/analytics-client-common@^2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-client-common/-/analytics-client-common-2.1.3.tgz#de761b170d4626c37e498e591afafa09aef51b18"
+  integrity sha512-GMg7qCFKeOBep9QouW8m00qqO+4AX3IGJdC6EL9oJaWnlntQzstDtHDZosesyuuUXEuvX57iiFIR+SDghb3LfQ==
+  dependencies:
+    "@amplitude/analytics-connector" "^1.4.8"
+    "@amplitude/analytics-core" "^2.2.4"
+    "@amplitude/analytics-types" "^2.5.0"
+    tslib "^2.4.1"
+
+"@amplitude/analytics-connector@^1.4.8":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-connector/-/analytics-connector-1.5.0.tgz#89a78b8c6463abe4de1d621db4af6c62f0d62b0a"
+  integrity sha512-T8mOYzB9RRxckzhL0NTHwdge9xuFxXEOplC8B1Y3UX3NHa3BLh7DlBUZlCOwQgMc2nxDfnSweDL5S3bhC+W90g==
+
+"@amplitude/analytics-core@^2.2.4":
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-core/-/analytics-core-2.2.4.tgz#e0c12161f502215c1f1c90bf0c6f0a31ad65e582"
+  integrity sha512-EySCSz3Sm6gcLRbg7PgVgKqqxPN+08OHJm/Jy5H3R1eIqI3owzoSLxlKecQ7d14rEiUxJ4W6102GsOhpU/WXbA==
+  dependencies:
+    "@amplitude/analytics-types" "^2.5.0"
+    tslib "^2.4.1"
+
+"@amplitude/analytics-types@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-types/-/analytics-types-2.5.0.tgz#d0d1ed66474b268909ccd89a06909e99f466bc14"
+  integrity sha512-aY69WxUvVlaCU+9geShjTsAYdUTvegEXH9i4WK/97kNbNLl4/7qUuIPe4hNireDeKLuQA9SA3H7TKynuNomDxw==
+
+"@amplitude/plugin-page-view-tracking-browser@^2.2.6":
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/@amplitude/plugin-page-view-tracking-browser/-/plugin-page-view-tracking-browser-2.2.6.tgz#08e5d46fa0b88d2f3e546d6e32d98b36d782fc7c"
+  integrity sha512-Vv6gDWI1bEfAKgHzwumVuwa6dZKuMh9tJZPdwA2PAYqV46v1J0L3vmGIODy/F967NgCb+GDBGEiggeEYZRelYg==
+  dependencies:
+    "@amplitude/analytics-client-common" "^2.1.3"
+    "@amplitude/analytics-types" "^2.5.0"
+    tslib "^2.4.1"
+
+"@amplitude/plugin-web-attribution-browser@^2.1.7":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@amplitude/plugin-web-attribution-browser/-/plugin-web-attribution-browser-2.1.7.tgz#b2c1d7cb65fe784ad6b355c2001eadc7de91451c"
+  integrity sha512-Fg3b/rVpdBbNKct9op5kKmOX1wLKGq1sxJDm/S+uRNGegv8xXc1h825lZyARX75XUu0Xfn1+AnDrSmtiPnxsIA==
+  dependencies:
+    "@amplitude/analytics-client-common" "^2.1.3"
+    "@amplitude/analytics-core" "^2.2.4"
+    "@amplitude/analytics-types" "^2.5.0"
+    tslib "^2.4.1"
+
 "@ampproject/remapping@^2.2.0":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.1.tgz#99e8e11851128b8702cd57c33684f1d0f260b630"
@@ -5816,7 +5875,7 @@ tsconfig-paths@^3.15.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^2.0.3, tslib@^2.5.0, tslib@^2.6.2:
+tslib@^2.0.3, tslib@^2.4.1, tslib@^2.5.0, tslib@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Statistikk på stønad

Har satt opp kobling mot fellesprosjekt på Amplitude. Dette skal brukes for alle eksterne applikasjoner, og ved bruk av fellesprosjekt er det ønskelig at man føler taksonomien som er laget for events. Alle events lagt til er fra denne og inkluderer de påkrevde feltene + et par ekstra som jeg tenkte var fine å ha (her kan man legge til så mange man vil). 

Har tatt i bruk stønadstype fremfor skjemanavn i koden fordi jeg tenker det er noe flere har et forhold til. Har også variert litt mellom om det tilpasses for flere søknader eller ikke. Hvis det var enkelt fordi man har stønadstypen gjorde jeg det, men om man måtte sjekke på url så ble det droppet for å kunne vurdere når vi vet hvordan neste søknad ser ut. 

Foreløpig har jeg kun lagt inn logging av: 
- Skjema generelt: Skjema startet, skjema fullførst, innsending feilet og steg fullført
   - Har satt definasjonen av "skjema startet" som når man trykker på "start søknad" 
- Navigering - brukt ved trykk på eksterne lenker (bruker går ut av vår søknad)
- Feilmeldinger i filopplaster

Plan videre: 
- Besøk: alle sidebesøk i appen