### PR TITLE
✨ Egen context for valideringsfeil

### DIFF
--- a/src/frontend/barnetilsyn/BarnetilsynApp.tsx
+++ b/src/frontend/barnetilsyn/BarnetilsynApp.tsx
@@ -4,6 +4,7 @@ import Søknadsdialog from './Søknadsdialog';
 import SøknadRouting from '../components/SøknadRouting/SøknadRouting';
 import { PassAvBarnSøknadProvider } from '../context/PassAvBarnSøknadContext';
 import { useSpråk } from '../context/SpråkContext';
+import { ValideringsfeilProvider } from '../context/ValideringsfeilContext';
 import { teksterStønad } from '../tekster/stønad';
 import { Stønadstype } from '../typer/stønadstyper';
 
@@ -15,11 +16,13 @@ const BarnetilsynApp = () => {
     }, [locale]);
 
     return (
-        <PassAvBarnSøknadProvider>
-            <SøknadRouting stønadstype={Stønadstype.BARNETILSYN}>
-                <Søknadsdialog />
-            </SøknadRouting>
-        </PassAvBarnSøknadProvider>
+        <ValideringsfeilProvider>
+            <PassAvBarnSøknadProvider>
+                <SøknadRouting stønadstype={Stønadstype.BARNETILSYN}>
+                    <Søknadsdialog />
+                </SøknadRouting>
+            </PassAvBarnSøknadProvider>
+        </ValideringsfeilProvider>
     );
 };
 

--- a/src/frontend/barnetilsyn/steg/2-hovedytelse/HovedytelsePassBarn.tsx
+++ b/src/frontend/barnetilsyn/steg/2-hovedytelse/HovedytelsePassBarn.tsx
@@ -1,10 +1,11 @@
 import HovedytelseSide from '../../../components/Hovedytelse/Hovedytelse';
 import { usePassAvBarnSøknad } from '../../../context/PassAvBarnSøknadContext';
+import { useValideringsfeil } from '../../../context/ValideringsfeilContext';
 import { Hovedytelse } from '../../../typer/søknad';
 
 const HovedytelsePassBarn = () => {
-    const { hovedytelse, settHovedytelse, valideringsfeil, settValideringsfeil } =
-        usePassAvBarnSøknad();
+    const { valideringsfeil, settValideringsfeil } = useValideringsfeil();
+    const { hovedytelse, settHovedytelse } = usePassAvBarnSøknad();
 
     return (
         <HovedytelseSide

--- a/src/frontend/barnetilsyn/steg/2-hovedytelse/HovedytelsePassBarn.tsx
+++ b/src/frontend/barnetilsyn/steg/2-hovedytelse/HovedytelsePassBarn.tsx
@@ -1,18 +1,14 @@
 import HovedytelseSide from '../../../components/Hovedytelse/Hovedytelse';
 import { usePassAvBarnSøknad } from '../../../context/PassAvBarnSøknadContext';
-import { useValideringsfeil } from '../../../context/ValideringsfeilContext';
 import { Hovedytelse } from '../../../typer/søknad';
 
 const HovedytelsePassBarn = () => {
-    const { valideringsfeil, settValideringsfeil } = useValideringsfeil();
     const { hovedytelse, settHovedytelse } = usePassAvBarnSøknad();
 
     return (
         <HovedytelseSide
             hovedytelse={hovedytelse}
             oppdaterHovedytelse={(hovedytelse: Hovedytelse) => settHovedytelse(hovedytelse)}
-            valideringsfeil={valideringsfeil}
-            settValideringsfeil={settValideringsfeil}
         />
     );
 };

--- a/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
+++ b/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
@@ -22,6 +22,7 @@ import LocaleTekstAvsnitt from '../../../components/Teksthåndtering/LocaleTekst
 import { UnderspørsmålContainer } from '../../../components/UnderspørsmålContainer';
 import { usePassAvBarnSøknad } from '../../../context/PassAvBarnSøknadContext';
 import { useSpråk } from '../../../context/SpråkContext';
+import { useValideringsfeil } from '../../../context/ValideringsfeilContext';
 import { AnnenAktivitetType } from '../../../typer/aktivitet';
 import { RegisterAktivitetMedLabel } from '../../../typer/registerAktivitet';
 import { EnumFelt, EnumFlereValgFelt } from '../../../typer/skjema';
@@ -32,11 +33,13 @@ import { aktivitetTekster } from '../../tekster/aktivitet';
 
 const Aktivitet = () => {
     const { locale } = useSpråk();
-    const { aktivitet, settAktivitet, valideringsfeil, settValideringsfeil } =
-        usePassAvBarnSøknad();
+    const { valideringsfeil, settValideringsfeil } = useValideringsfeil();
+    const { aktivitet, settAktivitet } = usePassAvBarnSøknad();
+
     const [valgteAktiviteter, settValgteAktiviteter] = useState<
         EnumFlereValgFelt<string> | undefined
     >(aktivitet ? aktivitet.aktiviteter : undefined);
+
     const [registerAktiviteter, settRegisterAktiviteter] =
         useState<Record<string, RegisterAktivitetMedLabel>>();
 

--- a/src/frontend/barnetilsyn/steg/4-dine-barn/DineBarn.tsx
+++ b/src/frontend/barnetilsyn/steg/4-dine-barn/DineBarn.tsx
@@ -10,6 +10,7 @@ import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
 import { usePassAvBarnSøknad } from '../../../context/PassAvBarnSøknadContext';
 import { usePerson } from '../../../context/PersonContext';
 import { useSpråk } from '../../../context/SpråkContext';
+import { useValideringsfeil } from '../../../context/ValideringsfeilContext';
 import { Stønadstype } from '../../../typer/stønadstyper';
 import { inneholderFeil, Valideringsfeil } from '../../../typer/validering';
 import { formaterIsoDato } from '../../../utils/formatering';
@@ -20,14 +21,9 @@ import { harBarnUnder2år, harValgtBarnOver9år } from '../5-pass-av-dine-barn/u
 const DineBarn = () => {
     const { locale } = useSpråk();
     const { person } = usePerson();
-    const {
-        valgteBarnIdenter,
-        settValgteBarnIdenter,
-        settDokumentasjon,
-        hovedytelse,
-        valideringsfeil,
-        settValideringsfeil,
-    } = usePassAvBarnSøknad();
+    const { valideringsfeil, settValideringsfeil } = useValideringsfeil();
+    const { valgteBarnIdenter, settValgteBarnIdenter, settDokumentasjon, hovedytelse } =
+        usePassAvBarnSøknad();
 
     const [barnIdenter, settBarnIdenter] = useState<string[]>(valgteBarnIdenter);
 

--- a/src/frontend/barnetilsyn/steg/5-pass-av-dine-barn/PassAvDineBarn.tsx
+++ b/src/frontend/barnetilsyn/steg/5-pass-av-dine-barn/PassAvDineBarn.tsx
@@ -12,6 +12,7 @@ import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
 import { usePassAvBarnSøknad } from '../../../context/PassAvBarnSøknadContext';
 import { usePerson } from '../../../context/PersonContext';
 import { useSpråk } from '../../../context/SpråkContext';
+import { useValideringsfeil } from '../../../context/ValideringsfeilContext';
 import { Barnepass } from '../../../typer/barn';
 import { Stønadstype } from '../../../typer/stønadstyper';
 import { inneholderFeil } from '../../../typer/validering';
@@ -21,14 +22,9 @@ import { barnepassTekster } from '../../tekster/barnepass';
 const PassAvDineBarn = () => {
     const { person } = usePerson();
     const { locale } = useSpråk();
-    const {
-        valgteBarnIdenter,
-        barnMedBarnepass,
-        settBarnMedBarnepass,
-        settDokumentasjonsbehov,
-        valideringsfeil,
-        settValideringsfeil,
-    } = usePassAvBarnSøknad();
+    const { valideringsfeil, settValideringsfeil } = useValideringsfeil();
+    const { valgteBarnIdenter, barnMedBarnepass, settBarnMedBarnepass, settDokumentasjonsbehov } =
+        usePassAvBarnSøknad();
 
     const [barnMedPass, settBarnMedPass] = useState<BarnepassIntern[]>(
         valgteBarnIdenter.map(

--- a/src/frontend/components/Hovedytelse/ArbeidOgOpphold/ArbeidOgOppholdUtenforNorge.tsx
+++ b/src/frontend/components/Hovedytelse/ArbeidOgOpphold/ArbeidOgOppholdUtenforNorge.tsx
@@ -7,7 +7,6 @@ import OppholdUtenforNorgeSiste12Mnd from './Opphold/OppholdUtenforNorgeSiste12M
 import Pengestøtte from './Pengestøtte';
 import { arbeidOgOppholdInnhold } from '../../../barnetilsyn/tekster/opphold';
 import { ArbeidOgOpphold } from '../../../typer/søknad';
-import { Valideringsfeil } from '../../../typer/validering';
 import { PellePanel } from '../../PellePanel/PellePanel';
 import LocaleInlineLenke from '../../Teksthåndtering/LocaleInlineLenke';
 import LocaleTekst from '../../Teksthåndtering/LocaleTekst';
@@ -16,16 +15,9 @@ import { UnderspørsmålContainer } from '../../UnderspørsmålContainer';
 interface Props {
     arbeidOgOpphold: ArbeidOgOpphold;
     settArbeidOgOpphold: React.Dispatch<React.SetStateAction<ArbeidOgOpphold>>;
-    valideringsfeil: Valideringsfeil;
-    settValideringsfeil: React.Dispatch<React.SetStateAction<Valideringsfeil>>;
 }
 
-const ArbeidOgOppholdUtenforNorge: React.FC<Props> = ({
-    arbeidOgOpphold,
-    settArbeidOgOpphold,
-    valideringsfeil,
-    settValideringsfeil,
-}) => {
+const ArbeidOgOppholdUtenforNorge: React.FC<Props> = ({ arbeidOgOpphold, settArbeidOgOpphold }) => {
     return (
         <UnderspørsmålContainer>
             <VStack gap="6">
@@ -39,20 +31,14 @@ const ArbeidOgOppholdUtenforNorge: React.FC<Props> = ({
                 <JobberDuIAnnetLand
                     arbeidOgOpphold={arbeidOgOpphold}
                     settArbeidOgOpphold={settArbeidOgOpphold}
-                    valideringsfeil={valideringsfeil}
-                    settValideringsfeil={settValideringsfeil}
                 />
                 <Pengestøtte
                     arbeidOgOpphold={arbeidOgOpphold}
                     settArbeidOgOpphold={settArbeidOgOpphold}
-                    valideringsfeil={valideringsfeil}
-                    settValideringsfeil={settValideringsfeil}
                 />
                 <OppholdUtenforNorgeSiste12Mnd
                     arbeidOgOpphold={arbeidOgOpphold}
                     settArbeidOgOpphold={settArbeidOgOpphold}
-                    valideringsfeil={valideringsfeil}
-                    settValideringsfeil={settValideringsfeil}
                 />
             </VStack>
         </UnderspørsmålContainer>

--- a/src/frontend/components/Hovedytelse/ArbeidOgOpphold/JobberDuIAnnetLand.tsx
+++ b/src/frontend/components/Hovedytelse/ArbeidOgOpphold/JobberDuIAnnetLand.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 
 import { skalTaStillingTilLandForJobberIAnnetLand } from './util';
 import { jobberIAnnetLandInnhold } from '../../../barnetilsyn/tekster/opphold';
+import { useValideringsfeil } from '../../../context/ValideringsfeilContext';
 import { EnumFelt, SelectFelt } from '../../../typer/skjema';
 import { ArbeidOgOpphold, JaNei } from '../../../typer/søknad';
-import { Valideringsfeil } from '../../../typer/validering';
 import { harVerdi } from '../../../utils/typer';
 import { BlåVenstreRammeContainer } from '../../BlåVenstreRammeContainer';
 import Landvelger from '../../Landvelger/Landvelger';
@@ -13,15 +13,9 @@ import LocaleRadioGroup from '../../Teksthåndtering/LocaleRadioGroup';
 interface Props {
     arbeidOgOpphold: ArbeidOgOpphold;
     settArbeidOgOpphold: React.Dispatch<React.SetStateAction<ArbeidOgOpphold>>;
-    valideringsfeil: Valideringsfeil;
-    settValideringsfeil: React.Dispatch<React.SetStateAction<Valideringsfeil>>;
 }
-const JobberDuIAnnetLand: React.FC<Props> = ({
-    arbeidOgOpphold,
-    settArbeidOgOpphold,
-    valideringsfeil,
-    settValideringsfeil,
-}) => {
+const JobberDuIAnnetLand: React.FC<Props> = ({ arbeidOgOpphold, settArbeidOgOpphold }) => {
+    const { valideringsfeil, settValideringsfeil } = useValideringsfeil();
     const oppdaterJobberIAnnetLandEnnNorge = (verdi: EnumFelt<JaNei>) => {
         settArbeidOgOpphold((prevState) => ({
             ...prevState,

--- a/src/frontend/components/Hovedytelse/ArbeidOgOpphold/Opphold/NyttOpphold.tsx
+++ b/src/frontend/components/Hovedytelse/ArbeidOgOpphold/Opphold/NyttOpphold.tsx
@@ -5,6 +5,7 @@ import { DatePicker, HStack, Label, useDatepicker, VStack } from '@navikt/ds-rea
 import { OppdatertOppholdFelt } from './typer';
 import { errorKeyFom, errorKeyLand, errorKeyTom, errorKeyÅrsak } from './validering';
 import { OppholdInnhold } from '../../../../barnetilsyn/tekster/opphold';
+import { useValideringsfeil } from '../../../../context/ValideringsfeilContext';
 import { SelectFelt, EnumFlereValgFelt } from '../../../../typer/skjema';
 import {
     ArbeidOgOpphold,
@@ -12,7 +13,6 @@ import {
     ÅrsakOppholdUtenforNorge,
 } from '../../../../typer/søknad';
 import { Locale } from '../../../../typer/tekst';
-import { Valideringsfeil } from '../../../../typer/validering';
 import { nullableTilDato, tilLocaleDateString } from '../../../../utils/formatering';
 import { harVerdi } from '../../../../utils/typer';
 import Landvelger from '../../../Landvelger/Landvelger';
@@ -27,9 +27,9 @@ const NyttOpphold: React.FC<{
     oppdater: OppdatertOppholdFelt;
     tekster: OppholdInnhold;
     locale: Locale;
-    valideringsfeil: Valideringsfeil;
-    settValideringsfeil: React.Dispatch<React.SetStateAction<Valideringsfeil>>;
-}> = ({ keyOpphold, opphold, oppdater, tekster, locale, valideringsfeil, settValideringsfeil }) => {
+}> = ({ keyOpphold, opphold, oppdater, tekster, locale }) => {
+    const { valideringsfeil, settValideringsfeil } = useValideringsfeil();
+
     const nullstillFeil = (verdi: string | undefined, errorKey: string) => {
         if (harVerdi(verdi)) {
             settValideringsfeil((prevState) => ({

--- a/src/frontend/components/Hovedytelse/ArbeidOgOpphold/Opphold/OppholdListe.tsx
+++ b/src/frontend/components/Hovedytelse/ArbeidOgOpphold/Opphold/OppholdListe.tsx
@@ -20,8 +20,9 @@ import {
     oppholdUtenforNorgeInnhold,
 } from '../../../../barnetilsyn/tekster/opphold';
 import { useSpråk } from '../../../../context/SpråkContext';
+import { useValideringsfeil } from '../../../../context/ValideringsfeilContext';
 import { ArbeidOgOpphold } from '../../../../typer/søknad';
-import { inneholderFeil, Valideringsfeil } from '../../../../typer/validering';
+import { inneholderFeil } from '../../../../typer/validering';
 
 const BlåVenstreRammeContainer = styled(VStack)`
     border-left: 5px solid ${ABlue500};
@@ -41,17 +42,9 @@ const OppholdListe: React.FC<{
     arbeidOgOpphold: ArbeidOgOpphold;
     settArbeidOgOpphold: React.Dispatch<React.SetStateAction<ArbeidOgOpphold>>;
     tekster: OppholdInnhold;
-    valideringsfeil: Valideringsfeil;
-    settValideringsfeil: React.Dispatch<React.SetStateAction<Valideringsfeil>>;
-}> = ({
-    keyOpphold,
-    arbeidOgOpphold,
-    settArbeidOgOpphold,
-    tekster,
-    valideringsfeil,
-    settValideringsfeil,
-}) => {
+}> = ({ keyOpphold, arbeidOgOpphold, settArbeidOgOpphold, tekster }) => {
     const { locale } = useSpråk();
+    const { settValideringsfeil } = useValideringsfeil();
 
     const oppholdUtenforNorge = arbeidOgOpphold[keyOpphold];
     const ulagretOpphold = oppholdUtenforNorge.find((opphold) => !opphold.lagret);
@@ -159,8 +152,6 @@ const OppholdListe: React.FC<{
                     oppdater={oppdaterOppholdUtenforNorge}
                     tekster={tekster}
                     locale={locale}
-                    valideringsfeil={valideringsfeil}
-                    settValideringsfeil={settValideringsfeil}
                 />
             )}
             <HStack>

--- a/src/frontend/components/Hovedytelse/ArbeidOgOpphold/Opphold/OppholdUtenforNorgeSiste12Mnd.tsx
+++ b/src/frontend/components/Hovedytelse/ArbeidOgOpphold/Opphold/OppholdUtenforNorgeSiste12Mnd.tsx
@@ -8,24 +8,22 @@ import {
 } from './util';
 import { nullstillteOppholsfeilNeste12mnd, nullstillteOppholsfeilSiste12mnd } from './validering';
 import { oppholdUtenforNorgeInnhold } from '../../../../barnetilsyn/tekster/opphold';
+import { useValideringsfeil } from '../../../../context/ValideringsfeilContext';
 import { EnumFelt } from '../../../../typer/skjema';
 import { ArbeidOgOpphold, JaNei, OppholdUtenforNorge } from '../../../../typer/søknad';
-import { Valideringsfeil } from '../../../../typer/validering';
 import LocaleRadioGroup from '../../../Teksthåndtering/LocaleRadioGroup';
 
 interface Props {
     arbeidOgOpphold: ArbeidOgOpphold;
     settArbeidOgOpphold: React.Dispatch<React.SetStateAction<ArbeidOgOpphold>>;
-    valideringsfeil: Valideringsfeil;
-    settValideringsfeil: React.Dispatch<React.SetStateAction<Valideringsfeil>>;
 }
 
 const OppholdUtenforNorgeSiste12Mnd: React.FC<Props> = ({
     arbeidOgOpphold,
     settArbeidOgOpphold,
-    valideringsfeil,
-    settValideringsfeil,
 }) => {
+    const { valideringsfeil, settValideringsfeil } = useValideringsfeil();
+
     const oppdaterOppholdSiste12mnd = (verdi: EnumFelt<JaNei>) => {
         settArbeidOgOpphold((prevState: ArbeidOgOpphold) => {
             const opphold: OppholdUtenforNorge[] =
@@ -84,8 +82,6 @@ const OppholdUtenforNorgeSiste12Mnd: React.FC<Props> = ({
                         arbeidOgOpphold={arbeidOgOpphold}
                         settArbeidOgOpphold={settArbeidOgOpphold}
                         tekster={oppholdUtenforNorgeInnhold.siste12mnd}
-                        valideringsfeil={valideringsfeil}
-                        settValideringsfeil={settValideringsfeil}
                     />
                     <LocaleRadioGroup
                         id={valideringsfeil.harOppholdUtenforNorgeNeste12mnd?.id}
@@ -100,8 +96,6 @@ const OppholdUtenforNorgeSiste12Mnd: React.FC<Props> = ({
                             arbeidOgOpphold={arbeidOgOpphold}
                             settArbeidOgOpphold={settArbeidOgOpphold}
                             tekster={oppholdUtenforNorgeInnhold.neste12mnd}
-                            valideringsfeil={valideringsfeil}
-                            settValideringsfeil={settValideringsfeil}
                         />
                     )}
                 </>

--- a/src/frontend/components/Hovedytelse/ArbeidOgOpphold/Pengestøtte.tsx
+++ b/src/frontend/components/Hovedytelse/ArbeidOgOpphold/Pengestøtte.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 
 import { skalTaStillingTilLandForPengestøtte } from './util';
 import { mottarPengestøtteInnhold } from '../../../barnetilsyn/tekster/opphold';
+import { useValideringsfeil } from '../../../context/ValideringsfeilContext';
 import { EnumFlereValgFelt, SelectFelt } from '../../../typer/skjema';
 import { ArbeidOgOpphold, MottarPengestøtteTyper } from '../../../typer/søknad';
-import { Valideringsfeil } from '../../../typer/validering';
 import { harVerdi } from '../../../utils/typer';
 import { BlåVenstreRammeContainer } from '../../BlåVenstreRammeContainer';
 import Landvelger from '../../Landvelger/Landvelger';
@@ -13,16 +13,11 @@ import LocaleCheckboxGroup from '../../Teksthåndtering/LocaleCheckboxGroup';
 interface Props {
     arbeidOgOpphold: ArbeidOgOpphold;
     settArbeidOgOpphold: React.Dispatch<React.SetStateAction<ArbeidOgOpphold>>;
-    valideringsfeil: Valideringsfeil;
-    settValideringsfeil: React.Dispatch<React.SetStateAction<Valideringsfeil>>;
 }
 
-const Pengestøtte: React.FC<Props> = ({
-    arbeidOgOpphold,
-    settArbeidOgOpphold,
-    valideringsfeil,
-    settValideringsfeil,
-}) => {
+const Pengestøtte: React.FC<Props> = ({ arbeidOgOpphold, settArbeidOgOpphold }) => {
+    const { valideringsfeil, settValideringsfeil } = useValideringsfeil();
+
     const oppdaterMottarDuPengestøtte = (verdi: EnumFlereValgFelt<MottarPengestøtteTyper>) => {
         settArbeidOgOpphold((prevState) => ({
             ...prevState,

--- a/src/frontend/components/Hovedytelse/Hovedytelse.tsx
+++ b/src/frontend/components/Hovedytelse/Hovedytelse.tsx
@@ -8,10 +8,11 @@ import { Ytelse } from './typer';
 import { validerHovedytelse } from './validering';
 import { hovedytelseInnhold } from '../../barnetilsyn/tekster/hovedytelse';
 import { useSpråk } from '../../context/SpråkContext';
+import { useValideringsfeil } from '../../context/ValideringsfeilContext';
 import { EnumFlereValgFelt } from '../../typer/skjema';
 import { Stønadstype } from '../../typer/stønadstyper';
 import { ArbeidOgOpphold, Hovedytelse } from '../../typer/søknad';
-import { inneholderFeil, Valideringsfeil } from '../../typer/validering';
+import { inneholderFeil } from '../../typer/validering';
 import { PellePanel } from '../PellePanel/PellePanel';
 import Side from '../Side';
 import LocaleCheckboxGroup from '../Teksthåndtering/LocaleCheckboxGroup';
@@ -25,17 +26,11 @@ const defaultArbeidOgOpphold: ArbeidOgOpphold = {
 interface Props {
     hovedytelse: Hovedytelse | undefined;
     oppdaterHovedytelse: (hovedytelse: Hovedytelse) => void;
-    valideringsfeil: Valideringsfeil;
-    settValideringsfeil: React.Dispatch<React.SetStateAction<Valideringsfeil>>;
 }
 
-const HovedytelseSide: React.FC<Props> = ({
-    hovedytelse,
-    oppdaterHovedytelse,
-    valideringsfeil,
-    settValideringsfeil,
-}) => {
+const HovedytelseSide: React.FC<Props> = ({ hovedytelse, oppdaterHovedytelse }) => {
     const { locale } = useSpråk();
+    const { valideringsfeil, settValideringsfeil } = useValideringsfeil();
 
     const [ytelse, settYtelse] = useState<EnumFlereValgFelt<Ytelse> | undefined>(
         hovedytelse?.ytelse
@@ -95,8 +90,6 @@ const HovedytelseSide: React.FC<Props> = ({
                 <ArbeidOgOppholdUtenforNorge
                     arbeidOgOpphold={arbeidOgOpphold}
                     settArbeidOgOpphold={settArbeidOgOpphold}
-                    valideringsfeil={valideringsfeil}
-                    settValideringsfeil={settValideringsfeil}
                 />
             )}
         </Side>

--- a/src/frontend/components/Side.tsx
+++ b/src/frontend/components/Side.tsx
@@ -18,6 +18,7 @@ import { sendInnSøknad } from '../api/api';
 import { ERouteBarnetilsyn, RouteTilPath } from '../barnetilsyn/routing/routesBarnetilsyn';
 import { usePassAvBarnSøknad } from '../context/PassAvBarnSøknadContext';
 import { useSpråk } from '../context/SpråkContext';
+import { useValideringsfeil } from '../context/ValideringsfeilContext';
 import { fellesTekster } from '../tekster/felles';
 import { IRoute } from '../typer/routes';
 import { Stønadstype } from '../typer/stønadstyper';
@@ -54,15 +55,9 @@ const Side: React.FC<Props> = ({ stønadstype, children, validerSteg, oppdaterS�
     const location = useLocation();
     const navigate = useNavigate();
     const { locale } = useSpråk();
-    const {
-        valideringsfeil,
-        settValideringsfeil,
-        hovedytelse,
-        aktivitet,
-        barnMedBarnepass,
-        dokumentasjon,
-        resetSøknad,
-    } = usePassAvBarnSøknad();
+    const { hovedytelse, aktivitet, barnMedBarnepass, dokumentasjon, resetSøknad } =
+        usePassAvBarnSøknad();
+    const { valideringsfeil, settValideringsfeil, resetValideringsfeil } = useValideringsfeil();
 
     const errorRef = useRef<HTMLDivElement>(null);
     const [senderInn, settSenderInn] = useState<boolean>(false);
@@ -127,6 +122,7 @@ const Side: React.FC<Props> = ({ stønadstype, children, validerSteg, oppdaterS�
                 );
 
                 resetSøknad();
+                resetValideringsfeil();
 
                 navigate(nesteRoute.path, { state: { innsendtTidspunkt: res.mottattTidspunkt } });
             })

--- a/src/frontend/context/LæremiddelSøknadContext.tsx
+++ b/src/frontend/context/LæremiddelSøknadContext.tsx
@@ -3,7 +3,6 @@ import { useState } from 'react';
 import createUseContext from 'constate';
 
 import { Hovedytelse } from '../typer/søknad';
-import { Valideringsfeil } from '../typer/validering';
 
 const [LæremidlerSøknadProvider, useLæremidlerSøknad] = createUseContext(() => {
     LæremidlerSøknadProvider.displayName = 'SØKNAD_LÆREMIDLER_PROVIDER';
@@ -16,13 +15,10 @@ const [LæremidlerSøknadProvider, useLæremidlerSøknad] = createUseContext(() 
     // const [dokumentasjonsbehov, settDokumentasjonsbehov] = useState<Dokumentasjonsbehov[]>([]);
     // const [dokumentasjon, settDokumentasjon] = useState<DokumentasjonFelt[]>([]);
 
-    const [valideringsfeil, settValideringsfeil] = useState<Valideringsfeil>({});
-
     const resetSøknad = () => {
         settHovedytelse(undefined);
         // settDokumentasjonsbehov([]);
         // settDokumentasjon([]);
-        settValideringsfeil({});
         settHarBekreftet(false);
     };
 
@@ -31,8 +27,6 @@ const [LæremidlerSøknadProvider, useLæremidlerSøknad] = createUseContext(() 
         settHarBekreftet,
         hovedytelse,
         settHovedytelse,
-        valideringsfeil,
-        settValideringsfeil,
         resetSøknad,
     };
 });

--- a/src/frontend/context/PassAvBarnSøknadContext.tsx
+++ b/src/frontend/context/PassAvBarnSøknadContext.tsx
@@ -5,7 +5,6 @@ import createUseContext from 'constate';
 import { Barnepass } from '../typer/barn';
 import { DokumentasjonFelt, Dokumentasjonsbehov } from '../typer/skjema';
 import { Aktivitet, Hovedytelse } from '../typer/søknad';
-import { Valideringsfeil } from '../typer/validering';
 
 const [PassAvBarnSøknadProvider, usePassAvBarnSøknad] = createUseContext(() => {
     PassAvBarnSøknadProvider.displayName = 'SØKNAD_PASS_AV_BARN_PROVIDER';
@@ -23,8 +22,6 @@ const [PassAvBarnSøknadProvider, usePassAvBarnSøknad] = createUseContext(() =>
 
     const [dokumentasjon, settDokumentasjon] = useState<DokumentasjonFelt[]>([]);
 
-    const [valideringsfeil, settValideringsfeil] = useState<Valideringsfeil>({});
-
     const resetSøknad = () => {
         settHovedytelse(undefined);
         settAktivitet(undefined);
@@ -32,7 +29,6 @@ const [PassAvBarnSøknadProvider, usePassAvBarnSøknad] = createUseContext(() =>
         settBarnMedBarnepass([]);
         settDokumentasjonsbehov([]);
         settDokumentasjon([]);
-        settValideringsfeil({});
         settHarBekreftet(false);
     };
 
@@ -49,8 +45,6 @@ const [PassAvBarnSøknadProvider, usePassAvBarnSøknad] = createUseContext(() =>
         settDokumentasjonsbehov,
         dokumentasjon,
         settDokumentasjon,
-        valideringsfeil,
-        settValideringsfeil,
         resetSøknad,
         valgteBarnIdenter,
         settValgteBarnIdenter,

--- a/src/frontend/context/ValideringsfeilContext.tsx
+++ b/src/frontend/context/ValideringsfeilContext.tsx
@@ -1,0 +1,23 @@
+import { useState } from 'react';
+
+import createUseContext from 'constate';
+
+import { Valideringsfeil } from '../typer/validering';
+
+const [ValideringsfeilProvider, useValideringsfeil] = createUseContext(() => {
+    ValideringsfeilProvider.displayName = 'VALIDERINGSFEIL_PROVIDER';
+
+    const [valideringsfeil, settValideringsfeil] = useState<Valideringsfeil>({});
+
+    const resetValideringsfeil = () => {
+        settValideringsfeil({});
+    };
+
+    return {
+        valideringsfeil,
+        settValideringsfeil,
+        resetValideringsfeil,
+    };
+});
+
+export { ValideringsfeilProvider, useValideringsfeil };

--- a/src/frontend/læremidler/LæremidlerApp.tsx
+++ b/src/frontend/læremidler/LæremidlerApp.tsx
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react';
 import Søknadsdialog from './Søknadsdialog';
 import { LæremidlerSøknadProvider } from '../context/LæremiddelSøknadContext';
 import { useSpråk } from '../context/SpråkContext';
+import { ValideringsfeilProvider } from '../context/ValideringsfeilContext';
 import { teksterStønad } from '../tekster/stønad';
 import { Stønadstype } from '../typer/stønadstyper';
 
@@ -15,9 +16,11 @@ const LæremidlerApp = () => {
 
     // TODO: Implementer logikk for routing
     return (
-        <LæremidlerSøknadProvider>
-            <Søknadsdialog />
-        </LæremidlerSøknadProvider>
+        <ValideringsfeilProvider>
+            <LæremidlerSøknadProvider>
+                <Søknadsdialog />
+            </LæremidlerSøknadProvider>
+        </ValideringsfeilProvider>
     );
 };
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det ble mye sending av valideringsfeil nedover til ulike komponenter, så nå er det en egen context for denne som ligger rundt hver søknad (ikke instanser av samme context) så de ikke får feil fra hverandre. 