### PR TITLE
✨ Lag ny header etter mal fra aksel

### DIFF
--- a/src/frontend/components/Header.tsx
+++ b/src/frontend/components/Header.tsx
@@ -1,0 +1,34 @@
+import styled from 'styled-components';
+
+import { BodyShort, Heading, VStack } from '@navikt/ds-react';
+import { ABreakpointMd } from '@navikt/ds-tokens/dist/tokens';
+
+import LocaleTekst from './Teksthåndtering/LocaleTekst';
+import { useSøknad } from '../context/SøknadContext';
+import { stønadstypeTilSkjemaId } from '../typer/skjemanavn';
+import { TekstElement } from '../typer/tekst';
+
+const Container = styled.div`
+    padding: 2rem 1rem 0.5rem 1rem;
+
+    @media (min-width: ${ABreakpointMd}) {
+        max-width: 35rem;
+        margin: auto;
+        padding: 2rem 0 0.5rem 0;
+    }
+`;
+
+export const Header: React.FC<{ tittel: TekstElement<string> }> = ({ tittel }) => {
+    const { stønadstype } = useSøknad();
+
+    return (
+        <Container>
+            <VStack gap="2">
+                <BodyShort>{stønadstypeTilSkjemaId[stønadstype]}</BodyShort>
+                <Heading size="xlarge" as="h1">
+                    <LocaleTekst tekst={tittel} />
+                </Heading>
+            </VStack>
+        </Container>
+    );
+};

--- a/src/frontend/læremidler/Søknadsdialog.tsx
+++ b/src/frontend/læremidler/Søknadsdialog.tsx
@@ -6,7 +6,7 @@ import HovedytelseLæremidler from './steg/1-hovedytelse/HovedytelseLæremidler'
 import Utdanning from './steg/2-utdanning/Utdanning';
 import VedleggLæremidler from './steg/3-vedlegg/VedleggLæremidler';
 import Oppsummering from './steg/4-oppsummering/Oppsummering';
-import { Banner } from '../components/Banner';
+import { Header } from '../components/Header';
 import Kvittering from '../components/Kvittering/Kvittering';
 import RedirectTilStart from '../components/RedirectTilStart';
 import { useLæremidlerSøknad } from '../context/LæremiddelSøknadContext';
@@ -15,7 +15,7 @@ import { fellesTekster } from '../tekster/felles';
 const Søknadsdialog: React.FC = () => {
     return (
         <>
-            <Banner tittel={fellesTekster.banner_læremidler} />
+            <Header tittel={fellesTekster.banner_læremidler} />
             <Routes>
                 <Route path={'/'} element={<Forside />} />
                 <Route path={'*'} element={<SøknadsdialogInnhold />} />


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Kan brukes på barnetilsyn og andre stønader også. Vi var ikke helt sikre på om hvordan dette ble uten ikonet så derfor er det laget en ny som bare brukes på læremidler midlertidig

<img width="847" alt="image" src="https://github.com/user-attachments/assets/69312c4b-96d4-4201-b307-9a79a5c468ce">

<img width="847" alt="image" src="https://github.com/user-attachments/assets/62e69926-cf73-477f-966c-f2425579d46f">

Mobil: 
<img width="394" alt="image" src="https://github.com/user-attachments/assets/15273f7f-0a09-4171-b02b-63152fd3ce10">
<img width="394" alt="image" src="https://github.com/user-attachments/assets/5b9f9934-1616-4efd-ab15-c56bf3d977cb">
