### PR TITLE
Utvider seksjonen for "Aktivitet" på oppsummerings-siden

### DIFF
--- a/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
@@ -129,7 +129,7 @@ const ArbeidsrettetAktivitet: React.FC<{ aktivitet: Aktivitet | undefined }> = (
         aktivitet.aktiviteter &&
         verdiFelterTilTekstElement(aktivitet.aktiviteter.verdier);
 
-    const aktivitetLabel = aktivitet?.aktiviteter?.label;
+    const aktiviteterLabel = aktivitet?.aktiviteter?.label;
     const annenAktivitetLabel = aktivitet?.annenAktivitet?.label;
     const lønnetAktivitetLabel = aktivitet?.lønnetAktivitet?.label;
 
@@ -144,7 +144,7 @@ const ArbeidsrettetAktivitet: React.FC<{ aktivitet: Aktivitet | undefined }> = (
             {aktiviteterSomTekstfelt && (
                 <LocalePunktliste
                     innhold={aktiviteterSomTekstfelt}
-                    tittel={{ nb: aktivitetLabel || '' }}
+                    tittel={{ nb: aktiviteterLabel || '' }}
                 />
             )}
             <Label>

--- a/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
@@ -86,7 +86,7 @@ const OmDeg: React.FC<{ person: Person }> = ({ person }) => (
         <FlexDiv>
             <div>
                 <Label>
-                    <LocaleTekst tekst={oppsummeringTekster.accordians.om_deg.adresse_label} />
+                    <LocaleTekst tekst={oppsummeringTekster.accordians.om_deg.navn_label} />
                 </Label>
                 <BodyShort>{person.visningsnavn}</BodyShort>
             </div>

--- a/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
@@ -30,7 +30,7 @@ import { Barn, Barnepass } from '../../../typer/barn';
 import { Person } from '../../../typer/person';
 import { DokumentasjonFelt } from '../../../typer/skjema';
 import { Stønadstype } from '../../../typer/stønadstyper';
-import { Hovedytelse } from '../../../typer/søknad';
+import { Aktivitet, Hovedytelse } from '../../../typer/søknad';
 import { TekstElement } from '../../../typer/tekst';
 import { formaterIsoDato } from '../../../utils/formatering';
 import { verdiFelterTilTekstElement } from '../../../utils/tekster';
@@ -123,20 +123,41 @@ const DinSituasjon: React.FC<{ hovedytelse: Hovedytelse | undefined }> = ({ hove
     );
 };
 
-const AktivitetUtdanning: React.FC = () => (
-    <AccordionItem
-        header={oppsummeringTekster.accordians.aktivitet_utdanning.tittel}
-        endreKnapp={{
-            route: RouteTilPath.AKTIVITET,
-            tekst: oppsummeringTekster.accordians.aktivitet_utdanning.endre_button,
-        }}
-    >
-        {/*TODO: Legg inn tekster for aktivitet når vi får på plass radioknapper.*/}
-        <BodyShort>
-            Her skal det komme oppsummering som er avhengig av hovedytelse og valgt aktivitet.
-        </BodyShort>
-    </AccordionItem>
-);
+const ArbeidsrettetAktivitet: React.FC<{ aktivitet: Aktivitet | undefined }> = ({ aktivitet }) => {
+    const aktiviteterSomTekstfelt =
+        aktivitet &&
+        aktivitet.aktiviteter &&
+        verdiFelterTilTekstElement(aktivitet.aktiviteter.verdier);
+
+    const aktivitetLabel = aktivitet?.aktiviteter?.label;
+    const annenAktivitetLabel = aktivitet?.annenAktivitet?.label;
+    const lønnetAktivitetLabel = aktivitet?.lønnetAktivitet?.label;
+
+    return (
+        <AccordionItem
+            header={oppsummeringTekster.accordians.arbeidsrettet_aktivitet.tittel}
+            endreKnapp={{
+                route: RouteTilPath.AKTIVITET,
+                tekst: oppsummeringTekster.accordians.arbeidsrettet_aktivitet.endre_button,
+            }}
+        >
+            {aktiviteterSomTekstfelt && (
+                <LocalePunktliste
+                    innhold={aktiviteterSomTekstfelt}
+                    tittel={{ nb: aktivitetLabel || '' }}
+                />
+            )}
+            <Label>
+                <LocaleTekst tekst={{ nb: annenAktivitetLabel || '' }} />
+            </Label>
+            {aktivitet?.annenAktivitet?.svarTekst}
+            <Label>
+                <LocaleTekst tekst={{ nb: lønnetAktivitetLabel || '' }} />
+            </Label>
+            {aktivitet?.lønnetAktivitet?.svarTekst}
+        </AccordionItem>
+    );
+};
 
 const DineBarn: React.FC<{ person: Person }> = ({ person }) => (
     <AccordionItem
@@ -241,7 +262,7 @@ const Vedlegg: React.FC<{ dokumentasjon: DokumentasjonFelt[] }> = ({ dokumentasj
 );
 
 const Oppsummering = () => {
-    const { hovedytelse, barnMedBarnepass, dokumentasjon } = useSøknad();
+    const { hovedytelse, aktivitet, barnMedBarnepass, dokumentasjon } = useSøknad();
     const { person } = usePerson();
     const [harBekreftet, settHarBekreftet] = useState(false);
     const [feil, settFeil] = useState<string>('');
@@ -267,7 +288,7 @@ const Oppsummering = () => {
             <Accordion>
                 <OmDeg person={person} />
                 <DinSituasjon hovedytelse={hovedytelse} />
-                <AktivitetUtdanning />
+                <ArbeidsrettetAktivitet aktivitet={aktivitet} />
                 <DineBarn person={person} />
                 <PassAvBarn person={person} barnMedBarnepass={barnMedBarnepass} />
                 <Vedlegg dokumentasjon={dokumentasjon} />

--- a/src/frontend/barnetilsyn/tekster/oppsummering.ts
+++ b/src/frontend/barnetilsyn/tekster/oppsummering.ts
@@ -22,7 +22,7 @@ interface OppsummeringInnhold {
             oppholdSiste12mnd: TekstElement<string>;
             oppholdNeste12mnd: TekstElement<string>;
         };
-        aktivitet_utdanning: {
+        arbeidsrettet_aktivitet: {
             tittel: TekstElement<string>;
             endre_button: TekstElement<string>;
         };
@@ -55,7 +55,7 @@ export const oppsummeringTekster: OppsummeringInnhold = {
     },
 
     accordians: {
-        aktivitet_utdanning: {
+        arbeidsrettet_aktivitet: {
             tittel: {
                 nb: 'Arbeidsrettet aktivitet',
             },


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Viser brukerens valg angående "Aktiviteter" på siste side av søknaden (oppsummeringssiden)

### FØR:

![Skjermbilde 2024-04-24 kl  14 20 17](https://github.com/navikt/tilleggsstonader-soknad/assets/28704275/4ef28845-571b-4a9e-9b80-178bd081c2b1)


### ETTER:

![Skjermbilde 2024-04-24 kl  14 19 01](https://github.com/navikt/tilleggsstonader-soknad/assets/28704275/f9f69add-a176-4bcd-80b6-a8e3540ec58d)
