### PR TITLE
Felles context for hele søknad og nullstilling av søknad+valideringsfeil

### DIFF
--- a/src/frontend/api/amplitude.ts
+++ b/src/frontend/api/amplitude.ts
@@ -79,18 +79,19 @@ export const loggAlertVist = (variant: string, tekst: string) => {
     });
 };
 
-export const loggBesøkBarnetilsyn = (url: string, sidetittel: string) => {
-    loggEventMedSkjema('besøk', Stønadstype.BARNETILSYN, {
+export const loggBesøk = (stønadstype: Stønadstype, url: string, sidetittel: string) => {
+    loggEventMedSkjema('besøk', stønadstype, {
         url: url,
         sidetittel: sidetittel,
     });
 };
 
+export const loggBesøkBarnetilsyn = (url: string, sidetittel: string) => {
+    loggBesøk(Stønadstype.BARNETILSYN, url, sidetittel);
+};
+
 export const loggBesøkLæremiddel = (url: string, sidetittel: string) => {
-    loggEventMedSkjema('besøk', Stønadstype.LÆREMIDLER, {
-        url: url,
-        sidetittel: sidetittel,
-    });
+    loggBesøk(Stønadstype.LÆREMIDLER, url, sidetittel);
 };
 
 export const loggAccordionEvent = (skalÅpnes: boolean, tekst: string, side?: string) => {

--- a/src/frontend/barnetilsyn/BarnetilsynApp.tsx
+++ b/src/frontend/barnetilsyn/BarnetilsynApp.tsx
@@ -2,11 +2,35 @@ import React, { useEffect } from 'react';
 
 import Søknadsdialog from './Søknadsdialog';
 import SøknadRouting from '../components/SøknadRouting/SøknadRouting';
-import { PassAvBarnSøknadProvider } from '../context/PassAvBarnSøknadContext';
+import { PassAvBarnSøknadProvider, usePassAvBarnSøknad } from '../context/PassAvBarnSøknadContext';
 import { useSpråk } from '../context/SpråkContext';
-import { ValideringsfeilProvider } from '../context/ValideringsfeilContext';
+import { SøknadProvider } from '../context/SøknadContext';
+import { useValideringsfeil, ValideringsfeilProvider } from '../context/ValideringsfeilContext';
 import { teksterStønad } from '../tekster/stønad';
 import { Stønadstype } from '../typer/stønadstyper';
+
+const BarnetilsynInnhold = () => {
+    const { resetValideringsfeil } = useValideringsfeil();
+    const { resetSøknad, hovedytelse, aktivitet, barnMedBarnepass, dokumentasjon } =
+        usePassAvBarnSøknad();
+
+    return (
+        <SøknadProvider
+            søknad={{
+                hovedytelse: hovedytelse,
+                aktivitet: aktivitet,
+                barnMedBarnepass: barnMedBarnepass,
+                dokumentasjon: dokumentasjon,
+            }}
+            resetValideringsfeil={resetValideringsfeil}
+            resetSøknad={resetSøknad}
+        >
+            <SøknadRouting stønadstype={Stønadstype.BARNETILSYN}>
+                <Søknadsdialog />
+            </SøknadRouting>
+        </SøknadProvider>
+    );
+};
 
 const BarnetilsynApp = () => {
     const { locale } = useSpråk();
@@ -18,9 +42,7 @@ const BarnetilsynApp = () => {
     return (
         <ValideringsfeilProvider>
             <PassAvBarnSøknadProvider>
-                <SøknadRouting stønadstype={Stønadstype.BARNETILSYN}>
-                    <Søknadsdialog />
-                </SøknadRouting>
+                <BarnetilsynInnhold />
             </PassAvBarnSøknadProvider>
         </ValideringsfeilProvider>
     );

--- a/src/frontend/components/Side.tsx
+++ b/src/frontend/components/Side.tsx
@@ -9,7 +9,7 @@ import { ABreakpointMd } from '@navikt/ds-tokens/dist/tokens';
 import { StegIndikator } from './StegIndikator';
 import LocaleTekst from './Teksthåndtering/LocaleTekst';
 import {
-    loggBesøkBarnetilsyn,
+    loggBesøk,
     loggSkjemaFullført,
     loggSkjemaInnsendtFeilet,
     loggSkjemaStegFullført,
@@ -73,8 +73,8 @@ const Side: React.FC<Props> = ({ stønadstype, children, validerSteg, oppdaterS�
     const aktivtSteg: IRoute | undefined = routes[aktivtStegIndex];
 
     useEffect(() => {
-        loggBesøkBarnetilsyn(aktivtSteg.path, aktivtSteg.label);
-    }, [aktivtSteg]);
+        loggBesøk(stønadstype, aktivtSteg.path, aktivtSteg.label);
+    }, [aktivtSteg, stønadstype]);
 
     const navigerTilNesteSide = () => {
         if (validerSteg && !validerSteg()) {
@@ -110,7 +110,8 @@ const Side: React.FC<Props> = ({ stønadstype, children, validerSteg, oppdaterS�
             .then((res) => {
                 loggSkjemaFullført(stønadstype);
 
-                loggBesøkBarnetilsyn(
+                loggBesøk(
+                    stønadstype,
                     RouteTilPath[ERouteBarnetilsyn.KVITTERING],
                     ERouteBarnetilsyn.KVITTERING
                 );

--- a/src/frontend/components/Side.tsx
+++ b/src/frontend/components/Side.tsx
@@ -15,7 +15,6 @@ import {
     loggSkjemaStegFullført,
 } from '../api/amplitude';
 import { sendInnSøknad } from '../api/api';
-import { ERouteBarnetilsyn } from '../barnetilsyn/routing/routesBarnetilsyn';
 import { useSpråk } from '../context/SpråkContext';
 import { useSøknad } from '../context/SøknadContext';
 import { useValideringsfeil } from '../context/ValideringsfeilContext';
@@ -23,7 +22,7 @@ import { fellesTekster } from '../tekster/felles';
 import { IRoute } from '../typer/routes';
 import { Stønadstype } from '../typer/stønadstyper';
 import { inneholderFeil } from '../typer/validering';
-import { hentForrigeRoute, hentNesteRoute, hentRoutes } from '../utils/routes';
+import { erOppsummeringsside, hentForrigeRoute, hentNesteRoute, hentRoutes } from '../utils/routes';
 
 interface Props {
     stønadstype: Stønadstype;
@@ -148,7 +147,7 @@ const Side: React.FC<Props> = ({ stønadstype, children, validerSteg, oppdaterS�
                 <Button variant="secondary" onClick={navigerTilForrigeSide}>
                     <LocaleTekst tekst={fellesTekster.forrige} />
                 </Button>
-                {aktivtSteg.route === ERouteBarnetilsyn.OPPSUMMERING ? (
+                {erOppsummeringsside(aktivtSteg.route) ? (
                     <Button onClick={sendSøknad} loading={senderInn}>
                         <LocaleTekst tekst={fellesTekster.send_inn_søknad} />
                     </Button>

--- a/src/frontend/components/Side.tsx
+++ b/src/frontend/components/Side.tsx
@@ -15,7 +15,7 @@ import {
     loggSkjemaStegFullført,
 } from '../api/amplitude';
 import { sendInnSøknad } from '../api/api';
-import { ERouteBarnetilsyn, RouteTilPath } from '../barnetilsyn/routing/routesBarnetilsyn';
+import { ERouteBarnetilsyn } from '../barnetilsyn/routing/routesBarnetilsyn';
 import { useSpråk } from '../context/SpråkContext';
 import { useSøknad } from '../context/SøknadContext';
 import { useValideringsfeil } from '../context/ValideringsfeilContext';
@@ -109,12 +109,7 @@ const Side: React.FC<Props> = ({ stønadstype, children, validerSteg, oppdaterS�
         sendInnSøknad(stønadstype, søknad)
             .then((res) => {
                 loggSkjemaFullført(stønadstype);
-
-                loggBesøk(
-                    stønadstype,
-                    RouteTilPath[ERouteBarnetilsyn.KVITTERING],
-                    ERouteBarnetilsyn.KVITTERING
-                );
+                loggBesøk(stønadstype, nåværendePath, 'KVITTERING');
 
                 resetSøknadOgValideringsfeil();
                 resetValideringsfeil();

--- a/src/frontend/components/Side.tsx
+++ b/src/frontend/components/Side.tsx
@@ -16,8 +16,8 @@ import {
 } from '../api/amplitude';
 import { sendInnSøknad } from '../api/api';
 import { ERouteBarnetilsyn, RouteTilPath } from '../barnetilsyn/routing/routesBarnetilsyn';
-import { usePassAvBarnSøknad } from '../context/PassAvBarnSøknadContext';
 import { useSpråk } from '../context/SpråkContext';
+import { useSøknad } from '../context/SøknadContext';
 import { useValideringsfeil } from '../context/ValideringsfeilContext';
 import { fellesTekster } from '../tekster/felles';
 import { IRoute } from '../typer/routes';
@@ -55,8 +55,7 @@ const Side: React.FC<Props> = ({ stønadstype, children, validerSteg, oppdaterS�
     const location = useLocation();
     const navigate = useNavigate();
     const { locale } = useSpråk();
-    const { hovedytelse, aktivitet, barnMedBarnepass, dokumentasjon, resetSøknad } =
-        usePassAvBarnSøknad();
+    const { søknad, resetSøknadOgValideringsfeil } = useSøknad();
     const { valideringsfeil, settValideringsfeil, resetValideringsfeil } = useValideringsfeil();
 
     const errorRef = useRef<HTMLDivElement>(null);
@@ -107,12 +106,7 @@ const Side: React.FC<Props> = ({ stønadstype, children, validerSteg, oppdaterS�
 
         const nesteRoute = hentNesteRoute(routes, nåværendePath);
 
-        sendInnSøknad(stønadstype, {
-            hovedytelse,
-            aktivitet,
-            barnMedBarnepass,
-            dokumentasjon,
-        })
+        sendInnSøknad(stønadstype, søknad)
             .then((res) => {
                 loggSkjemaFullført(stønadstype);
 
@@ -121,7 +115,7 @@ const Side: React.FC<Props> = ({ stønadstype, children, validerSteg, oppdaterS�
                     ERouteBarnetilsyn.KVITTERING
                 );
 
-                resetSøknad();
+                resetSøknadOgValideringsfeil();
                 resetValideringsfeil();
 
                 navigate(nesteRoute.path, { state: { innsendtTidspunkt: res.mottattTidspunkt } });

--- a/src/frontend/context/SøknadContext.tsx
+++ b/src/frontend/context/SøknadContext.tsx
@@ -1,0 +1,27 @@
+import constate from 'constate';
+
+import { Søknad } from '../typer/søknad';
+
+interface Props {
+    søknad: Søknad;
+    resetSøknad: () => void;
+    resetValideringsfeil: () => void;
+}
+
+const [SøknadProvider, useSøknad] = constate(
+    ({ søknad, resetSøknad, resetValideringsfeil }: Props) => {
+        SøknadProvider.displayName = 'SØKNAD_PROVIDER';
+
+        const resetSøknadOgValideringsfeil = () => {
+            resetSøknad;
+            resetValideringsfeil;
+        };
+
+        return {
+            søknad,
+            resetSøknadOgValideringsfeil,
+        };
+    }
+);
+
+export { SøknadProvider, useSøknad };

--- a/src/frontend/læremidler/LæremidlerApp.tsx
+++ b/src/frontend/læremidler/LæremidlerApp.tsx
@@ -1,11 +1,29 @@
 import React, { useEffect } from 'react';
 
 import Søknadsdialog from './Søknadsdialog';
-import { LæremidlerSøknadProvider } from '../context/LæremiddelSøknadContext';
+import { LæremidlerSøknadProvider, useLæremidlerSøknad } from '../context/LæremiddelSøknadContext';
 import { useSpråk } from '../context/SpråkContext';
-import { ValideringsfeilProvider } from '../context/ValideringsfeilContext';
+import { SøknadProvider } from '../context/SøknadContext';
+import { useValideringsfeil, ValideringsfeilProvider } from '../context/ValideringsfeilContext';
 import { teksterStønad } from '../tekster/stønad';
 import { Stønadstype } from '../typer/stønadstyper';
+
+const LæremidlerInnhold = () => {
+    const { resetValideringsfeil } = useValideringsfeil();
+    const { resetSøknad, hovedytelse } = useLæremidlerSøknad();
+
+    return (
+        <SøknadProvider
+            søknad={{
+                hovedytelse: hovedytelse,
+            }}
+            resetValideringsfeil={resetValideringsfeil}
+            resetSøknad={resetSøknad}
+        >
+            <Søknadsdialog />
+        </SøknadProvider>
+    );
+};
 
 const LæremidlerApp = () => {
     const { locale } = useSpråk();
@@ -18,7 +36,7 @@ const LæremidlerApp = () => {
     return (
         <ValideringsfeilProvider>
             <LæremidlerSøknadProvider>
-                <Søknadsdialog />
+                <LæremidlerInnhold />
             </LæremidlerSøknadProvider>
         </ValideringsfeilProvider>
     );

--- a/src/frontend/typer/søknad.ts
+++ b/src/frontend/typer/søknad.ts
@@ -1,6 +1,20 @@
 import { AnnenAktivitetType } from './aktivitet';
-import { EnumFelt, EnumFlereValgFelt, SelectFelt, VerdiFelt } from './skjema';
+import { Barnepass } from './barn';
+import { DokumentasjonFelt, EnumFelt, EnumFlereValgFelt, SelectFelt, VerdiFelt } from './skjema';
 import { Ytelse } from '../components/Hovedytelse/typer';
+
+export type Søknad = SøknadPassAvBarn | SøknadLæremidler;
+
+export interface SøknadPassAvBarn {
+    hovedytelse: Hovedytelse | undefined;
+    aktivitet: Aktivitet | undefined;
+    barnMedBarnepass: Barnepass[];
+    dokumentasjon: DokumentasjonFelt[];
+}
+
+export interface SøknadLæremidler {
+    hovedytelse: Hovedytelse;
+}
 
 export interface Hovedytelse {
     ytelse: EnumFlereValgFelt<Ytelse>;

--- a/src/frontend/typer/søknad.ts
+++ b/src/frontend/typer/søknad.ts
@@ -13,7 +13,7 @@ export interface SøknadPassAvBarn {
 }
 
 export interface SøknadLæremidler {
-    hovedytelse: Hovedytelse;
+    hovedytelse: Hovedytelse | undefined;
 }
 
 export interface Hovedytelse {

--- a/src/frontend/utils/routes.ts
+++ b/src/frontend/utils/routes.ts
@@ -1,6 +1,14 @@
-import { RoutesBarnetilsyn, barnetilsynPath } from '../barnetilsyn/routing/routesBarnetilsyn';
-import { læremidlerPath, routesLæremidler } from '../læremidler/routing/routesLæremidler';
-import { IRoute } from '../typer/routes';
+import {
+    ERouteBarnetilsyn,
+    RoutesBarnetilsyn,
+    barnetilsynPath,
+} from '../barnetilsyn/routing/routesBarnetilsyn';
+import {
+    ERouteLæremidler,
+    læremidlerPath,
+    routesLæremidler,
+} from '../læremidler/routing/routesLæremidler';
+import { IRoute, RouteType } from '../typer/routes';
 import { Stønadstype } from '../typer/stønadstyper';
 
 export const hentRoutes = (stønadstype: Stønadstype): IRoute[] => {
@@ -29,4 +37,12 @@ export const hentStartRoute = (stønadstype: Stønadstype) => {
         case Stønadstype.LÆREMIDLER:
             return læremidlerPath;
     }
+};
+
+export const erOppsummeringsside = (route: RouteType): boolean => {
+    if (route === ERouteBarnetilsyn.OPPSUMMERING || route === ERouteLæremidler.OPPSUMMERING) {
+        return true;
+    }
+
+    return false;
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Komponenten `Side` er avhengig av feltene for å bygge opp en søknad som skal sendes inn og resette alt. 
Nå hentes dette fra `SøknadContext` som lages i de ulike søknadene ved å samle de ulike statene fra de andre contextene. 

Alternativt kunne man hatt ulike side-komponenter eller sendt inn søknad som prop på oppsummering. Sistnevnte føltes litt skjult :/