### PR TITLE
Egen søknadcontext per stønad

### DIFF
--- a/src/frontend/api/amplitude.ts
+++ b/src/frontend/api/amplitude.ts
@@ -86,6 +86,13 @@ export const loggBesøkBarnetilsyn = (url: string, sidetittel: string) => {
     });
 };
 
+export const loggBesøkLæremiddel = (url: string, sidetittel: string) => {
+    loggEventMedSkjema('besøk', Stønadstype.LÆREMIDLER, {
+        url: url,
+        sidetittel: sidetittel,
+    });
+};
+
 export const loggAccordionEvent = (skalÅpnes: boolean, tekst: string, side?: string) => {
     const event = skalÅpnes ? 'accordion åpnet' : 'accordion lukket';
 

--- a/src/frontend/barnetilsyn/BarnetilsynApp.tsx
+++ b/src/frontend/barnetilsyn/BarnetilsynApp.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 
 import Søknadsdialog from './Søknadsdialog';
 import SøknadRouting from '../components/SøknadRouting/SøknadRouting';
+import { PassAvBarnSøknadProvider } from '../context/PassAvBarnSøknadContext';
 import { useSpråk } from '../context/SpråkContext';
 import { teksterStønad } from '../tekster/stønad';
 import { Stønadstype } from '../typer/stønadstyper';
@@ -14,9 +15,11 @@ const BarnetilsynApp = () => {
     }, [locale]);
 
     return (
-        <SøknadRouting stønadstype={Stønadstype.BARNETILSYN}>
-            <Søknadsdialog />
-        </SøknadRouting>
+        <PassAvBarnSøknadProvider>
+            <SøknadRouting stønadstype={Stønadstype.BARNETILSYN}>
+                <Søknadsdialog />
+            </SøknadRouting>
+        </PassAvBarnSøknadProvider>
     );
 };
 

--- a/src/frontend/barnetilsyn/BarnetilsynApp.tsx
+++ b/src/frontend/barnetilsyn/BarnetilsynApp.tsx
@@ -4,6 +4,7 @@ import Søknadsdialog from './Søknadsdialog';
 import SøknadRouting from '../components/SøknadRouting/SøknadRouting';
 import { PassAvBarnSøknadProvider } from '../context/PassAvBarnSøknadContext';
 import { useSpråk } from '../context/SpråkContext';
+import { ValideringsfeilProvider } from '../context/ValideringsfeilContext';
 import { teksterStønad } from '../tekster/stønad';
 import { Stønadstype } from '../typer/stønadstyper';
 
@@ -15,11 +16,13 @@ const BarnetilsynApp = () => {
     }, [locale]);
 
     return (
-        <PassAvBarnSøknadProvider>
-            <SøknadRouting stønadstype={Stønadstype.BARNETILSYN}>
-                <Søknadsdialog />
-            </SøknadRouting>
-        </PassAvBarnSøknadProvider>
+        <ValideringsfeilProvider>
+            <PassAvBarnSøknadProvider>
+                <SøknadRouting stønadstype={Stønadstype.BARNETILSYN}>
+                    <Søknadsdialog />
+                </SøknadRouting>
+            </PassAvBarnSøknadProvider>
+        </ValideringsfeilProvider>
     );
 };
 

--- a/src/frontend/barnetilsyn/Forside.tsx
+++ b/src/frontend/barnetilsyn/Forside.tsx
@@ -23,8 +23,8 @@ import LocaleInlineLenke from '../components/Teksthåndtering/LocaleInlineLenke'
 import LocalePunktliste from '../components/Teksthåndtering/LocalePunktliste';
 import LocaleTekst from '../components/Teksthåndtering/LocaleTekst';
 import LocaleTekstAvsnitt from '../components/Teksthåndtering/LocaleTekstAvsnitt';
+import { usePassAvBarnSøknad } from '../context/PassAvBarnSøknadContext';
 import { usePerson } from '../context/PersonContext';
-import { useSøknad } from '../context/SøknadContext';
 import { fellesTekster } from '../tekster/felles';
 import { Stønadstype } from '../typer/stønadstyper';
 import { erSnartNyttSkoleår } from '../utils/dato';
@@ -39,7 +39,7 @@ const KnappeContainer = styled(BodyShort)`
 const Forside: React.FC = () => {
     const navigate = useNavigate();
     const location = useLocation();
-    const { harBekreftet, settHarBekreftet } = useSøknad();
+    const { harBekreftet, settHarBekreftet } = usePassAvBarnSøknad();
     const { person } = usePerson();
 
     const [skalViseFeilmelding, settSkalViseFeilmelding] = useState(false);

--- a/src/frontend/barnetilsyn/Søknadsdialog.tsx
+++ b/src/frontend/barnetilsyn/Søknadsdialog.tsx
@@ -10,6 +10,7 @@ import Vedlegg from './steg/6-vedlegg/Vedlegg';
 import Oppsummering from './steg/7-oppsummering/Oppsummering';
 import { Banner } from '../components/Banner';
 import RedirectTilStart from '../components/RedirectTilStart';
+import { usePassAvBarnSøknad } from '../context/PassAvBarnSøknadContext';
 import { fellesTekster } from '../tekster/felles';
 import { Stønadstype } from '../typer/stønadstyper';
 
@@ -27,8 +28,9 @@ const Søknadsdialog: React.FC = () => {
 };
 
 const SøknadsdialogInnhold = () => {
+    const { harBekreftet } = usePassAvBarnSøknad();
     return (
-        <RedirectTilStart stønadstype={Stønadstype.BARNETILSYN}>
+        <RedirectTilStart harBekreftet={harBekreftet} stønadstype={Stønadstype.BARNETILSYN}>
             <Routes>
                 <Route path={'/hovedytelse'} element={<HovedytelsePassBarn />} />
                 <Route path={'/aktivitet'} element={<Aktivitet />} />

--- a/src/frontend/barnetilsyn/steg/2-hovedytelse/HovedytelsePassBarn.tsx
+++ b/src/frontend/barnetilsyn/steg/2-hovedytelse/HovedytelsePassBarn.tsx
@@ -1,9 +1,10 @@
 import HovedytelseSide from '../../../components/Hovedytelse/Hovedytelse';
-import { useSøknad } from '../../../context/SøknadContext';
+import { usePassAvBarnSøknad } from '../../../context/PassAvBarnSøknadContext';
 import { Hovedytelse } from '../../../typer/søknad';
 
 const HovedytelsePassBarn = () => {
-    const { hovedytelse, settHovedytelse, valideringsfeil, settValideringsfeil } = useSøknad();
+    const { hovedytelse, settHovedytelse, valideringsfeil, settValideringsfeil } =
+        usePassAvBarnSøknad();
 
     return (
         <HovedytelseSide

--- a/src/frontend/barnetilsyn/steg/2-hovedytelse/HovedytelsePassBarn.tsx
+++ b/src/frontend/barnetilsyn/steg/2-hovedytelse/HovedytelsePassBarn.tsx
@@ -3,15 +3,12 @@ import { usePassAvBarnSøknad } from '../../../context/PassAvBarnSøknadContext'
 import { Hovedytelse } from '../../../typer/søknad';
 
 const HovedytelsePassBarn = () => {
-    const { hovedytelse, settHovedytelse, valideringsfeil, settValideringsfeil } =
-        usePassAvBarnSøknad();
+    const { hovedytelse, settHovedytelse } = usePassAvBarnSøknad();
 
     return (
         <HovedytelseSide
             hovedytelse={hovedytelse}
             oppdaterHovedytelse={(hovedytelse: Hovedytelse) => settHovedytelse(hovedytelse)}
-            valideringsfeil={valideringsfeil}
-            settValideringsfeil={settValideringsfeil}
         />
     );
 };

--- a/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
+++ b/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
@@ -22,6 +22,7 @@ import LocaleTekstAvsnitt from '../../../components/Teksthåndtering/LocaleTekst
 import { UnderspørsmålContainer } from '../../../components/UnderspørsmålContainer';
 import { usePassAvBarnSøknad } from '../../../context/PassAvBarnSøknadContext';
 import { useSpråk } from '../../../context/SpråkContext';
+import { useValideringsfeil } from '../../../context/ValideringsfeilContext';
 import { AnnenAktivitetType } from '../../../typer/aktivitet';
 import { RegisterAktivitetMedLabel } from '../../../typer/registerAktivitet';
 import { EnumFelt, EnumFlereValgFelt } from '../../../typer/skjema';
@@ -32,11 +33,13 @@ import { aktivitetTekster } from '../../tekster/aktivitet';
 
 const Aktivitet = () => {
     const { locale } = useSpråk();
-    const { aktivitet, settAktivitet, valideringsfeil, settValideringsfeil } =
-        usePassAvBarnSøknad();
+    const { valideringsfeil, settValideringsfeil } = useValideringsfeil();
+    const { aktivitet, settAktivitet } = usePassAvBarnSøknad();
+
     const [valgteAktiviteter, settValgteAktiviteter] = useState<
         EnumFlereValgFelt<string> | undefined
     >(aktivitet ? aktivitet.aktiviteter : undefined);
+
     const [registerAktiviteter, settRegisterAktiviteter] =
         useState<Record<string, RegisterAktivitetMedLabel>>();
 

--- a/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
+++ b/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
@@ -20,8 +20,8 @@ import LocaleInlineLenke from '../../../components/Teksthåndtering/LocaleInline
 import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
 import LocaleTekstAvsnitt from '../../../components/Teksthåndtering/LocaleTekstAvsnitt';
 import { UnderspørsmålContainer } from '../../../components/UnderspørsmålContainer';
+import { usePassAvBarnSøknad } from '../../../context/PassAvBarnSøknadContext';
 import { useSpråk } from '../../../context/SpråkContext';
-import { useSøknad } from '../../../context/SøknadContext';
 import { AnnenAktivitetType } from '../../../typer/aktivitet';
 import { RegisterAktivitetMedLabel } from '../../../typer/registerAktivitet';
 import { EnumFelt, EnumFlereValgFelt } from '../../../typer/skjema';
@@ -32,7 +32,8 @@ import { aktivitetTekster } from '../../tekster/aktivitet';
 
 const Aktivitet = () => {
     const { locale } = useSpråk();
-    const { aktivitet, settAktivitet, valideringsfeil, settValideringsfeil } = useSøknad();
+    const { aktivitet, settAktivitet, valideringsfeil, settValideringsfeil } =
+        usePassAvBarnSøknad();
     const [valgteAktiviteter, settValgteAktiviteter] = useState<
         EnumFlereValgFelt<string> | undefined
     >(aktivitet ? aktivitet.aktiviteter : undefined);

--- a/src/frontend/barnetilsyn/steg/4-dine-barn/DineBarn.tsx
+++ b/src/frontend/barnetilsyn/steg/4-dine-barn/DineBarn.tsx
@@ -10,6 +10,7 @@ import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
 import { usePassAvBarnSøknad } from '../../../context/PassAvBarnSøknadContext';
 import { usePerson } from '../../../context/PersonContext';
 import { useSpråk } from '../../../context/SpråkContext';
+import { useValideringsfeil } from '../../../context/ValideringsfeilContext';
 import { Stønadstype } from '../../../typer/stønadstyper';
 import { inneholderFeil, Valideringsfeil } from '../../../typer/validering';
 import { formaterIsoDato } from '../../../utils/formatering';
@@ -20,14 +21,9 @@ import { harBarnUnder2år, harValgtBarnOver9år } from '../5-pass-av-dine-barn/u
 const DineBarn = () => {
     const { locale } = useSpråk();
     const { person } = usePerson();
-    const {
-        valgteBarnIdenter,
-        settValgteBarnIdenter,
-        settDokumentasjon,
-        hovedytelse,
-        valideringsfeil,
-        settValideringsfeil,
-    } = usePassAvBarnSøknad();
+    const { valideringsfeil, settValideringsfeil } = useValideringsfeil();
+    const { valgteBarnIdenter, settValgteBarnIdenter, settDokumentasjon, hovedytelse } =
+        usePassAvBarnSøknad();
 
     const [barnIdenter, settBarnIdenter] = useState<string[]>(valgteBarnIdenter);
 

--- a/src/frontend/barnetilsyn/steg/4-dine-barn/DineBarn.tsx
+++ b/src/frontend/barnetilsyn/steg/4-dine-barn/DineBarn.tsx
@@ -7,9 +7,9 @@ import Side from '../../../components/Side';
 import LocaleInlineLenke from '../../../components/Teksthåndtering/LocaleInlineLenke';
 import { LocaleReadMoreMedChildren } from '../../../components/Teksthåndtering/LocaleReadMore';
 import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
+import { usePassAvBarnSøknad } from '../../../context/PassAvBarnSøknadContext';
 import { usePerson } from '../../../context/PersonContext';
 import { useSpråk } from '../../../context/SpråkContext';
-import { useSøknad } from '../../../context/SøknadContext';
 import { Stønadstype } from '../../../typer/stønadstyper';
 import { inneholderFeil, Valideringsfeil } from '../../../typer/validering';
 import { formaterIsoDato } from '../../../utils/formatering';
@@ -27,7 +27,7 @@ const DineBarn = () => {
         hovedytelse,
         valideringsfeil,
         settValideringsfeil,
-    } = useSøknad();
+    } = usePassAvBarnSøknad();
 
     const [barnIdenter, settBarnIdenter] = useState<string[]>(valgteBarnIdenter);
 

--- a/src/frontend/barnetilsyn/steg/5-pass-av-dine-barn/PassAvDineBarn.tsx
+++ b/src/frontend/barnetilsyn/steg/5-pass-av-dine-barn/PassAvDineBarn.tsx
@@ -12,6 +12,7 @@ import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
 import { usePassAvBarnSøknad } from '../../../context/PassAvBarnSøknadContext';
 import { usePerson } from '../../../context/PersonContext';
 import { useSpråk } from '../../../context/SpråkContext';
+import { useValideringsfeil } from '../../../context/ValideringsfeilContext';
 import { Barnepass } from '../../../typer/barn';
 import { Stønadstype } from '../../../typer/stønadstyper';
 import { inneholderFeil } from '../../../typer/validering';
@@ -21,14 +22,9 @@ import { barnepassTekster } from '../../tekster/barnepass';
 const PassAvDineBarn = () => {
     const { person } = usePerson();
     const { locale } = useSpråk();
-    const {
-        valgteBarnIdenter,
-        barnMedBarnepass,
-        settBarnMedBarnepass,
-        settDokumentasjonsbehov,
-        valideringsfeil,
-        settValideringsfeil,
-    } = usePassAvBarnSøknad();
+    const { valideringsfeil, settValideringsfeil } = useValideringsfeil();
+    const { valgteBarnIdenter, barnMedBarnepass, settBarnMedBarnepass, settDokumentasjonsbehov } =
+        usePassAvBarnSøknad();
 
     const [barnMedPass, settBarnMedPass] = useState<BarnepassIntern[]>(
         valgteBarnIdenter.map(

--- a/src/frontend/barnetilsyn/steg/5-pass-av-dine-barn/PassAvDineBarn.tsx
+++ b/src/frontend/barnetilsyn/steg/5-pass-av-dine-barn/PassAvDineBarn.tsx
@@ -9,9 +9,9 @@ import { valider } from './utils';
 import { PellePanel } from '../../../components/PellePanel/PellePanel';
 import Side from '../../../components/Side';
 import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
+import { usePassAvBarnSøknad } from '../../../context/PassAvBarnSøknadContext';
 import { usePerson } from '../../../context/PersonContext';
 import { useSpråk } from '../../../context/SpråkContext';
-import { useSøknad } from '../../../context/SøknadContext';
 import { Barnepass } from '../../../typer/barn';
 import { Stønadstype } from '../../../typer/stønadstyper';
 import { inneholderFeil } from '../../../typer/validering';
@@ -28,7 +28,7 @@ const PassAvDineBarn = () => {
         settDokumentasjonsbehov,
         valideringsfeil,
         settValideringsfeil,
-    } = useSøknad();
+    } = usePassAvBarnSøknad();
 
     const [barnMedPass, settBarnMedPass] = useState<BarnepassIntern[]>(
         valgteBarnIdenter.map(

--- a/src/frontend/barnetilsyn/steg/6-vedlegg/Dokumentasjonskrav.tsx
+++ b/src/frontend/barnetilsyn/steg/6-vedlegg/Dokumentasjonskrav.tsx
@@ -1,12 +1,12 @@
 import { BodyShort, List } from '@navikt/ds-react';
 
 import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
+import { usePassAvBarnSøknad } from '../../../context/PassAvBarnSøknadContext';
 import { useSpråk } from '../../../context/SpråkContext';
-import { useSøknad } from '../../../context/SøknadContext';
 import { typerVedleggTekster, vedleggTekster } from '../../tekster/vedlegg';
 
 const Dokumentasjonskrav = () => {
-    const { dokumentasjonsbehov } = useSøknad();
+    const { dokumentasjonsbehov } = usePassAvBarnSøknad();
     const { locale } = useSpråk();
 
     return (

--- a/src/frontend/barnetilsyn/steg/6-vedlegg/Vedlegg.tsx
+++ b/src/frontend/barnetilsyn/steg/6-vedlegg/Vedlegg.tsx
@@ -13,8 +13,8 @@ import Side from '../../../components/Side';
 import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
 import LocaleTekstAvsnitt from '../../../components/Teksthåndtering/LocaleTekstAvsnitt';
 import VedleggGenerellInfo from '../../../components/VedleggGenerellInfo';
+import { usePassAvBarnSøknad } from '../../../context/PassAvBarnSøknadContext';
 import { useSpråk } from '../../../context/SpråkContext';
-import { useSøknad } from '../../../context/SøknadContext';
 import { Dokument, DokumentasjonFelt } from '../../../typer/skjema';
 import { Stønadstype } from '../../../typer/stønadstyper';
 import { typerVedleggTekster, vedleggTekster } from '../../tekster/vedlegg';
@@ -28,7 +28,7 @@ const VedleggContainer = styled.div`
 
 const Vedlegg = () => {
     const { locale } = useSpråk();
-    const { dokumentasjon, settDokumentasjon, dokumentasjonsbehov } = useSøknad();
+    const { dokumentasjon, settDokumentasjon, dokumentasjonsbehov } = usePassAvBarnSøknad();
 
     const ref = useRef<HTMLDialogElement>(null);
     const [ikkeOpplastedeDokumenter, settIkkeOpplastedeDokumenter] = React.useState<string[]>([]);

--- a/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
@@ -23,8 +23,8 @@ import Side from '../../../components/Side';
 import LocalePunktliste from '../../../components/Teksthåndtering/LocalePunktliste';
 import { LocaleReadMoreMedLenke } from '../../../components/Teksthåndtering/LocaleReadMore';
 import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
+import { usePassAvBarnSøknad } from '../../../context/PassAvBarnSøknadContext';
 import { usePerson } from '../../../context/PersonContext';
-import { useSøknad } from '../../../context/SøknadContext';
 import { JaNeiTilTekst } from '../../../tekster/felles';
 import { Barn, Barnepass } from '../../../typer/barn';
 import { Person } from '../../../typer/person';
@@ -266,7 +266,7 @@ const Vedlegg: React.FC<{ dokumentasjon: DokumentasjonFelt[] }> = ({ dokumentasj
 
 const Oppsummering = () => {
     const { hovedytelse, aktivitet, valgteBarnIdenter, barnMedBarnepass, dokumentasjon } =
-        useSøknad();
+        usePassAvBarnSøknad();
     const { person } = usePerson();
     const [harBekreftet, settHarBekreftet] = useState(false);
     const [feil, settFeil] = useState<string>('');

--- a/src/frontend/components/BekreftelseCheckbox.tsx
+++ b/src/frontend/components/BekreftelseCheckbox.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+import { CheckboxGroup, Checkbox } from '@navikt/ds-react';
+
+import LocaleTekst from './Teksthåndtering/LocaleTekst';
+import { fellesTekster } from '../tekster/felles';
+
+interface Props {
+    skalViseFeilmelding: boolean;
+    harBekreftet: boolean;
+    oppdaterHarBekreftet: (harBekreftet: boolean) => void;
+    fjernFeilmelding: () => void;
+}
+
+const BekreftelseCheckbox: React.FC<Props> = ({
+    skalViseFeilmelding,
+    harBekreftet,
+    oppdaterHarBekreftet,
+    fjernFeilmelding,
+}) => {
+    return (
+        <CheckboxGroup
+            legend={<LocaleTekst tekst={fellesTekster.vi_stoler_tittel} />}
+            error={
+                skalViseFeilmelding && <LocaleTekst tekst={fellesTekster.vi_stoler_feilmelding} />
+            }
+            value={[harBekreftet]}
+        >
+            <Checkbox
+                value={true}
+                onChange={(e) => {
+                    oppdaterHarBekreftet(e.target.checked);
+                    fjernFeilmelding();
+                }}
+            >
+                <LocaleTekst tekst={fellesTekster.vi_stoler_innhold} />
+            </Checkbox>
+        </CheckboxGroup>
+    );
+};
+
+export default BekreftelseCheckbox;

--- a/src/frontend/components/Hovedytelse/ArbeidOgOpphold/ArbeidOgOppholdUtenforNorge.tsx
+++ b/src/frontend/components/Hovedytelse/ArbeidOgOpphold/ArbeidOgOppholdUtenforNorge.tsx
@@ -7,7 +7,6 @@ import OppholdUtenforNorgeSiste12Mnd from './Opphold/OppholdUtenforNorgeSiste12M
 import Pengestøtte from './Pengestøtte';
 import { arbeidOgOppholdInnhold } from '../../../barnetilsyn/tekster/opphold';
 import { ArbeidOgOpphold } from '../../../typer/søknad';
-import { Valideringsfeil } from '../../../typer/validering';
 import { PellePanel } from '../../PellePanel/PellePanel';
 import LocaleInlineLenke from '../../Teksthåndtering/LocaleInlineLenke';
 import LocaleTekst from '../../Teksthåndtering/LocaleTekst';
@@ -16,16 +15,9 @@ import { UnderspørsmålContainer } from '../../UnderspørsmålContainer';
 interface Props {
     arbeidOgOpphold: ArbeidOgOpphold;
     settArbeidOgOpphold: React.Dispatch<React.SetStateAction<ArbeidOgOpphold>>;
-    valideringsfeil: Valideringsfeil;
-    settValideringsfeil: React.Dispatch<React.SetStateAction<Valideringsfeil>>;
 }
 
-const ArbeidOgOppholdUtenforNorge: React.FC<Props> = ({
-    arbeidOgOpphold,
-    settArbeidOgOpphold,
-    valideringsfeil,
-    settValideringsfeil,
-}) => {
+const ArbeidOgOppholdUtenforNorge: React.FC<Props> = ({ arbeidOgOpphold, settArbeidOgOpphold }) => {
     return (
         <UnderspørsmålContainer>
             <VStack gap="6">
@@ -39,20 +31,14 @@ const ArbeidOgOppholdUtenforNorge: React.FC<Props> = ({
                 <JobberDuIAnnetLand
                     arbeidOgOpphold={arbeidOgOpphold}
                     settArbeidOgOpphold={settArbeidOgOpphold}
-                    valideringsfeil={valideringsfeil}
-                    settValideringsfeil={settValideringsfeil}
                 />
                 <Pengestøtte
                     arbeidOgOpphold={arbeidOgOpphold}
                     settArbeidOgOpphold={settArbeidOgOpphold}
-                    valideringsfeil={valideringsfeil}
-                    settValideringsfeil={settValideringsfeil}
                 />
                 <OppholdUtenforNorgeSiste12Mnd
                     arbeidOgOpphold={arbeidOgOpphold}
                     settArbeidOgOpphold={settArbeidOgOpphold}
-                    valideringsfeil={valideringsfeil}
-                    settValideringsfeil={settValideringsfeil}
                 />
             </VStack>
         </UnderspørsmålContainer>

--- a/src/frontend/components/Hovedytelse/ArbeidOgOpphold/JobberDuIAnnetLand.tsx
+++ b/src/frontend/components/Hovedytelse/ArbeidOgOpphold/JobberDuIAnnetLand.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 
 import { skalTaStillingTilLandForJobberIAnnetLand } from './util';
 import { jobberIAnnetLandInnhold } from '../../../barnetilsyn/tekster/opphold';
+import { useValideringsfeil } from '../../../context/ValideringsfeilContext';
 import { EnumFelt, SelectFelt } from '../../../typer/skjema';
 import { ArbeidOgOpphold, JaNei } from '../../../typer/søknad';
-import { Valideringsfeil } from '../../../typer/validering';
 import { harVerdi } from '../../../utils/typer';
 import { BlåVenstreRammeContainer } from '../../BlåVenstreRammeContainer';
 import Landvelger from '../../Landvelger/Landvelger';
@@ -13,15 +13,9 @@ import LocaleRadioGroup from '../../Teksthåndtering/LocaleRadioGroup';
 interface Props {
     arbeidOgOpphold: ArbeidOgOpphold;
     settArbeidOgOpphold: React.Dispatch<React.SetStateAction<ArbeidOgOpphold>>;
-    valideringsfeil: Valideringsfeil;
-    settValideringsfeil: React.Dispatch<React.SetStateAction<Valideringsfeil>>;
 }
-const JobberDuIAnnetLand: React.FC<Props> = ({
-    arbeidOgOpphold,
-    settArbeidOgOpphold,
-    valideringsfeil,
-    settValideringsfeil,
-}) => {
+const JobberDuIAnnetLand: React.FC<Props> = ({ arbeidOgOpphold, settArbeidOgOpphold }) => {
+    const { valideringsfeil, settValideringsfeil } = useValideringsfeil();
     const oppdaterJobberIAnnetLandEnnNorge = (verdi: EnumFelt<JaNei>) => {
         settArbeidOgOpphold((prevState) => ({
             ...prevState,

--- a/src/frontend/components/Hovedytelse/ArbeidOgOpphold/Opphold/NyttOpphold.tsx
+++ b/src/frontend/components/Hovedytelse/ArbeidOgOpphold/Opphold/NyttOpphold.tsx
@@ -5,7 +5,6 @@ import { DatePicker, HStack, Label, useDatepicker, VStack } from '@navikt/ds-rea
 import { OppdatertOppholdFelt } from './typer';
 import { errorKeyFom, errorKeyLand, errorKeyTom, errorKeyÅrsak } from './validering';
 import { OppholdInnhold } from '../../../../barnetilsyn/tekster/opphold';
-import { usePassAvBarnSøknad } from '../../../../context/PassAvBarnSøknadContext';
 import { SelectFelt, EnumFlereValgFelt } from '../../../../typer/skjema';
 import {
     ArbeidOgOpphold,
@@ -13,6 +12,7 @@ import {
     ÅrsakOppholdUtenforNorge,
 } from '../../../../typer/søknad';
 import { Locale } from '../../../../typer/tekst';
+import { Valideringsfeil } from '../../../../typer/validering';
 import { nullableTilDato, tilLocaleDateString } from '../../../../utils/formatering';
 import { harVerdi } from '../../../../utils/typer';
 import Landvelger from '../../../Landvelger/Landvelger';
@@ -27,9 +27,9 @@ const NyttOpphold: React.FC<{
     oppdater: OppdatertOppholdFelt;
     tekster: OppholdInnhold;
     locale: Locale;
-}> = ({ keyOpphold, opphold, oppdater, tekster, locale }) => {
-    const { valideringsfeil, settValideringsfeil } = usePassAvBarnSøknad();
-
+    valideringsfeil: Valideringsfeil;
+    settValideringsfeil: React.Dispatch<React.SetStateAction<Valideringsfeil>>;
+}> = ({ keyOpphold, opphold, oppdater, tekster, locale, valideringsfeil, settValideringsfeil }) => {
     const nullstillFeil = (verdi: string | undefined, errorKey: string) => {
         if (harVerdi(verdi)) {
             settValideringsfeil((prevState) => ({

--- a/src/frontend/components/Hovedytelse/ArbeidOgOpphold/Opphold/NyttOpphold.tsx
+++ b/src/frontend/components/Hovedytelse/ArbeidOgOpphold/Opphold/NyttOpphold.tsx
@@ -5,6 +5,7 @@ import { DatePicker, HStack, Label, useDatepicker, VStack } from '@navikt/ds-rea
 import { OppdatertOppholdFelt } from './typer';
 import { errorKeyFom, errorKeyLand, errorKeyTom, errorKeyÅrsak } from './validering';
 import { OppholdInnhold } from '../../../../barnetilsyn/tekster/opphold';
+import { useValideringsfeil } from '../../../../context/ValideringsfeilContext';
 import { SelectFelt, EnumFlereValgFelt } from '../../../../typer/skjema';
 import {
     ArbeidOgOpphold,
@@ -12,7 +13,6 @@ import {
     ÅrsakOppholdUtenforNorge,
 } from '../../../../typer/søknad';
 import { Locale } from '../../../../typer/tekst';
-import { Valideringsfeil } from '../../../../typer/validering';
 import { nullableTilDato, tilLocaleDateString } from '../../../../utils/formatering';
 import { harVerdi } from '../../../../utils/typer';
 import Landvelger from '../../../Landvelger/Landvelger';
@@ -27,9 +27,9 @@ const NyttOpphold: React.FC<{
     oppdater: OppdatertOppholdFelt;
     tekster: OppholdInnhold;
     locale: Locale;
-    valideringsfeil: Valideringsfeil;
-    settValideringsfeil: React.Dispatch<React.SetStateAction<Valideringsfeil>>;
-}> = ({ keyOpphold, opphold, oppdater, tekster, locale, valideringsfeil, settValideringsfeil }) => {
+}> = ({ keyOpphold, opphold, oppdater, tekster, locale }) => {
+    const { valideringsfeil, settValideringsfeil } = useValideringsfeil();
+
     const nullstillFeil = (verdi: string | undefined, errorKey: string) => {
         if (harVerdi(verdi)) {
             settValideringsfeil((prevState) => ({

--- a/src/frontend/components/Hovedytelse/ArbeidOgOpphold/Opphold/NyttOpphold.tsx
+++ b/src/frontend/components/Hovedytelse/ArbeidOgOpphold/Opphold/NyttOpphold.tsx
@@ -5,7 +5,7 @@ import { DatePicker, HStack, Label, useDatepicker, VStack } from '@navikt/ds-rea
 import { OppdatertOppholdFelt } from './typer';
 import { errorKeyFom, errorKeyLand, errorKeyTom, errorKeyÅrsak } from './validering';
 import { OppholdInnhold } from '../../../../barnetilsyn/tekster/opphold';
-import { useSøknad } from '../../../../context/SøknadContext';
+import { usePassAvBarnSøknad } from '../../../../context/PassAvBarnSøknadContext';
 import { SelectFelt, EnumFlereValgFelt } from '../../../../typer/skjema';
 import {
     ArbeidOgOpphold,
@@ -28,7 +28,7 @@ const NyttOpphold: React.FC<{
     tekster: OppholdInnhold;
     locale: Locale;
 }> = ({ keyOpphold, opphold, oppdater, tekster, locale }) => {
-    const { valideringsfeil, settValideringsfeil } = useSøknad();
+    const { valideringsfeil, settValideringsfeil } = usePassAvBarnSøknad();
 
     const nullstillFeil = (verdi: string | undefined, errorKey: string) => {
         if (harVerdi(verdi)) {

--- a/src/frontend/components/Hovedytelse/ArbeidOgOpphold/Opphold/OppholdListe.tsx
+++ b/src/frontend/components/Hovedytelse/ArbeidOgOpphold/Opphold/OppholdListe.tsx
@@ -19,8 +19,8 @@ import {
     OppholdInnhold,
     oppholdUtenforNorgeInnhold,
 } from '../../../../barnetilsyn/tekster/opphold';
+import { usePassAvBarnSøknad } from '../../../../context/PassAvBarnSøknadContext';
 import { useSpråk } from '../../../../context/SpråkContext';
-import { useSøknad } from '../../../../context/SøknadContext';
 import { ArbeidOgOpphold } from '../../../../typer/søknad';
 import { inneholderFeil } from '../../../../typer/validering';
 
@@ -44,7 +44,7 @@ const OppholdListe: React.FC<{
     tekster: OppholdInnhold;
 }> = ({ keyOpphold, arbeidOgOpphold, settArbeidOgOpphold, tekster }) => {
     const { locale } = useSpråk();
-    const { settValideringsfeil } = useSøknad();
+    const { settValideringsfeil } = usePassAvBarnSøknad();
 
     const oppholdUtenforNorge = arbeidOgOpphold[keyOpphold];
     const ulagretOpphold = oppholdUtenforNorge.find((opphold) => !opphold.lagret);

--- a/src/frontend/components/Hovedytelse/ArbeidOgOpphold/Opphold/OppholdListe.tsx
+++ b/src/frontend/components/Hovedytelse/ArbeidOgOpphold/Opphold/OppholdListe.tsx
@@ -19,10 +19,9 @@ import {
     OppholdInnhold,
     oppholdUtenforNorgeInnhold,
 } from '../../../../barnetilsyn/tekster/opphold';
-import { usePassAvBarnSøknad } from '../../../../context/PassAvBarnSøknadContext';
 import { useSpråk } from '../../../../context/SpråkContext';
 import { ArbeidOgOpphold } from '../../../../typer/søknad';
-import { inneholderFeil } from '../../../../typer/validering';
+import { inneholderFeil, Valideringsfeil } from '../../../../typer/validering';
 
 const BlåVenstreRammeContainer = styled(VStack)`
     border-left: 5px solid ${ABlue500};
@@ -42,9 +41,17 @@ const OppholdListe: React.FC<{
     arbeidOgOpphold: ArbeidOgOpphold;
     settArbeidOgOpphold: React.Dispatch<React.SetStateAction<ArbeidOgOpphold>>;
     tekster: OppholdInnhold;
-}> = ({ keyOpphold, arbeidOgOpphold, settArbeidOgOpphold, tekster }) => {
+    valideringsfeil: Valideringsfeil;
+    settValideringsfeil: React.Dispatch<React.SetStateAction<Valideringsfeil>>;
+}> = ({
+    keyOpphold,
+    arbeidOgOpphold,
+    settArbeidOgOpphold,
+    tekster,
+    valideringsfeil,
+    settValideringsfeil,
+}) => {
     const { locale } = useSpråk();
-    const { settValideringsfeil } = usePassAvBarnSøknad();
 
     const oppholdUtenforNorge = arbeidOgOpphold[keyOpphold];
     const ulagretOpphold = oppholdUtenforNorge.find((opphold) => !opphold.lagret);
@@ -152,6 +159,8 @@ const OppholdListe: React.FC<{
                     oppdater={oppdaterOppholdUtenforNorge}
                     tekster={tekster}
                     locale={locale}
+                    valideringsfeil={valideringsfeil}
+                    settValideringsfeil={settValideringsfeil}
                 />
             )}
             <HStack>

--- a/src/frontend/components/Hovedytelse/ArbeidOgOpphold/Opphold/OppholdListe.tsx
+++ b/src/frontend/components/Hovedytelse/ArbeidOgOpphold/Opphold/OppholdListe.tsx
@@ -20,8 +20,9 @@ import {
     oppholdUtenforNorgeInnhold,
 } from '../../../../barnetilsyn/tekster/opphold';
 import { useSpråk } from '../../../../context/SpråkContext';
+import { useValideringsfeil } from '../../../../context/ValideringsfeilContext';
 import { ArbeidOgOpphold } from '../../../../typer/søknad';
-import { inneholderFeil, Valideringsfeil } from '../../../../typer/validering';
+import { inneholderFeil } from '../../../../typer/validering';
 
 const BlåVenstreRammeContainer = styled(VStack)`
     border-left: 5px solid ${ABlue500};
@@ -41,17 +42,9 @@ const OppholdListe: React.FC<{
     arbeidOgOpphold: ArbeidOgOpphold;
     settArbeidOgOpphold: React.Dispatch<React.SetStateAction<ArbeidOgOpphold>>;
     tekster: OppholdInnhold;
-    valideringsfeil: Valideringsfeil;
-    settValideringsfeil: React.Dispatch<React.SetStateAction<Valideringsfeil>>;
-}> = ({
-    keyOpphold,
-    arbeidOgOpphold,
-    settArbeidOgOpphold,
-    tekster,
-    valideringsfeil,
-    settValideringsfeil,
-}) => {
+}> = ({ keyOpphold, arbeidOgOpphold, settArbeidOgOpphold, tekster }) => {
     const { locale } = useSpråk();
+    const { settValideringsfeil } = useValideringsfeil();
 
     const oppholdUtenforNorge = arbeidOgOpphold[keyOpphold];
     const ulagretOpphold = oppholdUtenforNorge.find((opphold) => !opphold.lagret);
@@ -159,8 +152,6 @@ const OppholdListe: React.FC<{
                     oppdater={oppdaterOppholdUtenforNorge}
                     tekster={tekster}
                     locale={locale}
-                    valideringsfeil={valideringsfeil}
-                    settValideringsfeil={settValideringsfeil}
                 />
             )}
             <HStack>

--- a/src/frontend/components/Hovedytelse/ArbeidOgOpphold/Opphold/OppholdUtenforNorgeSiste12Mnd.tsx
+++ b/src/frontend/components/Hovedytelse/ArbeidOgOpphold/Opphold/OppholdUtenforNorgeSiste12Mnd.tsx
@@ -84,6 +84,8 @@ const OppholdUtenforNorgeSiste12Mnd: React.FC<Props> = ({
                         arbeidOgOpphold={arbeidOgOpphold}
                         settArbeidOgOpphold={settArbeidOgOpphold}
                         tekster={oppholdUtenforNorgeInnhold.siste12mnd}
+                        valideringsfeil={valideringsfeil}
+                        settValideringsfeil={settValideringsfeil}
                     />
                     <LocaleRadioGroup
                         id={valideringsfeil.harOppholdUtenforNorgeNeste12mnd?.id}
@@ -98,6 +100,8 @@ const OppholdUtenforNorgeSiste12Mnd: React.FC<Props> = ({
                             arbeidOgOpphold={arbeidOgOpphold}
                             settArbeidOgOpphold={settArbeidOgOpphold}
                             tekster={oppholdUtenforNorgeInnhold.neste12mnd}
+                            valideringsfeil={valideringsfeil}
+                            settValideringsfeil={settValideringsfeil}
                         />
                     )}
                 </>

--- a/src/frontend/components/Hovedytelse/ArbeidOgOpphold/Opphold/OppholdUtenforNorgeSiste12Mnd.tsx
+++ b/src/frontend/components/Hovedytelse/ArbeidOgOpphold/Opphold/OppholdUtenforNorgeSiste12Mnd.tsx
@@ -8,24 +8,22 @@ import {
 } from './util';
 import { nullstillteOppholsfeilNeste12mnd, nullstillteOppholsfeilSiste12mnd } from './validering';
 import { oppholdUtenforNorgeInnhold } from '../../../../barnetilsyn/tekster/opphold';
+import { useValideringsfeil } from '../../../../context/ValideringsfeilContext';
 import { EnumFelt } from '../../../../typer/skjema';
 import { ArbeidOgOpphold, JaNei, OppholdUtenforNorge } from '../../../../typer/søknad';
-import { Valideringsfeil } from '../../../../typer/validering';
 import LocaleRadioGroup from '../../../Teksthåndtering/LocaleRadioGroup';
 
 interface Props {
     arbeidOgOpphold: ArbeidOgOpphold;
     settArbeidOgOpphold: React.Dispatch<React.SetStateAction<ArbeidOgOpphold>>;
-    valideringsfeil: Valideringsfeil;
-    settValideringsfeil: React.Dispatch<React.SetStateAction<Valideringsfeil>>;
 }
 
 const OppholdUtenforNorgeSiste12Mnd: React.FC<Props> = ({
     arbeidOgOpphold,
     settArbeidOgOpphold,
-    valideringsfeil,
-    settValideringsfeil,
 }) => {
+    const { valideringsfeil, settValideringsfeil } = useValideringsfeil();
+
     const oppdaterOppholdSiste12mnd = (verdi: EnumFelt<JaNei>) => {
         settArbeidOgOpphold((prevState: ArbeidOgOpphold) => {
             const opphold: OppholdUtenforNorge[] =
@@ -84,8 +82,6 @@ const OppholdUtenforNorgeSiste12Mnd: React.FC<Props> = ({
                         arbeidOgOpphold={arbeidOgOpphold}
                         settArbeidOgOpphold={settArbeidOgOpphold}
                         tekster={oppholdUtenforNorgeInnhold.siste12mnd}
-                        valideringsfeil={valideringsfeil}
-                        settValideringsfeil={settValideringsfeil}
                     />
                     <LocaleRadioGroup
                         id={valideringsfeil.harOppholdUtenforNorgeNeste12mnd?.id}
@@ -100,8 +96,6 @@ const OppholdUtenforNorgeSiste12Mnd: React.FC<Props> = ({
                             arbeidOgOpphold={arbeidOgOpphold}
                             settArbeidOgOpphold={settArbeidOgOpphold}
                             tekster={oppholdUtenforNorgeInnhold.neste12mnd}
-                            valideringsfeil={valideringsfeil}
-                            settValideringsfeil={settValideringsfeil}
                         />
                     )}
                 </>

--- a/src/frontend/components/Hovedytelse/ArbeidOgOpphold/Pengestøtte.tsx
+++ b/src/frontend/components/Hovedytelse/ArbeidOgOpphold/Pengestøtte.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 
 import { skalTaStillingTilLandForPengestøtte } from './util';
 import { mottarPengestøtteInnhold } from '../../../barnetilsyn/tekster/opphold';
+import { useValideringsfeil } from '../../../context/ValideringsfeilContext';
 import { EnumFlereValgFelt, SelectFelt } from '../../../typer/skjema';
 import { ArbeidOgOpphold, MottarPengestøtteTyper } from '../../../typer/søknad';
-import { Valideringsfeil } from '../../../typer/validering';
 import { harVerdi } from '../../../utils/typer';
 import { BlåVenstreRammeContainer } from '../../BlåVenstreRammeContainer';
 import Landvelger from '../../Landvelger/Landvelger';
@@ -13,16 +13,11 @@ import LocaleCheckboxGroup from '../../Teksthåndtering/LocaleCheckboxGroup';
 interface Props {
     arbeidOgOpphold: ArbeidOgOpphold;
     settArbeidOgOpphold: React.Dispatch<React.SetStateAction<ArbeidOgOpphold>>;
-    valideringsfeil: Valideringsfeil;
-    settValideringsfeil: React.Dispatch<React.SetStateAction<Valideringsfeil>>;
 }
 
-const Pengestøtte: React.FC<Props> = ({
-    arbeidOgOpphold,
-    settArbeidOgOpphold,
-    valideringsfeil,
-    settValideringsfeil,
-}) => {
+const Pengestøtte: React.FC<Props> = ({ arbeidOgOpphold, settArbeidOgOpphold }) => {
+    const { valideringsfeil, settValideringsfeil } = useValideringsfeil();
+
     const oppdaterMottarDuPengestøtte = (verdi: EnumFlereValgFelt<MottarPengestøtteTyper>) => {
         settArbeidOgOpphold((prevState) => ({
             ...prevState,

--- a/src/frontend/components/Hovedytelse/Hovedytelse.tsx
+++ b/src/frontend/components/Hovedytelse/Hovedytelse.tsx
@@ -8,10 +8,11 @@ import { Ytelse } from './typer';
 import { validerHovedytelse } from './validering';
 import { hovedytelseInnhold } from '../../barnetilsyn/tekster/hovedytelse';
 import { useSpråk } from '../../context/SpråkContext';
+import { useValideringsfeil } from '../../context/ValideringsfeilContext';
 import { EnumFlereValgFelt } from '../../typer/skjema';
 import { Stønadstype } from '../../typer/stønadstyper';
 import { ArbeidOgOpphold, Hovedytelse } from '../../typer/søknad';
-import { inneholderFeil, Valideringsfeil } from '../../typer/validering';
+import { inneholderFeil } from '../../typer/validering';
 import { PellePanel } from '../PellePanel/PellePanel';
 import Side from '../Side';
 import LocaleCheckboxGroup from '../Teksthåndtering/LocaleCheckboxGroup';
@@ -25,17 +26,11 @@ const defaultArbeidOgOpphold: ArbeidOgOpphold = {
 interface Props {
     hovedytelse: Hovedytelse | undefined;
     oppdaterHovedytelse: (hovedytelse: Hovedytelse) => void;
-    valideringsfeil: Valideringsfeil;
-    settValideringsfeil: React.Dispatch<React.SetStateAction<Valideringsfeil>>;
 }
 
-const HovedytelseSide: React.FC<Props> = ({
-    hovedytelse,
-    oppdaterHovedytelse,
-    valideringsfeil,
-    settValideringsfeil,
-}) => {
+const HovedytelseSide: React.FC<Props> = ({ hovedytelse, oppdaterHovedytelse }) => {
     const { locale } = useSpråk();
+    const { valideringsfeil, settValideringsfeil } = useValideringsfeil();
 
     const [ytelse, settYtelse] = useState<EnumFlereValgFelt<Ytelse> | undefined>(
         hovedytelse?.ytelse
@@ -95,8 +90,6 @@ const HovedytelseSide: React.FC<Props> = ({
                 <ArbeidOgOppholdUtenforNorge
                     arbeidOgOpphold={arbeidOgOpphold}
                     settArbeidOgOpphold={settArbeidOgOpphold}
-                    valideringsfeil={valideringsfeil}
-                    settValideringsfeil={settValideringsfeil}
                 />
             )}
         </Side>

--- a/src/frontend/components/RedirectTilStart.tsx
+++ b/src/frontend/components/RedirectTilStart.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Navigate } from 'react-router-dom';
 
-import { useSøknad } from '../context/SøknadContext';
+import { usePassAvBarnSøknad } from '../context/PassAvBarnSøknadContext';
 import { Stønadstype } from '../typer/stønadstyper';
 import { hentStartRoute } from '../utils/routes';
 
@@ -12,7 +12,7 @@ interface Props {
 }
 
 const RedirectTilStart: React.FC<Props> = ({ stønadstype, children }) => {
-    const { harBekreftet } = useSøknad();
+    const { harBekreftet } = usePassAvBarnSøknad();
     return !harBekreftet ? <Navigate to={hentStartRoute(stønadstype)} /> : children;
 };
 

--- a/src/frontend/components/RedirectTilStart.tsx
+++ b/src/frontend/components/RedirectTilStart.tsx
@@ -2,17 +2,16 @@ import React from 'react';
 
 import { Navigate } from 'react-router-dom';
 
-import { usePassAvBarnSøknad } from '../context/PassAvBarnSøknadContext';
 import { Stønadstype } from '../typer/stønadstyper';
 import { hentStartRoute } from '../utils/routes';
 
 interface Props {
+    harBekreftet: boolean;
     stønadstype: Stønadstype;
     children: React.ReactElement;
 }
 
-const RedirectTilStart: React.FC<Props> = ({ stønadstype, children }) => {
-    const { harBekreftet } = usePassAvBarnSøknad();
+const RedirectTilStart: React.FC<Props> = ({ harBekreftet, stønadstype, children }) => {
     return !harBekreftet ? <Navigate to={hentStartRoute(stønadstype)} /> : children;
 };
 

--- a/src/frontend/components/Side.tsx
+++ b/src/frontend/components/Side.tsx
@@ -16,8 +16,8 @@ import {
 } from '../api/amplitude';
 import { sendInnSøknad } from '../api/api';
 import { ERouteBarnetilsyn, RouteTilPath } from '../barnetilsyn/routing/routesBarnetilsyn';
+import { usePassAvBarnSøknad } from '../context/PassAvBarnSøknadContext';
 import { useSpråk } from '../context/SpråkContext';
-import { useSøknad } from '../context/SøknadContext';
 import { fellesTekster } from '../tekster/felles';
 import { IRoute } from '../typer/routes';
 import { Stønadstype } from '../typer/stønadstyper';
@@ -62,7 +62,7 @@ const Side: React.FC<Props> = ({ stønadstype, children, validerSteg, oppdaterS�
         barnMedBarnepass,
         dokumentasjon,
         resetSøknad,
-    } = useSøknad();
+    } = usePassAvBarnSøknad();
 
     const errorRef = useRef<HTMLDivElement>(null);
     const [senderInn, settSenderInn] = useState<boolean>(false);

--- a/src/frontend/components/Side.tsx
+++ b/src/frontend/components/Side.tsx
@@ -18,6 +18,7 @@ import { sendInnSøknad } from '../api/api';
 import { ERouteBarnetilsyn, RouteTilPath } from '../barnetilsyn/routing/routesBarnetilsyn';
 import { usePassAvBarnSøknad } from '../context/PassAvBarnSøknadContext';
 import { useSpråk } from '../context/SpråkContext';
+import { useValideringsfeil } from '../context/ValideringsfeilContext';
 import { fellesTekster } from '../tekster/felles';
 import { IRoute } from '../typer/routes';
 import { Stønadstype } from '../typer/stønadstyper';
@@ -54,15 +55,9 @@ const Side: React.FC<Props> = ({ stønadstype, children, validerSteg, oppdaterS�
     const location = useLocation();
     const navigate = useNavigate();
     const { locale } = useSpråk();
-    const {
-        valideringsfeil,
-        settValideringsfeil,
-        hovedytelse,
-        aktivitet,
-        barnMedBarnepass,
-        dokumentasjon,
-        resetSøknad,
-    } = usePassAvBarnSøknad();
+    const { hovedytelse, aktivitet, barnMedBarnepass, dokumentasjon, resetSøknad } =
+        usePassAvBarnSøknad();
+    const { valideringsfeil, settValideringsfeil, resetValideringsfeil } = useValideringsfeil();
 
     const errorRef = useRef<HTMLDivElement>(null);
     const [senderInn, settSenderInn] = useState<boolean>(false);
@@ -127,6 +122,7 @@ const Side: React.FC<Props> = ({ stønadstype, children, validerSteg, oppdaterS�
                 );
 
                 resetSøknad();
+                resetValideringsfeil();
 
                 navigate(nesteRoute.path, { state: { innsendtTidspunkt: res.mottattTidspunkt } });
             })

--- a/src/frontend/context/LæremiddelSøknadContext.tsx
+++ b/src/frontend/context/LæremiddelSøknadContext.tsx
@@ -3,7 +3,6 @@ import { useState } from 'react';
 import createUseContext from 'constate';
 
 import { Hovedytelse } from '../typer/søknad';
-import { Valideringsfeil } from '../typer/validering';
 
 const [LæremidlerSøknadProvider, useLæremidlerSøknad] = createUseContext(() => {
     LæremidlerSøknadProvider.displayName = 'SØKNAD_LÆREMIDLER_PROVIDER';
@@ -16,13 +15,10 @@ const [LæremidlerSøknadProvider, useLæremidlerSøknad] = createUseContext(() 
     // const [dokumentasjonsbehov, settDokumentasjonsbehov] = useState<Dokumentasjonsbehov[]>([]);
     // const [dokumentasjon, settDokumentasjon] = useState<DokumentasjonFelt[]>([]);
 
-    const [valideringsfeil, settValideringsfeil] = useState<Valideringsfeil>({});
-
     const resetSøknad = () => {
         settHovedytelse(undefined);
         // settDokumentasjonsbehov([]);
         // settDokumentasjon([]);
-        settValideringsfeil({});
         settHarBekreftet(false);
     };
 
@@ -31,8 +27,6 @@ const [LæremidlerSøknadProvider, useLæremidlerSøknad] = createUseContext(() 
         settHarBekreftet,
         hovedytelse,
         settHovedytelse,
-        valideringsfeil,
-        settValideringsfeil,
         resetSøknad,
     };
 });

--- a/src/frontend/context/LæremiddelSøknadContext.tsx
+++ b/src/frontend/context/LæremiddelSøknadContext.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+
+import createUseContext from 'constate';
+
+import { Hovedytelse } from '../typer/søknad';
+import { Valideringsfeil } from '../typer/validering';
+
+const [LæremidlerSøknadProvider, useLæremidlerSøknad] = createUseContext(() => {
+    LæremidlerSøknadProvider.displayName = 'SØKNAD_LÆREMIDLER_PROVIDER';
+
+    const [harBekreftet, settHarBekreftet] = useState<boolean>(false);
+
+    const [hovedytelse, settHovedytelse] = useState<Hovedytelse>();
+
+    // TODO: Håndter dokumentasjon
+    // const [dokumentasjonsbehov, settDokumentasjonsbehov] = useState<Dokumentasjonsbehov[]>([]);
+    // const [dokumentasjon, settDokumentasjon] = useState<DokumentasjonFelt[]>([]);
+
+    const [valideringsfeil, settValideringsfeil] = useState<Valideringsfeil>({});
+
+    const resetSøknad = () => {
+        settHovedytelse(undefined);
+        // settDokumentasjonsbehov([]);
+        // settDokumentasjon([]);
+        settValideringsfeil({});
+        settHarBekreftet(false);
+    };
+
+    return {
+        harBekreftet,
+        settHarBekreftet,
+        hovedytelse,
+        settHovedytelse,
+        valideringsfeil,
+        settValideringsfeil,
+        resetSøknad,
+    };
+});
+
+export { LæremidlerSøknadProvider, useLæremidlerSøknad };

--- a/src/frontend/context/PassAvBarnSøknadContext.tsx
+++ b/src/frontend/context/PassAvBarnSøknadContext.tsx
@@ -5,7 +5,6 @@ import createUseContext from 'constate';
 import { Barnepass } from '../typer/barn';
 import { DokumentasjonFelt, Dokumentasjonsbehov } from '../typer/skjema';
 import { Aktivitet, Hovedytelse } from '../typer/søknad';
-import { Valideringsfeil } from '../typer/validering';
 
 const [PassAvBarnSøknadProvider, usePassAvBarnSøknad] = createUseContext(() => {
     PassAvBarnSøknadProvider.displayName = 'SØKNAD_PASS_AV_BARN_PROVIDER';
@@ -23,8 +22,6 @@ const [PassAvBarnSøknadProvider, usePassAvBarnSøknad] = createUseContext(() =>
 
     const [dokumentasjon, settDokumentasjon] = useState<DokumentasjonFelt[]>([]);
 
-    const [valideringsfeil, settValideringsfeil] = useState<Valideringsfeil>({});
-
     const resetSøknad = () => {
         settHovedytelse(undefined);
         settAktivitet(undefined);
@@ -32,7 +29,6 @@ const [PassAvBarnSøknadProvider, usePassAvBarnSøknad] = createUseContext(() =>
         settBarnMedBarnepass([]);
         settDokumentasjonsbehov([]);
         settDokumentasjon([]);
-        settValideringsfeil({});
         settHarBekreftet(false);
     };
 
@@ -49,8 +45,6 @@ const [PassAvBarnSøknadProvider, usePassAvBarnSøknad] = createUseContext(() =>
         settDokumentasjonsbehov,
         dokumentasjon,
         settDokumentasjon,
-        valideringsfeil,
-        settValideringsfeil,
         resetSøknad,
         valgteBarnIdenter,
         settValgteBarnIdenter,

--- a/src/frontend/context/PassAvBarnSøknadContext.tsx
+++ b/src/frontend/context/PassAvBarnSøknadContext.tsx
@@ -8,7 +8,7 @@ import { Aktivitet, Hovedytelse } from '../typer/søknad';
 import { Valideringsfeil } from '../typer/validering';
 
 const [PassAvBarnSøknadProvider, usePassAvBarnSøknad] = createUseContext(() => {
-    PassAvBarnSøknadProvider.displayName = 'SØKNAD_PROVIDER';
+    PassAvBarnSøknadProvider.displayName = 'SØKNAD_PASS_AV_BARN_PROVIDER';
 
     const [harBekreftet, settHarBekreftet] = useState<boolean>(false);
 

--- a/src/frontend/context/PassAvBarnSøknadContext.tsx
+++ b/src/frontend/context/PassAvBarnSøknadContext.tsx
@@ -7,8 +7,8 @@ import { DokumentasjonFelt, Dokumentasjonsbehov } from '../typer/skjema';
 import { Aktivitet, Hovedytelse } from '../typer/søknad';
 import { Valideringsfeil } from '../typer/validering';
 
-const [SøknadProvider, useSøknad] = createUseContext(() => {
-    SøknadProvider.displayName = 'SØKNAD_PROVIDER';
+const [PassAvBarnSøknadProvider, usePassAvBarnSøknad] = createUseContext(() => {
+    PassAvBarnSøknadProvider.displayName = 'SØKNAD_PROVIDER';
 
     const [harBekreftet, settHarBekreftet] = useState<boolean>(false);
 
@@ -57,4 +57,4 @@ const [SøknadProvider, useSøknad] = createUseContext(() => {
     };
 });
 
-export { SøknadProvider, useSøknad };
+export { PassAvBarnSøknadProvider, usePassAvBarnSøknad };

--- a/src/frontend/context/ValideringsfeilContext.tsx
+++ b/src/frontend/context/ValideringsfeilContext.tsx
@@ -1,0 +1,23 @@
+import { useState } from 'react';
+
+import createUseContext from 'constate';
+
+import { Valideringsfeil } from '../typer/validering';
+
+const [ValideringsfeilProvider, useValideringsfeil] = createUseContext(() => {
+    ValideringsfeilProvider.displayName = 'VALIDERINGSFEIL_PROVIDER';
+
+    const [valideringsfeil, settValideringsfeil] = useState<Valideringsfeil>({});
+
+    const resetValideringsfeil = () => {
+        settValideringsfeil({});
+    };
+
+    return {
+        valideringsfeil,
+        settValideringsfeil,
+        resetValideringsfeil,
+    };
+});
+
+export { ValideringsfeilProvider, useValideringsfeil };

--- a/src/frontend/index.tsx
+++ b/src/frontend/index.tsx
@@ -10,9 +10,9 @@ import { initSentry } from './api/Sentry';
 import BarnetilsynApp from './barnetilsyn/BarnetilsynApp';
 import { barnetilsynPath } from './barnetilsyn/routing/routesBarnetilsyn';
 import ScrollToTop from './components/ScrollToTop';
+import { PassAvBarnSøknadProvider } from './context/PassAvBarnSøknadContext';
 import { PersonProvider, usePerson } from './context/PersonContext';
 import { SpråkProvider } from './context/SpråkContext';
-import { SøknadProvider } from './context/SøknadContext';
 import LæremidlerApp from './læremidler/LæremidlerApp';
 import { læremidlerPath } from './læremidler/routing/routesLæremidler';
 import { erProd } from './utils/miljø';
@@ -57,11 +57,11 @@ const AppRoutes = () => {
 root.render(
     <main id={'maincontent'} tabIndex={-1}>
         <SpråkProvider>
-            <SøknadProvider>
+            <PassAvBarnSøknadProvider>
                 <PersonProvider>
                     <AppRoutes />
                 </PersonProvider>
-            </SøknadProvider>
+            </PassAvBarnSøknadProvider>
         </SpråkProvider>
     </main>
 );

--- a/src/frontend/index.tsx
+++ b/src/frontend/index.tsx
@@ -10,7 +10,6 @@ import { initSentry } from './api/Sentry';
 import BarnetilsynApp from './barnetilsyn/BarnetilsynApp';
 import { barnetilsynPath } from './barnetilsyn/routing/routesBarnetilsyn';
 import ScrollToTop from './components/ScrollToTop';
-import { PassAvBarnSøknadProvider } from './context/PassAvBarnSøknadContext';
 import { PersonProvider, usePerson } from './context/PersonContext';
 import { SpråkProvider } from './context/SpråkContext';
 import LæremidlerApp from './læremidler/LæremidlerApp';
@@ -57,11 +56,9 @@ const AppRoutes = () => {
 root.render(
     <main id={'maincontent'} tabIndex={-1}>
         <SpråkProvider>
-            <PassAvBarnSøknadProvider>
-                <PersonProvider>
-                    <AppRoutes />
-                </PersonProvider>
-            </PassAvBarnSøknadProvider>
+            <PersonProvider>
+                <AppRoutes />
+            </PersonProvider>
         </SpråkProvider>
     </main>
 );

--- a/src/frontend/læremidler/Forside.tsx
+++ b/src/frontend/læremidler/Forside.tsx
@@ -3,11 +3,11 @@ import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { styled } from 'styled-components';
 
-import { Accordion, Alert, BodyShort, Button, Heading, Label } from '@navikt/ds-react';
+import { Accordion, BodyLong, BodyShort, Button, Label } from '@navikt/ds-react';
 
-import { ERouteBarnetilsyn, RoutesBarnetilsyn } from './routing/routesBarnetilsyn';
+import { ERouteLæremidler, routesLæremidler } from './routing/routesLæremidler';
 import { forsideTekster } from './tekster/forside';
-import { loggAccordionEvent, loggBesøkBarnetilsyn, loggSkjemaStartet } from '../api/amplitude';
+import { loggAccordionEvent, loggBesøkLæremiddel, loggSkjemaStartet } from '../api/amplitude';
 import BekreftelseCheckbox from '../components/BekreftelseCheckbox';
 import { PellePanel } from '../components/PellePanel/PellePanel';
 import { Container } from '../components/Side';
@@ -15,10 +15,9 @@ import LocaleInlineLenke from '../components/Teksthåndtering/LocaleInlineLenke'
 import LocalePunktliste from '../components/Teksthåndtering/LocalePunktliste';
 import LocaleTekst from '../components/Teksthåndtering/LocaleTekst';
 import LocaleTekstAvsnitt from '../components/Teksthåndtering/LocaleTekstAvsnitt';
-import { usePassAvBarnSøknad } from '../context/PassAvBarnSøknadContext';
+import { useLæremidlerSøknad } from '../context/LæremiddelSøknadContext';
 import { usePerson } from '../context/PersonContext';
 import { Stønadstype } from '../typer/stønadstyper';
-import { erSnartNyttSkoleår } from '../utils/dato';
 import { hentNesteRoute } from '../utils/routes';
 
 const KnappeContainer = styled(BodyShort)`
@@ -30,20 +29,20 @@ const KnappeContainer = styled(BodyShort)`
 const Forside: React.FC = () => {
     const navigate = useNavigate();
     const location = useLocation();
-    const { harBekreftet, settHarBekreftet } = usePassAvBarnSøknad();
+    const { harBekreftet, settHarBekreftet } = useLæremidlerSøknad();
     const { person } = usePerson();
 
     const [skalViseFeilmelding, settSkalViseFeilmelding] = useState(false);
 
     useEffect(() => {
-        const route = RoutesBarnetilsyn[0];
-        loggBesøkBarnetilsyn(route.path, route.label);
+        const route = routesLæremidler[0];
+        loggBesøkLæremiddel(route.path, route.label);
     }, []);
 
     const startSøknad = () => {
         if (harBekreftet) {
-            loggSkjemaStartet(Stønadstype.BARNETILSYN);
-            const nesteRoute = hentNesteRoute(RoutesBarnetilsyn, location.pathname);
+            loggSkjemaStartet(Stønadstype.LÆREMIDLER);
+            const nesteRoute = hentNesteRoute(routesLæremidler, location.pathname);
             navigate(nesteRoute.path);
         } else {
             settSkalViseFeilmelding(true);
@@ -51,7 +50,7 @@ const Forside: React.FC = () => {
     };
 
     const loggAccordionÅpning = (skalÅpne: boolean, tittel: string) => {
-        loggAccordionEvent(skalÅpne, tittel, ERouteBarnetilsyn.FORSIDE);
+        loggAccordionEvent(skalÅpne, tittel, ERouteLæremidler.FORSIDE);
     };
 
     return (
@@ -65,17 +64,9 @@ const Forside: React.FC = () => {
                 </Label>
                 <LocaleTekstAvsnitt tekst={forsideTekster.veileder_innhold} />
             </PellePanel>
-            {erSnartNyttSkoleår() && (
-                <Alert variant="info">
-                    <Heading size="small" spacing>
-                        <LocaleTekst tekst={forsideTekster.mottatt_faktura_alert_tittel} />
-                    </Heading>
-                    <LocaleTekstAvsnitt tekst={forsideTekster.mottatt_faktura_alert_innhold} />
-                </Alert>
-            )}
             <LocalePunktliste
-                tittel={forsideTekster.dine_plikter_tittel}
-                innhold={forsideTekster.dine_plikter_innhold}
+                tittel={forsideTekster.viktig_å_vite_tittel}
+                innhold={forsideTekster.viktig_å_vite_innhold}
             />
             <Accordion>
                 <Accordion.Item
@@ -84,29 +75,15 @@ const Forside: React.FC = () => {
                     }
                 >
                     <Accordion.Header>
-                        <LocaleTekst tekst={forsideTekster.utgifter_som_dekkes_tittel} />
+                        <LocaleTekst tekst={forsideTekster.mengde_støtte_tittel} />
                     </Accordion.Header>
                     <Accordion.Content>
-                        <LocaleTekstAvsnitt tekst={forsideTekster.utgifter_som_dekkes_innhold} />
-                    </Accordion.Content>
-                </Accordion.Item>
-                <Accordion.Item
-                    onOpenChange={(skalÅpne) =>
-                        loggAccordionÅpning(skalÅpne, 'Dokumentasjon av utgifter')
-                    }
-                >
-                    <Accordion.Header>
-                        <LocaleTekst tekst={forsideTekster.dokumentasjon_utgifter_tittel} />
-                    </Accordion.Header>
-                    <Accordion.Content>
-                        {forsideTekster.dokumentasjon_utgifter_innhold.map((tekst, indeks) => (
-                            <LocalePunktliste
-                                key={indeks}
-                                tittel={tekst.tittel}
-                                innhold={tekst.innhold}
-                                tittelSomLabel
-                            />
-                        ))}
+                        <BodyLong spacing>
+                            <LocaleInlineLenke tekst={forsideTekster.mengde_støtte_innhold1} />
+                        </BodyLong>
+                        <BodyLong>
+                            <LocaleTekst tekst={forsideTekster.mengde_støtte_innhold2} />
+                        </BodyLong>
                     </Accordion.Content>
                 </Accordion.Item>
                 <Accordion.Item

--- a/src/frontend/læremidler/LæremidlerApp.tsx
+++ b/src/frontend/læremidler/LæremidlerApp.tsx
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react';
 import Søknadsdialog from './Søknadsdialog';
 import { LæremidlerSøknadProvider } from '../context/LæremiddelSøknadContext';
 import { useSpråk } from '../context/SpråkContext';
+import { ValideringsfeilProvider } from '../context/ValideringsfeilContext';
 import { teksterStønad } from '../tekster/stønad';
 import { Stønadstype } from '../typer/stønadstyper';
 
@@ -15,9 +16,11 @@ const LæremidlerApp = () => {
 
     // TODO: Implementer logikk for routing
     return (
-        <LæremidlerSøknadProvider>
-            <Søknadsdialog />
-        </LæremidlerSøknadProvider>
+        <ValideringsfeilProvider>
+            <LæremidlerSøknadProvider>
+                <Søknadsdialog />
+            </LæremidlerSøknadProvider>
+        </ValideringsfeilProvider>
     );
 };
 

--- a/src/frontend/læremidler/LæremidlerApp.tsx
+++ b/src/frontend/læremidler/LæremidlerApp.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 
 import Søknadsdialog from './Søknadsdialog';
+import { LæremidlerSøknadProvider } from '../context/LæremiddelSøknadContext';
 import { useSpråk } from '../context/SpråkContext';
 import { teksterStønad } from '../tekster/stønad';
 import { Stønadstype } from '../typer/stønadstyper';
@@ -13,7 +14,11 @@ const LæremidlerApp = () => {
     }, [locale]);
 
     // TODO: Implementer logikk for routing
-    return <Søknadsdialog />;
+    return (
+        <LæremidlerSøknadProvider>
+            <Søknadsdialog />
+        </LæremidlerSøknadProvider>
+    );
 };
 
 export default LæremidlerApp;

--- a/src/frontend/læremidler/Søknadsdialog.tsx
+++ b/src/frontend/læremidler/Søknadsdialog.tsx
@@ -2,6 +2,7 @@ import { Route, Routes } from 'react-router';
 
 import { Banner } from '../components/Banner';
 import RedirectTilStart from '../components/RedirectTilStart';
+import { useLæremidlerSøknad } from '../context/LæremiddelSøknadContext';
 import { fellesTekster } from '../tekster/felles';
 import { Stønadstype } from '../typer/stønadstyper';
 
@@ -19,8 +20,9 @@ const Søknadsdialog: React.FC = () => {
 };
 
 const SøknadsdialogInnhold = () => {
+    const { harBekreftet } = useLæremidlerSøknad();
     return (
-        <RedirectTilStart stønadstype={Stønadstype.LÆREMIDLER}>
+        <RedirectTilStart harBekreftet={harBekreftet} stønadstype={Stønadstype.LÆREMIDLER}>
             <Routes>
                 <Route path={'/hovedytelse'} element={<h1>Hovedytelse</h1>} />
                 <Route path={'/utdanning'} element={<h1>Utdanning</h1>} />

--- a/src/frontend/læremidler/Søknadsdialog.tsx
+++ b/src/frontend/læremidler/Søknadsdialog.tsx
@@ -1,5 +1,6 @@
 import { Route, Routes } from 'react-router';
 
+import Forside from './Forside';
 import { Banner } from '../components/Banner';
 import RedirectTilStart from '../components/RedirectTilStart';
 import { useLæremidlerSøknad } from '../context/LæremiddelSøknadContext';
@@ -11,7 +12,7 @@ const Søknadsdialog: React.FC = () => {
         <>
             <Banner tittel={fellesTekster.banner_læremidler} />
             <Routes>
-                <Route path={'/'} element={<p>Forside</p>} />
+                <Route path={'/'} element={<Forside />} />
                 <Route path={'*'} element={<SøknadsdialogInnhold />} />
                 <Route path={'/kvittering'} element={<p>Kvittering</p>} />
             </Routes>

--- a/src/frontend/læremidler/tekster/forside.ts
+++ b/src/frontend/læremidler/tekster/forside.ts
@@ -1,0 +1,86 @@
+import { TekstElement, InlineLenke } from '../../typer/tekst';
+
+interface ForsideInnhold {
+    veileder_tittel: TekstElement<string>;
+    veileder_innhold: TekstElement<string[]>;
+    viktig_å_vite_tittel: TekstElement<string>;
+    viktig_å_vite_innhold: TekstElement<string[]>;
+    mengde_støtte_tittel: TekstElement<string>;
+    mengde_støtte_innhold1: TekstElement<InlineLenke>;
+    mengde_støtte_innhold2: TekstElement<string>;
+    info_som_hentes_tittel: TekstElement<string>;
+    info_som_hentes_innhold1: TekstElement<string>;
+    info_som_hentes_innhold2: TekstElement<string[]>;
+    info_som_hentes_innhold3: TekstElement<string>;
+    info_som_hentes_innhold4: TekstElement<string[]>;
+    info_som_hentes_innhold5: TekstElement<InlineLenke>;
+}
+
+export const forsideTekster: ForsideInnhold = {
+    veileder_tittel: {
+        nb: 'Hei [0]!',
+    },
+    veileder_innhold: {
+        nb: [
+            'Denne pengestøtten kan gis til deg som går på utdanning eller opplæring godkjent av NAV, og er enslig mor/far, gjenlevende, mottar AAP, uføretrygd, sykepenger eller har nedsatt arbeidsevne.',
+        ],
+    },
+    viktig_å_vite_tittel: {
+        nb: 'Viktig å vite før du søker',
+    },
+    viktig_å_vite_innhold: {
+        nb: [
+            'Du må gi oss riktige opplysninger i søknaden.',
+            'Du må dokumentere utgiftene dine i søknaden.',
+            'Du må gi beskjed til oss hvis situasjonen din endrer seg.',
+            'Hvis du får utgiftene dine dekket på annen måte (f.eks. utstyrsstipend fra Lånekassa) har du mest sannsynlig ikke rett til denne stønaden.',
+        ],
+    },
+    mengde_støtte_tittel: {
+        nb: 'Hvor mye kan du få i støtte?',
+    },
+    mengde_støtte_innhold1: {
+        nb: [
+            'Det er ',
+            {
+                tekst: 'faste satser ',
+                url: 'https://www.nav.no/tilleggsstonader#hva',
+                variant: 'neutral',
+            },
+            'som bestemmer hvor mye du kan få i støtte. Satsene er ulike avhengig av om du studerer deltid eller heltid, og nivået på opplæringen din.',
+        ],
+    },
+    mengde_støtte_innhold2: {
+        nb: 'Hvis du har særlig store utgifter grunnet funksjonsnedsettelse kan du få dekket faktiske utgiftene dine. Du må dokumentere din funksjonsnedsettelse med uttalelse fra helsepersonell og utgiftene dine med faktura eller kvittering.',
+    },
+    info_som_hentes_tittel: {
+        nb: 'Informasjon vi henter om deg',
+    },
+    info_som_hentes_innhold1: {
+        nb: 'I tillegg til den informasjonen du oppgir i søknaden, henter vi:',
+    },
+    info_som_hentes_innhold2: {
+        nb: [
+            'adressen din og opplysninger om dine barn fra Folkeregisteret',
+            'informasjon om utdanning eller opplæring avtalt med veileder i NAV',
+            'hvilke andre andre ytelser du mottar fra NAV',
+        ],
+    },
+    info_som_hentes_innhold3: {
+        nb: 'Ved behov sjekker vi:',
+    },
+    info_som_hentes_innhold4: {
+        nb: ['om du er medlem i folketrygden'],
+    },
+    info_som_hentes_innhold5: {
+        nb: [
+            'NAV er ansvarlig for å behandle personopplysningene dine. Vi deler ikke informasjonen du gir oss i søknaden med noen andre.  ',
+            {
+                tekst: 'Personvernerklæringen på nav.no',
+                url: 'https://www.nav.no/personvernerklaering',
+                variant: 'neutral',
+            },
+            ' (åpnes i ny fane) gir mer informasjon om hvordan vi behandler dine personopplysninger.',
+        ],
+    },
+};


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Trenger en context for å lagre ned svar underveis i søknad. Til å begynne med blir det to helt separate contexter, men senere kan man se om det er mulig å samle noe som er felles. 

⚠️ Første commit er kun navneendring. Faktiske endringer er i resterende

### Hva er gjort? 🤓 
- Endret navn på eksisterende `SøknadContext` til `PassAvBarnSøknadContext`
- Lagd ny context for læremiddel som per nå kun inneholder hovedytelse og valideringsfeil fordi disse vet jeg skal være slik. 