### PR TITLE
Skal sende bruker med høyere gradert barn til papirsøknad

### DIFF
--- a/src/frontend/api/Environment.ts
+++ b/src/frontend/api/Environment.ts
@@ -4,6 +4,7 @@ interface EnvironmentProps {
     wonderwallUrl: string;
     sentryUrl?: string;
     urlGammelSøknad: string;
+    urlPapirsøknad: string;
     miljø: string;
     modellVersjon: IModellversjon;
 }
@@ -25,6 +26,8 @@ const Environment = (): EnvironmentProps => {
             sentryUrl: 'https://06b839ad5487467cb88097c5a27bbbb5@sentry.gc.nav.no/167',
             urlGammelSøknad:
                 'https://skjemadelingslenke.ekstern.dev.nav.no/fyllut/nav111215b?sub=digital',
+            urlPapirsøknad:
+                'https://skjemadelingslenke.ekstern.dev.nav.no/fyllut/nav111215b?sub=paper',
             miljø: 'preprod',
             modellVersjon: modellVersjon,
         };
@@ -35,6 +38,7 @@ const Environment = (): EnvironmentProps => {
             wonderwallUrl: 'https://www.nav.no/tilleggsstonader/soknad/oauth2/login?redirect=',
             sentryUrl: 'https://06b839ad5487467cb88097c5a27bbbb5@sentry.gc.nav.no/167',
             urlGammelSøknad: 'https://www.nav.no/fyllut/nav111215b?sub=digital',
+            urlPapirsøknad: 'https://www.nav.no/fyllut/nav111215b?sub=paper',
             miljø: 'production',
             modellVersjon: modellVersjon,
         };
@@ -43,7 +47,10 @@ const Environment = (): EnvironmentProps => {
             apiProxyUrl: 'http://localhost:8080/api',
             vedleggProxyUrl: 'http://localhost:8080/api/vedlegg/tillegg',
             wonderwallUrl: `http://localhost:8001/test/cookie?redirect=`,
-            urlGammelSøknad: 'https://soknad.intern.dev.nav.no/soknadtilleggsstonader',
+            urlGammelSøknad:
+                'https://skjemadelingslenke.ekstern.dev.nav.no/fyllut/nav111215b?sub=digital',
+            urlPapirsøknad:
+                'https://skjemadelingslenke.ekstern.dev.nav.no/fyllut/nav111215b?sub=paper',
             miljø: 'local',
             modellVersjon: modellVersjon,
         };

--- a/src/frontend/components/SøknadRouting/sendSøkerTilGammelSøknad.ts
+++ b/src/frontend/components/SøknadRouting/sendSøkerTilGammelSøknad.ts
@@ -3,3 +3,7 @@ import Environment from '../../api/Environment';
 export const sendSøkerTilGammelSøknad = () => {
     window.location.href = Environment().urlGammelSøknad;
 };
+
+export const sendSøkerTilPapirsøknad = () => {
+    window.location.href = Environment().urlPapirsøknad;
+};

--- a/src/frontend/context/PersonContext.tsx
+++ b/src/frontend/context/PersonContext.tsx
@@ -4,11 +4,11 @@ import axios, { AxiosError } from 'axios';
 import createUseContext from 'constate';
 
 import { hentPersonData } from '../api/api';
-import { sendSøkerTilGammelSøknad } from '../components/SøknadRouting/sendSøkerTilGammelSøknad';
+import { sendSøkerTilPapirsøknad } from '../components/SøknadRouting/sendSøkerTilGammelSøknad';
 import { initiellPerson } from '../mock/initiellPerson';
 import { Person } from '../typer/person';
 
-const erFeilOgSkalRouteTilGammelSøknad = (req: AxiosError<{ detail?: string }, unknown>) => {
+const erFeilOgSkalRouteTilPapirsøknad = (req: AxiosError<{ detail?: string }, unknown>) => {
     return req?.response?.data?.detail === 'ROUTING_GAMMEL_SØKNAD';
 };
 
@@ -25,8 +25,8 @@ const [PersonProvider, usePerson] = createUseContext(() => {
                 settHarLastetPerson(true);
             })
             .catch((req) => {
-                if (axios.isAxiosError(req) && erFeilOgSkalRouteTilGammelSøknad(req)) {
-                    sendSøkerTilGammelSøknad();
+                if (axios.isAxiosError(req) && erFeilOgSkalRouteTilPapirsøknad(req)) {
+                    sendSøkerTilPapirsøknad();
                 } else {
                     // TODO noe bedre håndtering?
                     settFeilmelding(


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Kode 6 og 7 har tidligere blitt sendt til gammel søknad.
De skal nå få sendt inn som vanlig.
Dersom de har barn med høyere gradering så er det nå ønskelig at de sendes til papirsøknaden.

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21257

* https://github.com/navikt/tilleggsstonader-soknad-api/pull/134