### PR TITLE
Legg til logging av accordions og read mores

### DIFF
--- a/src/frontend/api/amplitude.ts
+++ b/src/frontend/api/amplitude.ts
@@ -12,7 +12,9 @@ type eventType =
     | 'skjema fullført'
     | 'navigere'
     | 'alert vist'
-    | 'besøk';
+    | 'besøk'
+    | 'accordion åpnet'
+    | 'accordion lukket';
 
 export const initAmplitude = () => {
     init('default', '', {
@@ -81,5 +83,14 @@ export const loggBesøkBarnetilsyn = (url: string, sidetittel: string) => {
     loggEventMedSkjema('besøk', Stønadstype.BARNETILSYN, {
         url: url,
         sidetittel: sidetittel,
+    });
+};
+
+export const loggAccordionEvent = (skalÅpnes: boolean, tekst: string, side?: string) => {
+    const event = skalÅpnes ? 'accordion åpnet' : 'accordion lukket';
+
+    loggEventMedSkjema(event, Stønadstype.BARNETILSYN, {
+        tekst: tekst,
+        side: side,
     });
 };

--- a/src/frontend/barnetilsyn/Forside.tsx
+++ b/src/frontend/barnetilsyn/Forside.tsx
@@ -14,9 +14,9 @@ import {
     Label,
 } from '@navikt/ds-react';
 
-import { RoutesBarnetilsyn } from './routing/routesBarnetilsyn';
+import { ERouteBarnetilsyn, RoutesBarnetilsyn } from './routing/routesBarnetilsyn';
 import { forsideTekster } from './tekster/forside';
-import { loggBesøkBarnetilsyn, loggSkjemaStartet } from '../api/amplitude';
+import { loggAccordionEvent, loggBesøkBarnetilsyn, loggSkjemaStartet } from '../api/amplitude';
 import { PellePanel } from '../components/PellePanel/PellePanel';
 import { Container } from '../components/Side';
 import LocaleInlineLenke from '../components/Teksthåndtering/LocaleInlineLenke';
@@ -59,6 +59,10 @@ const Forside: React.FC = () => {
         }
     };
 
+    const loggAccordionÅpning = (skalÅpne: boolean, tittel: string) => {
+        loggAccordionEvent(skalÅpne, tittel, ERouteBarnetilsyn.FORSIDE);
+    };
+
     return (
         <Container>
             <PellePanel poster>
@@ -83,7 +87,11 @@ const Forside: React.FC = () => {
                 innhold={forsideTekster.dine_plikter_innhold}
             />
             <Accordion>
-                <Accordion.Item>
+                <Accordion.Item
+                    onOpenChange={(skalÅpne) =>
+                        loggAccordionÅpning(skalÅpne, 'Hvilke utgifter dekker vi?')
+                    }
+                >
                     <Accordion.Header>
                         <LocaleTekst tekst={forsideTekster.utgifter_som_dekkes_tittel} />
                     </Accordion.Header>
@@ -91,7 +99,11 @@ const Forside: React.FC = () => {
                         <LocaleTekstAvsnitt tekst={forsideTekster.utgifter_som_dekkes_innhold} />
                     </Accordion.Content>
                 </Accordion.Item>
-                <Accordion.Item>
+                <Accordion.Item
+                    onOpenChange={(skalÅpne) =>
+                        loggAccordionÅpning(skalÅpne, 'Dokumentasjon av utgifter')
+                    }
+                >
                     <Accordion.Header>
                         <LocaleTekst tekst={forsideTekster.dokumentasjon_utgifter_tittel} />
                     </Accordion.Header>
@@ -106,7 +118,11 @@ const Forside: React.FC = () => {
                         ))}
                     </Accordion.Content>
                 </Accordion.Item>
-                <Accordion.Item>
+                <Accordion.Item
+                    onOpenChange={(skalÅpne) =>
+                        loggAccordionÅpning(skalÅpne, 'Informasjon vi henter')
+                    }
+                >
                     <Accordion.Header>
                         <LocaleTekst tekst={forsideTekster.info_som_hentes_tittel} />
                     </Accordion.Header>

--- a/src/frontend/components/Teksthåndtering/LocaleReadMore.tsx
+++ b/src/frontend/components/Teksthåndtering/LocaleReadMore.tsx
@@ -1,6 +1,7 @@
 import { BodyLong, List, ReadMore } from '@navikt/ds-react';
 
 import LocaleInlineLenke from './LocaleInlineLenke';
+import { loggAccordionEvent } from '../../api/amplitude';
 import { useSpråk } from '../../context/SpråkContext';
 import { InlineLenke, LesMer, TekstElement } from '../../typer/tekst';
 
@@ -10,10 +11,14 @@ export const LocaleReadMore: React.FC<{
 }> = ({ tekst, somPunktListe = false }) => {
     const { locale } = useSpråk();
 
+    const header = tekst.header[locale];
     const innhold = tekst.innhold[locale];
 
     return (
-        <ReadMore header={tekst.header[locale]}>
+        <ReadMore
+            header={header}
+            onOpenChange={(skalÅpnes) => loggAccordionEvent(skalÅpnes, header)}
+        >
             {Array.isArray(innhold) ? (
                 somPunktListe ? (
                     <List>
@@ -38,8 +43,13 @@ export const LocaleReadMore: React.FC<{
 export const LocaleReadMoreMedLenke: React.FC<{ tekst: LesMer<InlineLenke> }> = ({ tekst }) => {
     const { locale } = useSpråk();
 
+    const header = tekst.header[locale];
+
     return (
-        <ReadMore header={tekst.header[locale]}>
+        <ReadMore
+            header={header}
+            onOpenChange={(skalÅpnes) => loggAccordionEvent(skalÅpnes, header)}
+        >
             <LocaleInlineLenke tekst={tekst.innhold} />
         </ReadMore>
     );
@@ -51,5 +61,14 @@ export const LocaleReadMoreMedChildren: React.FC<{
 }> = ({ header, children }) => {
     const { locale } = useSpråk();
 
-    return <ReadMore header={header[locale]}>{children}</ReadMore>;
+    const headerTekst = header[locale];
+
+    return (
+        <ReadMore
+            header={headerTekst}
+            onOpenChange={(skalÅpnes) => loggAccordionEvent(skalÅpnes, headerTekst)}
+        >
+            {children}
+        </ReadMore>
+    );
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Bruker eventet for åpning av accordions både for accordions og read more.

Side sendes kun med på steder hvor man vet hvilken side man har. Kan senere utvides til å ha side i en context så det kan hentes ut uten å sjekke på path. Foreløpig droppet å sende inn da man bør kunne se på teksten hvilken det er.