### PR TITLE
Routing læremidler

### DIFF
--- a/src/frontend/api/Environment.ts
+++ b/src/frontend/api/Environment.ts
@@ -1,10 +1,12 @@
+import { Stønadstype } from '../typer/stønadstyper';
+
 interface EnvironmentProps {
     apiProxyUrl: string;
     vedleggProxyUrl: string;
     wonderwallUrl: string;
     sentryUrl?: string;
-    urlGammelSøknad: string;
-    urlPapirsøknad: string;
+    urlGammelSøknad: (stønadstype: Stønadstype) => string;
+    urlPapirsøknad: (stønadstype: Stønadstype) => string;
     miljø: string;
     modellVersjon: IModellversjon;
 }
@@ -12,6 +14,23 @@ interface EnvironmentProps {
 interface IModellversjon {
     barnetilsyn: number;
 }
+
+const StønadstypeTilFyllutSkjema: Record<Stønadstype, string> = {
+    BARNETILSYN: 'nav111215b',
+    LÆREMIDLER: 'nav111216b',
+};
+
+const urlGammelSøknadProd = (stønadstype: Stønadstype) =>
+    `https://www.nav.no/fyllut/${StønadstypeTilFyllutSkjema[stønadstype]}?sub=digital`;
+
+const urlGammelSøknadDev = (stønadstype: Stønadstype) =>
+    `https://skjemadelingslenke.ekstern.dev.nav.no/fyllut/${StønadstypeTilFyllutSkjema[stønadstype]}?sub=digital`;
+
+const urlPapirsøknadProd = (stønadstype: Stønadstype) =>
+    `https://www.nav.no/fyllut/${StønadstypeTilFyllutSkjema[stønadstype]}?sub=paper`;
+
+const urlPapirsøknadDev = (stønadstype: Stønadstype) =>
+    `https://skjemadelingslenke.ekstern.dev.nav.no/fyllut/${StønadstypeTilFyllutSkjema[stønadstype]}?sub=paper`;
 
 const Environment = (): EnvironmentProps => {
     const modellVersjon = { overgangsstønad: 7, barnetilsyn: 2, skolepenger: 2 };
@@ -24,21 +43,19 @@ const Environment = (): EnvironmentProps => {
             wonderwallUrl:
                 'https://tilleggsstonader.ekstern.dev.nav.no/tilleggsstonader/soknad/oauth2/login?redirect=',
             sentryUrl: 'https://06b839ad5487467cb88097c5a27bbbb5@sentry.gc.nav.no/167',
-            urlGammelSøknad:
-                'https://skjemadelingslenke.ekstern.dev.nav.no/fyllut/nav111215b?sub=digital',
-            urlPapirsøknad:
-                'https://skjemadelingslenke.ekstern.dev.nav.no/fyllut/nav111215b?sub=paper',
+            urlGammelSøknad: urlGammelSøknadDev,
+            urlPapirsøknad: urlPapirsøknadDev,
             miljø: 'preprod',
             modellVersjon: modellVersjon,
         };
-    } else if (window.location.hostname.indexOf('www') > -1) {
+    } else if (window.location.hostname.indexOf('nav.no') > -1) {
         return {
             apiProxyUrl: 'https://www.nav.no/tilleggsstonader/soknad/api',
             vedleggProxyUrl: 'https://www.nav.no/tilleggsstonader/soknad/api/vedlegg',
             wonderwallUrl: 'https://www.nav.no/tilleggsstonader/soknad/oauth2/login?redirect=',
             sentryUrl: 'https://06b839ad5487467cb88097c5a27bbbb5@sentry.gc.nav.no/167',
-            urlGammelSøknad: 'https://www.nav.no/fyllut/nav111215b?sub=digital',
-            urlPapirsøknad: 'https://www.nav.no/fyllut/nav111215b?sub=paper',
+            urlGammelSøknad: urlGammelSøknadProd,
+            urlPapirsøknad: urlPapirsøknadProd,
             miljø: 'production',
             modellVersjon: modellVersjon,
         };
@@ -47,10 +64,8 @@ const Environment = (): EnvironmentProps => {
             apiProxyUrl: 'http://localhost:8080/api',
             vedleggProxyUrl: 'http://localhost:8080/api/vedlegg/tillegg',
             wonderwallUrl: `http://localhost:8001/test/cookie?redirect=`,
-            urlGammelSøknad:
-                'https://skjemadelingslenke.ekstern.dev.nav.no/fyllut/nav111215b?sub=digital',
-            urlPapirsøknad:
-                'https://skjemadelingslenke.ekstern.dev.nav.no/fyllut/nav111215b?sub=paper',
+            urlGammelSøknad: urlGammelSøknadDev,
+            urlPapirsøknad: urlPapirsøknadDev,
             miljø: 'local',
             modellVersjon: modellVersjon,
         };

--- a/src/frontend/api/api.ts
+++ b/src/frontend/api/api.ts
@@ -19,9 +19,12 @@ export const defaultConfig = () => ({
     withCredentials: true,
 });
 
-export const hentPersonData = (): Promise<Person> => {
+export const hentPersonData = (medBarn: boolean): Promise<Person> => {
     return axios
-        .get<Person>(`${Environment().apiProxyUrl}/person`, defaultConfig())
+        .get<Person>(
+            `${Environment().apiProxyUrl}/person${medBarn ? '/med-barn' : ''}`,
+            defaultConfig()
+        )
         .then((response) => response.data);
 };
 

--- a/src/frontend/barnetilsyn/BarnetilsynApp.tsx
+++ b/src/frontend/barnetilsyn/BarnetilsynApp.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 
 import Søknadsdialog from './Søknadsdialog';
+import { PersonRouting } from '../components/PersonRouting';
 import SøknadRouting from '../components/SøknadRouting/SøknadRouting';
 import { PassAvBarnSøknadProvider, usePassAvBarnSøknad } from '../context/PassAvBarnSøknadContext';
 import { useSpråk } from '../context/SpråkContext';
@@ -41,11 +42,13 @@ const BarnetilsynApp = () => {
     }, [locale]);
 
     return (
-        <ValideringsfeilProvider>
-            <PassAvBarnSøknadProvider>
-                <BarnetilsynInnhold />
-            </PassAvBarnSøknadProvider>
-        </ValideringsfeilProvider>
+        <PersonRouting stønadstype={Stønadstype.BARNETILSYN}>
+            <ValideringsfeilProvider>
+                <PassAvBarnSøknadProvider>
+                    <BarnetilsynInnhold />
+                </PassAvBarnSøknadProvider>
+            </ValideringsfeilProvider>
+        </PersonRouting>
     );
 };
 

--- a/src/frontend/components/PersonRouting.tsx
+++ b/src/frontend/components/PersonRouting.tsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from 'react';
+
+import axios, { AxiosError } from 'axios';
+
+import { sendSøkerTilPapirsøknad } from './SøknadRouting/sendSøkerTilGammelSøknad';
+import { hentPersonData } from '../api/api';
+import { PersonProvider } from '../context/PersonContext';
+import { initiellPerson } from '../mock/initiellPerson';
+import { Person } from '../typer/person';
+import { Stønadstype } from '../typer/stønadstyper';
+
+const erFeilOgSkalRouteTilPapirsøknad = (req: AxiosError<{ detail?: string }, unknown>) => {
+    return req?.response?.data?.detail === 'ROUTING_GAMMEL_SØKNAD';
+};
+
+export const PersonRouting: React.FC<{ stønadstype: Stønadstype; children: React.ReactNode }> = ({
+    //stønadstype,
+    children,
+}) => {
+    const [person, settPerson] = useState<Person>(initiellPerson);
+    const [harLastetPerson, settHarLastetPerson] = useState<boolean>(false);
+    const [feilmelding, settFeilmelding] = useState<string>();
+
+    useEffect(() => {
+        // TODO hent data basert på om brukeren skal ha barn eller ikke, kun barn-kall kan ev sende til papirsøknad
+        hentPersonData()
+            .then((resp) => {
+                settPerson(resp);
+                settHarLastetPerson(true);
+            })
+            .catch((req) => {
+                if (axios.isAxiosError(req) && erFeilOgSkalRouteTilPapirsøknad(req)) {
+                    sendSøkerTilPapirsøknad();
+                } else {
+                    settFeilmelding(
+                        'Feilet henting av personopplysninger. Prøv å laste inn siden på nytt'
+                    );
+                }
+            });
+    }, []);
+
+    if (feilmelding) {
+        return <div>{feilmelding}</div>;
+    }
+    if (!harLastetPerson) {
+        return null;
+    }
+
+    return <PersonProvider person={person}>{children}</PersonProvider>;
+};

--- a/src/frontend/components/PersonRouting.tsx
+++ b/src/frontend/components/PersonRouting.tsx
@@ -13,6 +13,11 @@ const erFeilOgSkalRouteTilPapirsøknad = (req: AxiosError<{ detail?: string }, u
     return req?.response?.data?.detail === 'ROUTING_GAMMEL_SØKNAD';
 };
 
+const stønadstyperMedBarn = [Stønadstype.BARNETILSYN];
+
+const skalHenteMedBarn = (stønadstype: Stønadstype) =>
+    stønadstyperMedBarn.indexOf(stønadstype) > -1;
+
 export const PersonRouting: React.FC<{ stønadstype: Stønadstype; children: React.ReactNode }> = ({
     stønadstype,
     children,
@@ -22,8 +27,7 @@ export const PersonRouting: React.FC<{ stønadstype: Stønadstype; children: Rea
     const [feilmelding, settFeilmelding] = useState<string>();
 
     useEffect(() => {
-        // TODO hent data basert på om brukeren skal ha barn eller ikke, kun barn-kall kan ev sende til papirsøknad
-        hentPersonData()
+        hentPersonData(skalHenteMedBarn(stønadstype))
             .then((resp) => {
                 settPerson(resp);
                 settHarLastetPerson(true);

--- a/src/frontend/components/PersonRouting.tsx
+++ b/src/frontend/components/PersonRouting.tsx
@@ -14,7 +14,7 @@ const erFeilOgSkalRouteTilPapirsøknad = (req: AxiosError<{ detail?: string }, u
 };
 
 export const PersonRouting: React.FC<{ stønadstype: Stønadstype; children: React.ReactNode }> = ({
-    //stønadstype,
+    stønadstype,
     children,
 }) => {
     const [person, settPerson] = useState<Person>(initiellPerson);
@@ -30,14 +30,14 @@ export const PersonRouting: React.FC<{ stønadstype: Stønadstype; children: Rea
             })
             .catch((req) => {
                 if (axios.isAxiosError(req) && erFeilOgSkalRouteTilPapirsøknad(req)) {
-                    sendSøkerTilPapirsøknad();
+                    sendSøkerTilPapirsøknad(stønadstype);
                 } else {
                     settFeilmelding(
                         'Feilet henting av personopplysninger. Prøv å laste inn siden på nytt'
                     );
                 }
             });
-    }, []);
+    }, [stønadstype]);
 
     if (feilmelding) {
         return <div>{feilmelding}</div>;

--- a/src/frontend/components/SøknadRouting/SøknadRouting.tsx
+++ b/src/frontend/components/SøknadRouting/SøknadRouting.tsx
@@ -20,7 +20,7 @@ const SøknadRouting: React.FC<{ stønadstype: Stønadstype; children: React.Rea
         case RoutingState.FEILET:
             return <Alert variant="error">Noe gikk galt! Prøv å laste siden på nytt.</Alert>;
         case RoutingState.GAMMEL:
-            sendSøkerTilGammelSøknad();
+            sendSøkerTilGammelSøknad(stønadstype);
             return null;
     }
 };

--- a/src/frontend/components/SøknadRouting/sendSøkerTilGammelSøknad.ts
+++ b/src/frontend/components/SøknadRouting/sendSøkerTilGammelSøknad.ts
@@ -5,6 +5,6 @@ export const sendSøkerTilGammelSøknad = (stønadstype: Stønadstype) => {
     window.location.href = Environment().urlGammelSøknad(stønadstype);
 };
 
-export const sendSøkerTilPapirsøknad = () => {
-    window.location.href = Environment().urlPapirsøknad(Stønadstype.BARNETILSYN); // TODO
+export const sendSøkerTilPapirsøknad = (stønadstype: Stønadstype) => {
+    window.location.href = Environment().urlPapirsøknad(stønadstype);
 };

--- a/src/frontend/components/SøknadRouting/sendSøkerTilGammelSøknad.ts
+++ b/src/frontend/components/SøknadRouting/sendSøkerTilGammelSøknad.ts
@@ -1,9 +1,10 @@
 import Environment from '../../api/Environment';
+import { Stønadstype } from '../../typer/stønadstyper';
 
-export const sendSøkerTilGammelSøknad = () => {
-    window.location.href = Environment().urlGammelSøknad;
+export const sendSøkerTilGammelSøknad = (stønadstype: Stønadstype) => {
+    window.location.href = Environment().urlGammelSøknad(stønadstype);
 };
 
 export const sendSøkerTilPapirsøknad = () => {
-    window.location.href = Environment().urlPapirsøknad;
+    window.location.href = Environment().urlPapirsøknad(Stønadstype.BARNETILSYN); // TODO
 };

--- a/src/frontend/context/PersonContext.tsx
+++ b/src/frontend/context/PersonContext.tsx
@@ -1,42 +1,14 @@
-import { useEffect, useState } from 'react';
+import constate from 'constate';
 
-import axios, { AxiosError } from 'axios';
-import createUseContext from 'constate';
-
-import { hentPersonData } from '../api/api';
-import { sendSøkerTilPapirsøknad } from '../components/SøknadRouting/sendSøkerTilGammelSøknad';
-import { initiellPerson } from '../mock/initiellPerson';
 import { Person } from '../typer/person';
 
-const erFeilOgSkalRouteTilPapirsøknad = (req: AxiosError<{ detail?: string }, unknown>) => {
-    return req?.response?.data?.detail === 'ROUTING_GAMMEL_SØKNAD';
-};
+interface Props {
+    person: Person;
+}
 
-const [PersonProvider, usePerson] = createUseContext(() => {
+const [PersonProvider, usePerson] = constate(({ person }: Props) => {
     PersonProvider.displayName = 'PERSON_PROVIDER';
-    const [person, settPerson] = useState<Person>(initiellPerson);
-    const [harLastetPerson, settHarLastetPerson] = useState<boolean>(false);
-    const [feilmelding, settFeilmelding] = useState<string>();
-
-    useEffect(() => {
-        hentPersonData()
-            .then((resp) => {
-                settPerson(resp);
-                settHarLastetPerson(true);
-            })
-            .catch((req) => {
-                if (axios.isAxiosError(req) && erFeilOgSkalRouteTilPapirsøknad(req)) {
-                    sendSøkerTilPapirsøknad();
-                } else {
-                    // TODO noe bedre håndtering?
-                    settFeilmelding(
-                        'Feiltet henting av personopplysninger. Prøv å laste inn siden på nytt'
-                    );
-                }
-            });
-    }, []);
-
-    return { harLastetPerson, feilmelding, person, settPerson };
+    return { person };
 });
 
 export { PersonProvider, usePerson };

--- a/src/frontend/index.tsx
+++ b/src/frontend/index.tsx
@@ -10,7 +10,6 @@ import { initSentry } from './api/Sentry';
 import BarnetilsynApp from './barnetilsyn/BarnetilsynApp';
 import { barnetilsynPath } from './barnetilsyn/routing/routesBarnetilsyn';
 import ScrollToTop from './components/ScrollToTop';
-import { PersonProvider, usePerson } from './context/PersonContext';
 import { SpråkProvider } from './context/SpråkContext';
 import LæremidlerApp from './læremidler/LæremidlerApp';
 import { læremidlerPath } from './læremidler/routing/routesLæremidler';
@@ -25,21 +24,6 @@ const root = createRoot(rootElement!);
 initAmplitude();
 
 const AppRoutes = () => {
-    const { harLastetPerson, feilmelding } = usePerson();
-
-    if (feilmelding) {
-        return (
-            <BrowserRouter basename={process.env.PUBLIC_URL}>
-                <Routes>
-                    <Route path={'*'} element={<div>{feilmelding}</div>} />
-                </Routes>
-            </BrowserRouter>
-        );
-    }
-    if (!harLastetPerson) {
-        return null;
-    }
-
     return (
         <BrowserRouter basename={process.env.PUBLIC_URL}>
             <ScrollToTop />
@@ -56,9 +40,7 @@ const AppRoutes = () => {
 root.render(
     <main id={'maincontent'} tabIndex={-1}>
         <SpråkProvider>
-            <PersonProvider>
-                <AppRoutes />
-            </PersonProvider>
+            <AppRoutes />
         </SpråkProvider>
     </main>
 );

--- a/src/frontend/læremidler/LæremidlerApp.tsx
+++ b/src/frontend/læremidler/LæremidlerApp.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 
 import Søknadsdialog from './Søknadsdialog';
+import { PersonRouting } from '../components/PersonRouting';
 import { LæremidlerSøknadProvider, useLæremidlerSøknad } from '../context/LæremiddelSøknadContext';
 import { useSpråk } from '../context/SpråkContext';
 import { SøknadProvider } from '../context/SøknadContext';
@@ -37,11 +38,13 @@ const LæremidlerApp = () => {
 
     // TODO: Implementer logikk for routing
     return (
-        <ValideringsfeilProvider>
-            <LæremidlerSøknadProvider>
-                <LæremidlerInnhold />
-            </LæremidlerSøknadProvider>
-        </ValideringsfeilProvider>
+        <PersonRouting stønadstype={Stønadstype.LÆREMIDLER}>
+            <ValideringsfeilProvider>
+                <LæremidlerSøknadProvider>
+                    <LæremidlerInnhold />
+                </LæremidlerSøknadProvider>
+            </ValideringsfeilProvider>
+        </PersonRouting>
     );
 };
 

--- a/src/frontend/læremidler/LæremidlerApp.tsx
+++ b/src/frontend/læremidler/LæremidlerApp.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 
 import Søknadsdialog from './Søknadsdialog';
 import { PersonRouting } from '../components/PersonRouting';
+import SøknadRouting from '../components/SøknadRouting/SøknadRouting';
 import { LæremidlerSøknadProvider, useLæremidlerSøknad } from '../context/LæremiddelSøknadContext';
 import { useSpråk } from '../context/SpråkContext';
 import { SøknadProvider } from '../context/SøknadContext';
@@ -24,7 +25,9 @@ const LæremidlerInnhold = () => {
             resetValideringsfeil={resetValideringsfeil}
             resetSøknad={resetSøknad}
         >
-            <Søknadsdialog />
+            <SøknadRouting stønadstype={Stønadstype.LÆREMIDLER}>
+                <Søknadsdialog />
+            </SøknadRouting>
         </SøknadProvider>
     );
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skal kun route noen få personer i prod i starten

* Routing til gammel søknad avhengig av stønadstype
* Routing til papirsøknad avhengig av stønadstypen
  * Av denne grunnen er håndteringen av PersonProvider endret, sånn at man må sende inn stønadstype
 
Henting av person gjøres nå avhengig av stønadstype, dette er pga 2 årsaker
* Skal route til riktig papirsøknad (avhengig av stønadstype) i tilfelle barn har høyere gradering enn søker 
* Trenger ikke å hente barn i for læremidler, og trenger ikke å sjekke gradering på barn for disse tilfellene.

❗ Se gjerne commit etter commit 💬

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-22340

Koblet til
* https://github.com/navikt/tilleggsstonader-soknad-api/commit/66016b05d07e1c649db20c2faef7dabef10be535
* https://github.com/navikt/tilleggsstonader-soknad-api/pull/137