### PR TITLE
Endrer ArbeidsrettedeAktiviteter til en felleskomponent

### DIFF
--- a/src/frontend/barnetilsyn/BarnetilsynApp.tsx
+++ b/src/frontend/barnetilsyn/BarnetilsynApp.tsx
@@ -4,6 +4,7 @@ import Søknadsdialog from './Søknadsdialog';
 import { PersonRouting } from '../components/PersonRouting';
 import SøknadRouting from '../components/SøknadRouting/SøknadRouting';
 import { PassAvBarnSøknadProvider, usePassAvBarnSøknad } from '../context/PassAvBarnSøknadContext';
+import { RegisterAktiviteterProvider } from '../context/RegisterAktiviteterContext';
 import { useSpråk } from '../context/SpråkContext';
 import { SøknadProvider } from '../context/SøknadContext';
 import { useValideringsfeil, ValideringsfeilProvider } from '../context/ValideringsfeilContext';
@@ -45,7 +46,9 @@ const BarnetilsynApp = () => {
         <PersonRouting stønadstype={Stønadstype.BARNETILSYN}>
             <ValideringsfeilProvider>
                 <PassAvBarnSøknadProvider>
-                    <BarnetilsynInnhold />
+                    <RegisterAktiviteterProvider>
+                        <BarnetilsynInnhold />
+                    </RegisterAktiviteterProvider>
                 </PassAvBarnSøknadProvider>
             </ValideringsfeilProvider>
         </PersonRouting>

--- a/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
+++ b/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
@@ -5,10 +5,13 @@ import { Alert, Heading, Label, List, VStack } from '@navikt/ds-react';
 import { AnnenArbeidsrettetAktivitet } from './AnnenArbeidsrettetAktivitet';
 import { LesMerHvilkenAktivitet } from './LesMerHvilkenAktivitet';
 import { LønnetTiltak } from './LønnetTiltak';
-import { skalTaStillingTilLønnetTiltak, skalTaStillingTilRegisterAktiviteter } from './utils';
+import { skalTaStillingTilLønnetTiltak } from './utils';
 import { feilAnnenAktivitet, feilLønnetAktivitet, feilValgtAktivitet } from './validering';
 import ArbeidsrettedeAktiviteter from '../../../components/Aktivitet/ArbeidsrettedeAktiviteter';
-import { skalTaStillingTilAnnenAktivitet } from '../../../components/Aktivitet/registerAktivitetUtil';
+import {
+    skalTaStillingTilAnnenAktivitet,
+    skalTaStillingTilRegisterAktiviteter,
+} from '../../../components/Aktivitet/registerAktivitetUtil';
 import { PellePanel } from '../../../components/PellePanel/PellePanel';
 import Side from '../../../components/Side';
 import LocaleInlineLenke from '../../../components/Teksthåndtering/LocaleInlineLenke';

--- a/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
+++ b/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
@@ -153,6 +153,7 @@ const Aktivitet = () => {
             </PellePanel>
             {skalViseArbeidsrettedeAktiviteter && (
                 <ArbeidsrettedeAktiviteter
+                    spørsmål={aktivitetTekster.hvilken_aktivitet.spm}
                     registerAktiviteter={registerAktiviteter}
                     oppdaterValgteAktiviteter={oppdaterValgteAktiviteter}
                     locale={locale}

--- a/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
+++ b/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
@@ -161,7 +161,6 @@ const Aktivitet = () => {
                     }
                     registerAktiviteter={registerAktiviteter}
                     oppdaterValgteAktiviteter={oppdaterValgteAktiviteter}
-                    locale={locale}
                     valgteAktiviteter={valgteAktiviteter}
                     feilmelding={valideringsfeil.valgteAktiviteter}
                 />

--- a/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
+++ b/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
@@ -5,13 +5,10 @@ import { Alert, Heading, Label, List, VStack } from '@navikt/ds-react';
 import { AnnenArbeidsrettetAktivitet } from './AnnenArbeidsrettetAktivitet';
 import { LesMerHvilkenAktivitet } from './LesMerHvilkenAktivitet';
 import { LønnetTiltak } from './LønnetTiltak';
-import {
-    skalTaStillingTilAnnenAktivitet,
-    skalTaStillingTilLønnetTiltak,
-    skalTaStillingTilRegisterAktiviteter,
-} from './utils';
+import { skalTaStillingTilLønnetTiltak, skalTaStillingTilRegisterAktiviteter } from './utils';
 import { feilAnnenAktivitet, feilLønnetAktivitet, feilValgtAktivitet } from './validering';
 import ArbeidsrettedeAktiviteter from '../../../components/Aktivitet/ArbeidsrettedeAktiviteter';
+import { skalTaStillingTilAnnenAktivitet } from '../../../components/Aktivitet/registerAktivitetUtil';
 import { PellePanel } from '../../../components/PellePanel/PellePanel';
 import Side from '../../../components/Side';
 import LocaleInlineLenke from '../../../components/Teksthåndtering/LocaleInlineLenke';

--- a/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
+++ b/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
@@ -3,7 +3,6 @@ import React, { useState } from 'react';
 import { Alert, Heading, Label, List, VStack } from '@navikt/ds-react';
 
 import { AnnenArbeidsrettetAktivitet } from './AnnenArbeidsrettetAktivitet';
-import ArbeidsrettedeAktiviteter from './ArbeidsrettedeAktiviteter';
 import { LesMerHvilkenAktivitet } from './LesMerHvilkenAktivitet';
 import { LønnetTiltak } from './LønnetTiltak';
 import {
@@ -12,6 +11,7 @@ import {
     skalTaStillingTilRegisterAktiviteter,
 } from './utils';
 import { feilAnnenAktivitet, feilLønnetAktivitet, feilValgtAktivitet } from './validering';
+import ArbeidsrettedeAktiviteter from '../../../components/Aktivitet/ArbeidsrettedeAktiviteter';
 import { PellePanel } from '../../../components/PellePanel/PellePanel';
 import Side from '../../../components/Side';
 import LocaleInlineLenke from '../../../components/Teksthåndtering/LocaleInlineLenke';

--- a/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
+++ b/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
@@ -154,6 +154,11 @@ const Aktivitet = () => {
             {skalViseArbeidsrettedeAktiviteter && (
                 <ArbeidsrettedeAktiviteter
                     spørsmål={aktivitetTekster.hvilken_aktivitet.spm}
+                    lesMer={
+                        <LesMerHvilkenAktivitet
+                            header={aktivitetTekster.hvilken_aktivitet.les_mer.header}
+                        />
+                    }
                     registerAktiviteter={registerAktiviteter}
                     oppdaterValgteAktiviteter={oppdaterValgteAktiviteter}
                     locale={locale}

--- a/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
+++ b/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 
 import { Alert, Heading, Label, List, VStack } from '@navikt/ds-react';
 
@@ -12,8 +12,6 @@ import {
     skalTaStillingTilRegisterAktiviteter,
 } from './utils';
 import { feilAnnenAktivitet, feilLønnetAktivitet, feilValgtAktivitet } from './validering';
-import { hentArbeidsrettedeAktiviteter } from '../../../api/api';
-import { mapTilRegisterAktiviteterObjektMedLabel } from '../../../components/Aktivitet/registerAktivitetUtil';
 import { PellePanel } from '../../../components/PellePanel/PellePanel';
 import Side from '../../../components/Side';
 import LocaleInlineLenke from '../../../components/Teksthåndtering/LocaleInlineLenke';
@@ -21,10 +19,10 @@ import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
 import LocaleTekstAvsnitt from '../../../components/Teksthåndtering/LocaleTekstAvsnitt';
 import { UnderspørsmålContainer } from '../../../components/UnderspørsmålContainer';
 import { usePassAvBarnSøknad } from '../../../context/PassAvBarnSøknadContext';
+import { useRegisterAktiviteter } from '../../../context/RegisterAktiviteterContext';
 import { useSpråk } from '../../../context/SpråkContext';
 import { useValideringsfeil } from '../../../context/ValideringsfeilContext';
 import { AnnenAktivitetType } from '../../../typer/aktivitet';
-import { RegisterAktivitetMedLabel } from '../../../typer/registerAktivitet';
 import { EnumFelt, EnumFlereValgFelt } from '../../../typer/skjema';
 import { JaNei } from '../../../typer/søknad';
 import { inneholderFeil, Valideringsfeil } from '../../../typer/validering';
@@ -34,13 +32,11 @@ const Aktivitet = () => {
     const { locale } = useSpråk();
     const { valideringsfeil, settValideringsfeil } = useValideringsfeil();
     const { aktivitet, settAktivitet } = usePassAvBarnSøknad();
+    const { registerAktiviteter } = useRegisterAktiviteter();
 
     const [valgteAktiviteter, settValgteAktiviteter] = useState<
         EnumFlereValgFelt<string> | undefined
     >(aktivitet ? aktivitet.aktiviteter : undefined);
-
-    const [registerAktiviteter, settRegisterAktiviteter] =
-        useState<Record<string, RegisterAktivitetMedLabel>>();
 
     const [annenAktivitet, setAnnenAktivitet] = useState<EnumFelt<AnnenAktivitetType> | undefined>(
         aktivitet ? aktivitet.annenAktivitet : undefined
@@ -49,16 +45,6 @@ const Aktivitet = () => {
     const [lønnetAktivitet, setLønnetAktivitet] = useState<EnumFelt<JaNei> | undefined>(
         aktivitet ? aktivitet.lønnetAktivitet : undefined
     );
-    useEffect(() => {
-        hentArbeidsrettedeAktiviteter()
-            .then((arbeidsrettedeAktiviteter) =>
-                settRegisterAktiviteter(
-                    // {}
-                    mapTilRegisterAktiviteterObjektMedLabel(arbeidsrettedeAktiviteter)
-                )
-            )
-            .catch(() => settRegisterAktiviteter({}));
-    }, []);
 
     const oppdaterAktivitetISøknad = () => {
         settAktivitet({

--- a/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
+++ b/src/frontend/barnetilsyn/steg/3-aktivitet/Aktivitet.tsx
@@ -7,13 +7,13 @@ import ArbeidsrettedeAktiviteter from './ArbeidsrettedeAktiviteter';
 import { LesMerHvilkenAktivitet } from './LesMerHvilkenAktivitet';
 import { LønnetTiltak } from './LønnetTiltak';
 import {
-    mapTilRegisterAktiviteterObjektMedLabel,
     skalTaStillingTilAnnenAktivitet,
     skalTaStillingTilLønnetTiltak,
     skalTaStillingTilRegisterAktiviteter,
 } from './utils';
 import { feilAnnenAktivitet, feilLønnetAktivitet, feilValgtAktivitet } from './validering';
 import { hentArbeidsrettedeAktiviteter } from '../../../api/api';
+import { mapTilRegisterAktiviteterObjektMedLabel } from '../../../components/Aktivitet/registerAktivitetUtil';
 import { PellePanel } from '../../../components/PellePanel/PellePanel';
 import Side from '../../../components/Side';
 import LocaleInlineLenke from '../../../components/Teksthåndtering/LocaleInlineLenke';

--- a/src/frontend/barnetilsyn/steg/3-aktivitet/utils.ts
+++ b/src/frontend/barnetilsyn/steg/3-aktivitet/utils.ts
@@ -2,10 +2,6 @@ import { AnnenAktivitetType } from '../../../typer/aktivitet';
 import { RegisterAktivitetMedLabel } from '../../../typer/registerAktivitet';
 import { EnumFelt, EnumFlereValgFelt } from '../../../typer/skjema';
 
-export const skalTaStillingTilAnnenAktivitet = (
-    valgteAktiviteter: EnumFlereValgFelt<string> | undefined
-): boolean => valgteAktiviteter?.verdier.some((verdi) => verdi.verdi === 'ANNET') ?? false;
-
 export const skalTaStillingTilLønnetTiltak = (
     valgteAktiviteter: EnumFlereValgFelt<string> | undefined,
     annenAktivitet: EnumFelt<AnnenAktivitetType> | undefined,

--- a/src/frontend/barnetilsyn/steg/3-aktivitet/utils.ts
+++ b/src/frontend/barnetilsyn/steg/3-aktivitet/utils.ts
@@ -1,15 +1,7 @@
-import { format } from 'date-fns';
-import { nb } from 'date-fns/locale';
-
 import { AnnenAktivitetType } from '../../../typer/aktivitet';
 import { RegisterAktivitetMedLabel, RegisterAktivitet } from '../../../typer/registerAktivitet';
 import { EnumFelt, EnumFlereValgFelt } from '../../../typer/skjema';
-import { tilDato } from '../../../utils/dato';
-
-//TODO: Legge til støtte for flere Locales enn Norsk Bokmål (nb)
-const tilTekstligDato = (dato: string) => {
-    return format(tilDato(dato), 'd. MMMM yyyy', { locale: nb });
-};
+import { tilTekstligDato } from '../../../utils/dato';
 
 export const mapTilRegisterAktiviteterObjektMedLabel = (
     registerAktiviteter: RegisterAktivitet[]

--- a/src/frontend/barnetilsyn/steg/3-aktivitet/utils.ts
+++ b/src/frontend/barnetilsyn/steg/3-aktivitet/utils.ts
@@ -1,22 +1,6 @@
 import { AnnenAktivitetType } from '../../../typer/aktivitet';
-import { RegisterAktivitetMedLabel, RegisterAktivitet } from '../../../typer/registerAktivitet';
+import { RegisterAktivitetMedLabel } from '../../../typer/registerAktivitet';
 import { EnumFelt, EnumFlereValgFelt } from '../../../typer/skjema';
-import { tilTekstligDato } from '../../../utils/dato';
-
-export const mapTilRegisterAktiviteterObjektMedLabel = (
-    registerAktiviteter: RegisterAktivitet[]
-): Record<string, RegisterAktivitetMedLabel> => {
-    return registerAktiviteter.reduce(
-        (acc, curr) => ({
-            ...acc,
-            [curr.id]: {
-                ...curr,
-                label: `${curr.typeNavn}: ${tilTekstligDato(curr.fom)} - ${curr.tom ? tilTekstligDato(curr.tom) : ''}`,
-            },
-        }),
-        {} as Record<string, RegisterAktivitetMedLabel>
-    );
-};
 
 export const skalTaStillingTilAnnenAktivitet = (
     valgteAktiviteter: EnumFlereValgFelt<string> | undefined

--- a/src/frontend/barnetilsyn/steg/3-aktivitet/utils.ts
+++ b/src/frontend/barnetilsyn/steg/3-aktivitet/utils.ts
@@ -16,7 +16,3 @@ export const skalTaStillingTilLønnetTiltak = (
         return aktivitet && !aktivitet.erUtdanning;
     });
 };
-
-export const skalTaStillingTilRegisterAktiviteter = (
-    registerAktiviteter: Record<string, RegisterAktivitetMedLabel>
-): boolean => Object.keys(registerAktiviteter).length > 0;

--- a/src/frontend/barnetilsyn/tekster/aktivitet.ts
+++ b/src/frontend/barnetilsyn/tekster/aktivitet.ts
@@ -27,7 +27,6 @@ interface AktivitetInnhold {
 
 interface HvilkenAktivitet {
     spm: TekstElement<string>;
-    checkboks_annet_tekst: TekstElement<string>;
     les_mer: {
         header: TekstElement<string>;
         header_ingen_registrerte_aktiviteter: TekstElement<string>;
@@ -63,7 +62,6 @@ export const AktivitetTypeTilTekst: Record<AnnenAktivitetType, TekstElement<stri
 
 const hvilkenAktivitet: HvilkenAktivitet = {
     spm: { nb: 'Hvilken aktivitet søker du om støtte i forbindelse med?' },
-    checkboks_annet_tekst: { nb: 'Annet' },
     les_mer: {
         header: {
             nb: 'Hva gjør jeg hvis noe mangler eller er feil?',

--- a/src/frontend/barnetilsyn/tekster/aktivitet.ts
+++ b/src/frontend/barnetilsyn/tekster/aktivitet.ts
@@ -1,3 +1,4 @@
+import { tekstArbeidsrettedeAktiviteter } from '../../tekster/aktivitet';
 import { JaNeiTilTekst } from '../../tekster/felles';
 import { AnnenAktivitetType } from '../../typer/aktivitet';
 import { JaNei } from '../../typer/søknad';
@@ -63,12 +64,9 @@ export const AktivitetTypeTilTekst: Record<AnnenAktivitetType, TekstElement<stri
 const hvilkenAktivitet: HvilkenAktivitet = {
     spm: { nb: 'Hvilken aktivitet søker du om støtte i forbindelse med?' },
     les_mer: {
-        header: {
-            nb: 'Hva gjør jeg hvis noe mangler eller er feil?',
-        },
-        header_ingen_registrerte_aktiviteter: {
-            nb: 'Hva gjør jeg hvis noe mangler?',
-        },
+        header: tekstArbeidsrettedeAktiviteter.lesMer.header,
+        header_ingen_registrerte_aktiviteter:
+            tekstArbeidsrettedeAktiviteter.lesMer.header_ingen_registrerte_aktiviteter,
         del1: {
             nb: [
                 'Vi henter tiltak og utdanning registrert på deg 3 måneder tilbake i tid. Er du registrert arbeidssøker kan vi ikke hente det.',

--- a/src/frontend/barnetilsyn/tekster/aktivitet.ts
+++ b/src/frontend/barnetilsyn/tekster/aktivitet.ts
@@ -101,9 +101,9 @@ const hvilkenAktivitet: HvilkenAktivitet = {
         ],
         del3: {
             nb: [
-                'Hvis du skal søke støtte i forbindelse med en aktivitet som ble avsluttet for over 3 måneder siden, må du fylle ut ',
+                'Hvis du skal søke støtte i forbindelse med en aktivitet som ble avsluttet for over 3 måneder siden, må du ',
                 {
-                    tekst: 'papirsøknad',
+                    tekst: 'fylle ut papirsøknad',
                     url: 'https://www.nav.no/fyllut/nav111215b?sub=paper',
                     variant: 'neutral',
                 },

--- a/src/frontend/components/Aktivitet/ArbeidsrettedeAktiviteter.tsx
+++ b/src/frontend/components/Aktivitet/ArbeidsrettedeAktiviteter.tsx
@@ -2,12 +2,12 @@ import React, { useMemo } from 'react';
 
 import { Checkbox, CheckboxGroup } from '@navikt/ds-react';
 
-import { LesMerHvilkenAktivitet } from './LesMerHvilkenAktivitet';
-import { RegisterAktivitetMedLabel } from '../../../typer/registerAktivitet';
-import { EnumFlereValgFelt } from '../../../typer/skjema';
-import { Locale } from '../../../typer/tekst';
-import { Feilmelding } from '../../../typer/validering';
-import { aktivitetTekster } from '../../tekster/aktivitet';
+import { LesMerHvilkenAktivitet } from '../../barnetilsyn/steg/3-aktivitet/LesMerHvilkenAktivitet';
+import { aktivitetTekster } from '../../barnetilsyn/tekster/aktivitet';
+import { RegisterAktivitetMedLabel } from '../../typer/registerAktivitet';
+import { EnumFlereValgFelt } from '../../typer/skjema';
+import { Locale } from '../../typer/tekst';
+import { Feilmelding } from '../../typer/validering';
 
 interface Props {
     registerAktiviteter: Record<string, RegisterAktivitetMedLabel>;

--- a/src/frontend/components/Aktivitet/ArbeidsrettedeAktiviteter.tsx
+++ b/src/frontend/components/Aktivitet/ArbeidsrettedeAktiviteter.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode, useMemo } from 'react';
 
 import { Checkbox, CheckboxGroup } from '@navikt/ds-react';
 
-import { aktivitetTekster } from '../../barnetilsyn/tekster/aktivitet';
+import { tekstArbeidsrettedeAktiviteter } from '../../tekster/aktivitet';
 import { RegisterAktivitetMedLabel } from '../../typer/registerAktivitet';
 import { EnumFlereValgFelt } from '../../typer/skjema';
 import { Locale, TekstElement } from '../../typer/tekst';
@@ -37,7 +37,7 @@ const ArbeidsrettedeAktiviteter: React.FC<Props> = ({
         const valgteVerdier = verdier.map((verdi) => {
             if (verdi === 'ANNET') {
                 return {
-                    label: aktivitetTekster.hvilken_aktivitet.checkboks_annet_tekst[locale],
+                    label: tekstArbeidsrettedeAktiviteter.checkboks_annet_tekst[locale],
                     verdi: 'ANNET',
                 };
             }
@@ -68,7 +68,7 @@ const ArbeidsrettedeAktiviteter: React.FC<Props> = ({
                 </Checkbox>
             ))}
             <Checkbox value="ANNET">
-                {aktivitetTekster.hvilken_aktivitet.checkboks_annet_tekst[locale]}
+                {tekstArbeidsrettedeAktiviteter.checkboks_annet_tekst[locale]}
             </Checkbox>
         </CheckboxGroup>
     );

--- a/src/frontend/components/Aktivitet/ArbeidsrettedeAktiviteter.tsx
+++ b/src/frontend/components/Aktivitet/ArbeidsrettedeAktiviteter.tsx
@@ -2,10 +2,11 @@ import React, { ReactNode, useMemo } from 'react';
 
 import { Checkbox, CheckboxGroup } from '@navikt/ds-react';
 
+import { useSpråk } from '../../context/SpråkContext';
 import { tekstArbeidsrettedeAktiviteter } from '../../tekster/aktivitet';
 import { RegisterAktivitetMedLabel } from '../../typer/registerAktivitet';
 import { EnumFlereValgFelt } from '../../typer/skjema';
-import { Locale, TekstElement } from '../../typer/tekst';
+import { TekstElement } from '../../typer/tekst';
 import { Feilmelding } from '../../typer/validering';
 
 interface Props {
@@ -13,7 +14,6 @@ interface Props {
     lesMer: ReactNode;
     registerAktiviteter: Record<string, RegisterAktivitetMedLabel>;
     oppdaterValgteAktiviteter: (verdier: EnumFlereValgFelt<string>) => void;
-    locale: Locale;
     valgteAktiviteter: EnumFlereValgFelt<string> | undefined;
     feilmelding: Feilmelding | undefined;
 }
@@ -23,10 +23,10 @@ const ArbeidsrettedeAktiviteter: React.FC<Props> = ({
     lesMer,
     registerAktiviteter,
     oppdaterValgteAktiviteter,
-    locale,
     valgteAktiviteter,
     feilmelding,
 }) => {
+    const { locale } = useSpråk();
     const registerAktiviteterListe = useMemo(
         () => Object.values(registerAktiviteter),
         [registerAktiviteter]

--- a/src/frontend/components/Aktivitet/ArbeidsrettedeAktiviteter.tsx
+++ b/src/frontend/components/Aktivitet/ArbeidsrettedeAktiviteter.tsx
@@ -6,10 +6,11 @@ import { LesMerHvilkenAktivitet } from '../../barnetilsyn/steg/3-aktivitet/LesMe
 import { aktivitetTekster } from '../../barnetilsyn/tekster/aktivitet';
 import { RegisterAktivitetMedLabel } from '../../typer/registerAktivitet';
 import { EnumFlereValgFelt } from '../../typer/skjema';
-import { Locale } from '../../typer/tekst';
+import { Locale, TekstElement } from '../../typer/tekst';
 import { Feilmelding } from '../../typer/validering';
 
 interface Props {
+    spørsmål: TekstElement<string>;
     registerAktiviteter: Record<string, RegisterAktivitetMedLabel>;
     oppdaterValgteAktiviteter: (verdier: EnumFlereValgFelt<string>) => void;
     locale: Locale;
@@ -18,6 +19,7 @@ interface Props {
 }
 
 const ArbeidsrettedeAktiviteter: React.FC<Props> = ({
+    spørsmål,
     registerAktiviteter,
     oppdaterValgteAktiviteter,
     locale,
@@ -43,7 +45,7 @@ const ArbeidsrettedeAktiviteter: React.FC<Props> = ({
             return { label: valgtAktivitet.label, verdi: verdi };
         });
         const nyeValgteAktiviteter = {
-            label: aktivitetTekster.hvilken_aktivitet.spm[locale],
+            label: spørsmål[locale],
             verdier: valgteVerdier,
             alternativer: Object.values(registerAktiviteter).map((a) => a.label),
         };
@@ -53,7 +55,7 @@ const ArbeidsrettedeAktiviteter: React.FC<Props> = ({
     return (
         <CheckboxGroup
             id={feilmelding?.id}
-            legend={aktivitetTekster.hvilken_aktivitet.spm[locale]}
+            legend={spørsmål[locale]}
             onChange={onChange}
             value={valgteAktiviteter?.verdier?.map((verdi) => verdi.verdi) || []}
             error={feilmelding?.melding}

--- a/src/frontend/components/Aktivitet/ArbeidsrettedeAktiviteter.tsx
+++ b/src/frontend/components/Aktivitet/ArbeidsrettedeAktiviteter.tsx
@@ -1,8 +1,7 @@
-import React, { useMemo } from 'react';
+import React, { ReactNode, useMemo } from 'react';
 
 import { Checkbox, CheckboxGroup } from '@navikt/ds-react';
 
-import { LesMerHvilkenAktivitet } from '../../barnetilsyn/steg/3-aktivitet/LesMerHvilkenAktivitet';
 import { aktivitetTekster } from '../../barnetilsyn/tekster/aktivitet';
 import { RegisterAktivitetMedLabel } from '../../typer/registerAktivitet';
 import { EnumFlereValgFelt } from '../../typer/skjema';
@@ -11,6 +10,7 @@ import { Feilmelding } from '../../typer/validering';
 
 interface Props {
     spørsmål: TekstElement<string>;
+    lesMer: ReactNode;
     registerAktiviteter: Record<string, RegisterAktivitetMedLabel>;
     oppdaterValgteAktiviteter: (verdier: EnumFlereValgFelt<string>) => void;
     locale: Locale;
@@ -20,6 +20,7 @@ interface Props {
 
 const ArbeidsrettedeAktiviteter: React.FC<Props> = ({
     spørsmål,
+    lesMer,
     registerAktiviteter,
     oppdaterValgteAktiviteter,
     locale,
@@ -60,7 +61,7 @@ const ArbeidsrettedeAktiviteter: React.FC<Props> = ({
             value={valgteAktiviteter?.verdier?.map((verdi) => verdi.verdi) || []}
             error={feilmelding?.melding}
         >
-            <LesMerHvilkenAktivitet header={aktivitetTekster.hvilken_aktivitet.les_mer.header} />
+            {lesMer}
             {registerAktiviteterListe.map((aktivitet) => (
                 <Checkbox key={aktivitet.id} value={aktivitet.id}>
                     {aktivitet ? aktivitet.label : ''}

--- a/src/frontend/components/Aktivitet/registerAktivitetUtil.ts
+++ b/src/frontend/components/Aktivitet/registerAktivitetUtil.ts
@@ -1,0 +1,17 @@
+import { RegisterAktivitet, RegisterAktivitetMedLabel } from '../../typer/registerAktivitet';
+import { tilTekstligDato } from '../../utils/dato';
+
+export const mapTilRegisterAktiviteterObjektMedLabel = (
+    registerAktiviteter: RegisterAktivitet[]
+): Record<string, RegisterAktivitetMedLabel> => {
+    return registerAktiviteter.reduce(
+        (acc, curr) => ({
+            ...acc,
+            [curr.id]: {
+                ...curr,
+                label: `${curr.typeNavn}: ${tilTekstligDato(curr.fom)} - ${curr.tom ? tilTekstligDato(curr.tom) : ''}`,
+            },
+        }),
+        {} as Record<string, RegisterAktivitetMedLabel>
+    );
+};

--- a/src/frontend/components/Aktivitet/registerAktivitetUtil.ts
+++ b/src/frontend/components/Aktivitet/registerAktivitetUtil.ts
@@ -1,4 +1,5 @@
 import { RegisterAktivitet, RegisterAktivitetMedLabel } from '../../typer/registerAktivitet';
+import { EnumFlereValgFelt } from '../../typer/skjema';
 import { tilTekstligDato } from '../../utils/dato';
 
 export const mapTilRegisterAktiviteterObjektMedLabel = (
@@ -15,3 +16,7 @@ export const mapTilRegisterAktiviteterObjektMedLabel = (
         {} as Record<string, RegisterAktivitetMedLabel>
     );
 };
+
+export const skalTaStillingTilAnnenAktivitet = (
+    valgteAktiviteter: EnumFlereValgFelt<string> | undefined
+): boolean => valgteAktiviteter?.verdier.some((verdi) => verdi.verdi === 'ANNET') ?? false;

--- a/src/frontend/components/Aktivitet/registerAktivitetUtil.ts
+++ b/src/frontend/components/Aktivitet/registerAktivitetUtil.ts
@@ -20,3 +20,7 @@ export const mapTilRegisterAktiviteterObjektMedLabel = (
 export const skalTaStillingTilAnnenAktivitet = (
     valgteAktiviteter: EnumFlereValgFelt<string> | undefined
 ): boolean => valgteAktiviteter?.verdier.some((verdi) => verdi.verdi === 'ANNET') ?? false;
+
+export const skalTaStillingTilRegisterAktiviteter = (
+    registerAktiviteter: Record<string, RegisterAktivitetMedLabel>
+): boolean => Object.keys(registerAktiviteter).length > 0;

--- a/src/frontend/context/RegisterAktiviteterContext.tsx
+++ b/src/frontend/context/RegisterAktiviteterContext.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+
+import createUseContext from 'constate';
+
+import { hentArbeidsrettedeAktiviteter } from '../api/api';
+import { mapTilRegisterAktiviteterObjektMedLabel } from '../components/Aktivitet/registerAktivitetUtil';
+import { RegisterAktivitetMedLabel } from '../typer/registerAktivitet';
+
+const [RegisterAktiviteterProvider, useRegisterAktiviteter] = createUseContext(() => {
+    RegisterAktiviteterProvider.displayName = 'AKTIVITETER_PROVIDER';
+
+    const [registerAktiviteter, settRegisterAktiviteter] =
+        useState<Record<string, RegisterAktivitetMedLabel>>();
+
+    useEffect(() => {
+        hentArbeidsrettedeAktiviteter()
+            .then((arbeidsrettedeAktiviteter) =>
+                settRegisterAktiviteter(
+                    mapTilRegisterAktiviteterObjektMedLabel(arbeidsrettedeAktiviteter)
+                )
+            )
+            .catch(() => settRegisterAktiviteter({}));
+    }, []);
+
+    return {
+        registerAktiviteter,
+    };
+});
+
+export { RegisterAktiviteterProvider, useRegisterAktiviteter };

--- a/src/frontend/tekster/aktivitet.ts
+++ b/src/frontend/tekster/aktivitet.ts
@@ -1,0 +1,7 @@
+import { TekstElement } from '../typer/tekst';
+
+export const tekstArbeidsrettedeAktiviteter: {
+    checkboks_annet_tekst: TekstElement<string>;
+} = {
+    checkboks_annet_tekst: { nb: 'Annet' },
+};

--- a/src/frontend/tekster/aktivitet.ts
+++ b/src/frontend/tekster/aktivitet.ts
@@ -2,6 +2,18 @@ import { TekstElement } from '../typer/tekst';
 
 export const tekstArbeidsrettedeAktiviteter: {
     checkboks_annet_tekst: TekstElement<string>;
+    lesMer: {
+        header: TekstElement<string>;
+        header_ingen_registrerte_aktiviteter: TekstElement<string>;
+    };
 } = {
     checkboks_annet_tekst: { nb: 'Annet' },
+    lesMer: {
+        header: {
+            nb: 'Hva gjør jeg hvis noe mangler eller er feil?',
+        },
+        header_ingen_registrerte_aktiviteter: {
+            nb: 'Hva gjør jeg hvis noe mangler?',
+        },
+    },
 };

--- a/src/frontend/utils/dato.ts
+++ b/src/frontend/utils/dato.ts
@@ -1,4 +1,5 @@
-import { isAfter, isEqual, parseISO } from 'date-fns';
+import { format, isAfter, isEqual, parseISO } from 'date-fns';
+import { nb } from 'date-fns/locale';
 
 export const erSnartNyttSkoleår = () => {
     const nåværendeMåned = new Date().getMonth() + 1;
@@ -14,4 +15,9 @@ export const erDatoEtterEllerLik = (fra: string, til: string): boolean => {
     const datoTil = tilDato(til);
 
     return isEqual(datoFra, datoTil) || isAfter(datoTil, datoFra);
+};
+
+//TODO: Legge til støtte for flere Locales enn Norsk Bokmål (nb)
+export const tilTekstligDato = (dato: string) => {
+    return format(tilDato(dato), 'd. MMMM yyyy', { locale: nb });
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Skal gjenbruke henting av aktiviteter til læremidler

* Flytter ut henting til en context, då får man også hentet de direkt når man laster søknaden og må ikke vente på langsom henting på aktivitets-steget
* Flytter utils som skal gjenbrukes til felles-utils
* Trekt ut spm og les-mer fra `ArbeidsrettedeAktiviteter` sånn at man sender med det
* Trekt ut noen felles-tekst-ting

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-22341