### PR TITLE
🐛 Skal håndtere at aktivitet kan ha null som tom-dato

### DIFF
--- a/src/frontend/barnetilsyn/steg/3-aktivitet/utils.ts
+++ b/src/frontend/barnetilsyn/steg/3-aktivitet/utils.ts
@@ -19,7 +19,7 @@ export const mapTilRegisterAktiviteterObjektMedLabel = (
             ...acc,
             [curr.id]: {
                 ...curr,
-                label: `${curr.typeNavn}: ${tilTekstligDato(curr.fom)} - ${tilTekstligDato(curr.tom)}`,
+                label: `${curr.typeNavn}: ${tilTekstligDato(curr.fom)} - ${curr.tom ? tilTekstligDato(curr.tom) : 'pågående'}`,
             },
         }),
         {} as Record<string, RegisterAktivitetMedLabel>

--- a/src/frontend/typer/registerAktivitet.ts
+++ b/src/frontend/typer/registerAktivitet.ts
@@ -1,7 +1,7 @@
 export interface RegisterAktivitet {
     id: string;
     fom: string;
-    tom: string;
+    tom: string | null;
     erUtdanning: boolean;
     typeNavn: string;
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Registeraktiviteter ble ikke vist fordi en av dem hadde null som tom-dato.

La til som pågående, men usikker på om det blir riktig?

![image](https://github.com/navikt/tilleggsstonader-soknad/assets/21220467/97fa4188-c71e-4c7f-9e0a-1d5ccc14bc84)

