### PR TITLE
Viser registeraktiviteter for læremidler

### DIFF
--- a/src/frontend/læremidler/LæremidlerApp.tsx
+++ b/src/frontend/læremidler/LæremidlerApp.tsx
@@ -4,6 +4,7 @@ import Søknadsdialog from './Søknadsdialog';
 import { PersonRouting } from '../components/PersonRouting';
 import SøknadRouting from '../components/SøknadRouting/SøknadRouting';
 import { LæremidlerSøknadProvider, useLæremidlerSøknad } from '../context/LæremiddelSøknadContext';
+import { RegisterAktiviteterProvider } from '../context/RegisterAktiviteterContext';
 import { useSpråk } from '../context/SpråkContext';
 import { SøknadProvider } from '../context/SøknadContext';
 import { useValideringsfeil, ValideringsfeilProvider } from '../context/ValideringsfeilContext';
@@ -39,12 +40,13 @@ const LæremidlerApp = () => {
         document.title = teksterStønad.tittelHtml[Stønadstype.LÆREMIDLER][locale];
     }, [locale]);
 
-    // TODO: Implementer logikk for routing
     return (
         <PersonRouting stønadstype={Stønadstype.LÆREMIDLER}>
             <ValideringsfeilProvider>
                 <LæremidlerSøknadProvider>
-                    <LæremidlerInnhold />
+                    <RegisterAktiviteterProvider>
+                        <LæremidlerInnhold />
+                    </RegisterAktiviteterProvider>
                 </LæremidlerSøknadProvider>
             </ValideringsfeilProvider>
         </PersonRouting>

--- a/src/frontend/læremidler/steg/2-utdanning/LesMerHvilkenAktivitet.tsx
+++ b/src/frontend/læremidler/steg/2-utdanning/LesMerHvilkenAktivitet.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { BodyLong } from '@navikt/ds-react';
+
 import LocaleInlineLenke from '../../../components/Teksthåndtering/LocaleInlineLenke';
 import { LocaleReadMoreMedChildren } from '../../../components/Teksthåndtering/LocaleReadMore';
 import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
@@ -13,8 +15,12 @@ interface Props {
 export const LesMerHvilkenAktivitet: React.FC<Props> = ({ header }) => {
     return (
         <LocaleReadMoreMedChildren header={header}>
-            <LocaleTekst tekst={utdanningTekster.hvilken_aktivitet.les_mer.del1} />
-            <LocaleTekst tekst={utdanningTekster.hvilken_aktivitet.les_mer.del2} />
+            <BodyLong spacing>
+                <LocaleTekst tekst={utdanningTekster.hvilken_aktivitet.les_mer.del1} />
+            </BodyLong>
+            <BodyLong spacing>
+                <LocaleTekst tekst={utdanningTekster.hvilken_aktivitet.les_mer.del2} />
+            </BodyLong>
             <LocaleInlineLenke tekst={utdanningTekster.hvilken_aktivitet.les_mer.del3} />
         </LocaleReadMoreMedChildren>
     );

--- a/src/frontend/læremidler/steg/2-utdanning/LesMerHvilkenAktivitet.tsx
+++ b/src/frontend/læremidler/steg/2-utdanning/LesMerHvilkenAktivitet.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import LocaleInlineLenke from '../../../components/Teksthåndtering/LocaleInlineLenke';
+import { LocaleReadMoreMedChildren } from '../../../components/Teksthåndtering/LocaleReadMore';
+import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
+import { TekstElement } from '../../../typer/tekst';
+import { utdanningTekster } from '../../tekster/utdanning';
+
+interface Props {
+    header: TekstElement<string>;
+}
+
+export const LesMerHvilkenAktivitet: React.FC<Props> = ({ header }) => {
+    return (
+        <LocaleReadMoreMedChildren header={header}>
+            <LocaleTekst tekst={utdanningTekster.hvilken_aktivitet.les_mer.del1} />
+            <LocaleTekst tekst={utdanningTekster.hvilken_aktivitet.les_mer.del2} />
+            <LocaleInlineLenke tekst={utdanningTekster.hvilken_aktivitet.les_mer.del3} />
+        </LocaleReadMoreMedChildren>
+    );
+};

--- a/src/frontend/læremidler/steg/2-utdanning/Utdanning.tsx
+++ b/src/frontend/læremidler/steg/2-utdanning/Utdanning.tsx
@@ -11,6 +11,7 @@ import {
     feilAnnenUtdanning,
     feilHarFunksjonsnedsettelse,
     feilMottarUtstyrsstipend,
+    feilValgtAktivitet,
 } from './validering';
 import ArbeidsrettedeAktiviteter from '../../../components/Aktivitet/ArbeidsrettedeAktiviteter';
 import {
@@ -106,10 +107,24 @@ const Utdanning = () => {
         nullstillAnnenAktivitet(nyeValgteAktiviteter);
     };
 
+    if (!registerAktiviteter) {
+        // ønsker ikke å vise siden før man har hentet aktivteter fra backend
+        return null;
+    }
+
+    const skalViseArbeidsrettedeAktiviteter =
+        skalTaStillingTilRegisterAktiviteter(registerAktiviteter);
+    const skalViseAnnenAktivitet =
+        !skalViseArbeidsrettedeAktiviteter || skalTaStillingTilAnnenAktivitet(valgteAktiviteter);
+
     const kanFortsette = (): boolean => {
         let feil: Valideringsfeil = {};
 
-        if (annenUtdanning === undefined) {
+        const verdierValgteAktiviteter = valgteAktiviteter?.verdier ?? [];
+        if (skalViseArbeidsrettedeAktiviteter && verdierValgteAktiviteter.length === 0) {
+            feil = feilValgtAktivitet(feil, locale);
+        }
+        if (skalViseAnnenAktivitet && annenUtdanning === undefined) {
             feil = feilAnnenUtdanning(feil, locale);
         }
         if (mottarUtstyrsstipend === undefined) {
@@ -122,15 +137,6 @@ const Utdanning = () => {
         settValideringsfeil(feil);
         return !inneholderFeil(feil);
     };
-
-    if (!registerAktiviteter) {
-        // ønsker ikke å vise siden før man har hentet aktivteter fra backend
-        return null;
-    }
-
-    const skalViseArbeidsrettedeAktiviteter =
-        skalTaStillingTilRegisterAktiviteter(registerAktiviteter);
-    const skalViseAnnenAktivitet = skalTaStillingTilAnnenAktivitet(valgteAktiviteter);
 
     return (
         <Side validerSteg={kanFortsette} oppdaterSøknad={oppdaterUtdanningISøknad}>
@@ -171,7 +177,7 @@ const Utdanning = () => {
                     </div>
                 </>
             )}
-            {(!skalViseArbeidsrettedeAktiviteter || skalViseAnnenAktivitet) && (
+            {skalViseAnnenAktivitet && (
                 <AnnenUtdanning
                     annenUtdanning={annenUtdanning}
                     oppdaterAnnenAktivitet={oppdaterAnnenAktivitet}

--- a/src/frontend/læremidler/steg/2-utdanning/validering.ts
+++ b/src/frontend/læremidler/steg/2-utdanning/validering.ts
@@ -2,6 +2,14 @@ import { Locale } from '../../../typer/tekst';
 import { Valideringsfeil } from '../../../typer/validering';
 import { utdanningTekster } from '../../tekster/utdanning';
 
+export const feilValgtAktivitet = (feil: Valideringsfeil, locale: Locale) => ({
+    ...feil,
+    valgteAktiviteter: {
+        id: '1',
+        melding: utdanningTekster.checkbox_velge_aktivitet_feilmelding[locale],
+    },
+});
+
 export const feilAnnenUtdanning = (feil: Valideringsfeil, locale: Locale) => ({
     ...feil,
     annenUtdanning: {

--- a/src/frontend/læremidler/steg/4-oppsummering/Utdanning.tsx
+++ b/src/frontend/læremidler/steg/4-oppsummering/Utdanning.tsx
@@ -12,6 +12,7 @@ import { Utdanning } from '../../typer/søknad';
 
 const UtdanningOppsummering: React.FC<{ utdanning: Utdanning }> = ({ utdanning }) => {
     const navigate = useNavigate();
+
     return (
         <FormSummary>
             <FormSummary.Header>
@@ -23,6 +24,16 @@ const UtdanningOppsummering: React.FC<{ utdanning: Utdanning }> = ({ utdanning }
                 </FormSummary.EditLink>
             </FormSummary.Header>
             <FormSummary.Answers>
+                {utdanning.aktiviteter && (
+                    <FormSummary.Answer>
+                        <FormSummary.Label>{utdanning.aktiviteter.label}</FormSummary.Label>
+                        {utdanning.aktiviteter.verdier
+                            .filter((verdi) => verdi.verdi !== 'ANNET')
+                            .map((verdi) => (
+                                <FormSummary.Value>{verdi.label}</FormSummary.Value>
+                            ))}
+                    </FormSummary.Answer>
+                )}
                 {utdanning.annenUtdanning !== undefined && (
                     <FormSummary.Answer>
                         <FormSummary.Label>{utdanning.annenUtdanning.label}</FormSummary.Label>

--- a/src/frontend/læremidler/tekster/utdanning.ts
+++ b/src/frontend/læremidler/tekster/utdanning.ts
@@ -1,11 +1,14 @@
+import { tekstArbeidsrettedeAktiviteter } from '../../tekster/aktivitet';
 import { JaNeiTilTekst } from '../../tekster/felles';
 import { JaNei } from '../../typer/søknad';
-import { Radiogruppe, TekstElement } from '../../typer/tekst';
+import { InlineLenke, Radiogruppe, TekstElement } from '../../typer/tekst';
 import { AnnenUtdanningType } from '../typer/søknad';
 
 interface AktivitetInnhold {
     tittel: TekstElement<string>;
     guide_innhold: TekstElement<string[]>;
+    hvilken_aktivitet: HvilkenAktivitet;
+    ingen_registrerte_aktiviterer_overskrift: TekstElement<string>;
     radio_annen_utdanning: Radiogruppe<AnnenUtdanningType>;
     radio_annen_utdanning_feilmelding: TekstElement<string>;
     ingen_utdanning_alert_tittel: TekstElement<string>;
@@ -14,6 +17,17 @@ interface AktivitetInnhold {
     radio_mottar_utstyrsstipend_feilmelding: TekstElement<string>;
     radio_mottar_har_funksjonsnedsettelse: Radiogruppe<JaNei>;
     radio_mottar_har_funksjonsnedsettelse_feilmelding: TekstElement<string>;
+}
+
+interface HvilkenAktivitet {
+    spm: TekstElement<string>;
+    les_mer: {
+        header: TekstElement<string>;
+        header_ingen_registrerte_aktiviteter: TekstElement<string>;
+        del1: TekstElement<string>;
+        del2: TekstElement<string>;
+        del3: TekstElement<InlineLenke>;
+    };
 }
 
 const AnnenUtdanningTypeTilTekst: Record<AnnenUtdanningType, TekstElement<string>> = {
@@ -29,6 +43,34 @@ const AnnenUtdanningTypeTilTekst: Record<AnnenUtdanningType, TekstElement<string
     },
 };
 
+const hvilkenAktivitet: HvilkenAktivitet = {
+    spm: {
+        nb: 'Hvilken utdanning eller opplæring søker du om støtte til læremidler for?',
+    },
+    les_mer: {
+        header: tekstArbeidsrettedeAktiviteter.lesMer.header,
+        header_ingen_registrerte_aktiviteter:
+            tekstArbeidsrettedeAktiviteter.lesMer.header_ingen_registrerte_aktiviteter,
+        del1: {
+            nb: 'Vi henter tiltak og utdanning registrert på deg 3 måneder tilbake i tid. Er du enslig eller gjenlevende så er det ikke alltid dette er registert på en måte så vi klare å hente det.',
+        },
+        del2: {
+            nb: 'Går du på arbeidsavklaringspenger eller mottar uføretrygd, og utdanningen din mangler? Da anbefaler vi at du tar kontakt med veilederen din og ber om at den registreres. Du kan fortsatt søke nå, men det tar lengre tid for oss å behandle din søknad hvis vi må kontakte veilederen din for deg.',
+        },
+        del3: {
+            nb: [
+                'Hvis du skal søke støtte i forbindelse med en utdanning som ble avsluttet for over 3 måneder siden, må du ',
+                {
+                    tekst: 'fylle ut papirsøknad',
+                    url: 'https://www.nav.no/fyllut/nav111215b?sub=paper',
+                    variant: 'neutral',
+                },
+                '.',
+            ],
+        },
+    },
+};
+
 export const utdanningTekster: AktivitetInnhold = {
     tittel: { nb: 'Utdanning eller opplæring' },
     guide_innhold: {
@@ -36,6 +78,10 @@ export const utdanningTekster: AktivitetInnhold = {
             'For å få støtte til læremidler må du ta en utdannelse eller opplæring godkjent av NAV.',
             'Vi viser utdanninger registrert på deg de siste 6 månedene.',
         ],
+    },
+    hvilken_aktivitet: hvilkenAktivitet,
+    ingen_registrerte_aktiviterer_overskrift: {
+        nb: 'Vi fant dessverre ingen arbeidsrettede aktiviteter som er registrert på deg.',
     },
     radio_annen_utdanning: {
         header: {

--- a/src/frontend/læremidler/tekster/utdanning.ts
+++ b/src/frontend/læremidler/tekster/utdanning.ts
@@ -9,6 +9,7 @@ interface AktivitetInnhold {
     guide_innhold: TekstElement<string[]>;
     hvilken_aktivitet: HvilkenAktivitet;
     ingen_registrerte_aktiviterer_overskrift: TekstElement<string>;
+    checkbox_velge_aktivitet_feilmelding: TekstElement<string>;
     radio_annen_utdanning: Radiogruppe<AnnenUtdanningType>;
     radio_annen_utdanning_feilmelding: TekstElement<string>;
     ingen_utdanning_alert_tittel: TekstElement<string>;
@@ -82,6 +83,9 @@ export const utdanningTekster: AktivitetInnhold = {
     hvilken_aktivitet: hvilkenAktivitet,
     ingen_registrerte_aktiviterer_overskrift: {
         nb: 'Vi fant dessverre ingen arbeidsrettede aktiviteter som er registrert på deg.',
+    },
+    checkbox_velge_aktivitet_feilmelding: {
+        nb: 'Du må svare på hvilken utdanning eller opplæring du søker om støtte i forbindelse med.',
     },
     radio_annen_utdanning: {
         header: {

--- a/src/frontend/læremidler/typer/søknad.ts
+++ b/src/frontend/læremidler/typer/søknad.ts
@@ -1,7 +1,8 @@
-import { EnumFelt } from '../../typer/skjema';
+import { EnumFelt, EnumFlereValgFelt } from '../../typer/skjema';
 import { JaNei } from '../../typer/søknad';
 
 export interface Utdanning {
+    aktiviteter: EnumFlereValgFelt<string> | undefined;
     annenUtdanning: EnumFelt<AnnenUtdanningType> | undefined;
     mottarUtstyrsstipend: EnumFelt<JaNei> | undefined;
     harFunksjonsnedsettelse: EnumFelt<JaNei> | undefined;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Lagt til visning og mulighet til å velge aktiviteter for læremidler

https://www.figma.com/design/f8PXWDQldItXCpUPQayNem/S%C3%B8knad---L%C3%A6remidler?node-id=325-39531&node-type=frame&t=3g8RpD8SN9tX3QZm-0
https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-22341

Bygger videre på 
* https://github.com/navikt/tilleggsstonader-soknad/pull/381

Koblet til
* https://github.com/navikt/tilleggsstonader-soknad-api/pull/144

📸 📸 📸 

<img width="756" alt="image" src="https://github.com/user-attachments/assets/b6b20eda-b56c-4eb2-bf5e-a2f72af6182b">

<img width="679" alt="image" src="https://github.com/user-attachments/assets/59d28357-d91a-458d-9db9-e5a4dce63007">
