### PR TITLE
Skal ikke rendere kvitteringssiden hvis man går inn på den urlen direkte

### DIFF
--- a/src/frontend/barnetilsyn/Kvittering.tsx
+++ b/src/frontend/barnetilsyn/Kvittering.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { Alert, BodyLong, BodyShort, Heading } from '@navikt/ds-react';
@@ -13,9 +15,15 @@ const Kvittering = () => {
     const locationState = useLocation().state;
     const navigate = useNavigate();
 
-    if (locationState === null) {
-        // brukeren har ikke gått inn via oppsummeringssiden
-        navigate(barnetilsynPath);
+    useEffect(() => {
+        if (locationState === null) {
+            navigate(barnetilsynPath);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [locationState]);
+
+    if (locationState == null) {
+        return null;
     }
 
     return (


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Siden ble rendert før brukeren ble navigert, og då kastet error

Hvis man ikke legger dette i en useEffect så får man
> You should call navigate() in a React.useEffect(), not when your component is first rendered.