### PR TITLE
Skal kun vise spm om utstyrsstipend hvis personen er under 21 år gammel

### DIFF
--- a/src/frontend/læremidler/steg/2-utdanning/Utdanning.tsx
+++ b/src/frontend/læremidler/steg/2-utdanning/Utdanning.tsx
@@ -118,6 +118,7 @@ const Utdanning = () => {
         skalTaStillingTilRegisterAktiviteter(registerAktiviteter);
     const skalViseAnnenAktivitet =
         !skalViseArbeidsrettedeAktiviteter || skalTaStillingTilAnnenAktivitet(valgteAktiviteter);
+    const skalViseMottarUtstyrsstipend = person.alder < 21;
 
     const kanFortsette = (): boolean => {
         let feil: Valideringsfeil = {};
@@ -129,7 +130,7 @@ const Utdanning = () => {
         if (skalViseAnnenAktivitet && annenUtdanning === undefined) {
             feil = feilAnnenUtdanning(feil, locale);
         }
-        if (mottarUtstyrsstipend === undefined) {
+        if (skalViseMottarUtstyrsstipend && mottarUtstyrsstipend === undefined) {
             feil = feilMottarUtstyrsstipend(feil, locale);
         }
         if (harFunksjonsnedsettelse === undefined) {
@@ -186,7 +187,7 @@ const Utdanning = () => {
                     feilmelding={valideringsfeil.annenUtdanning}
                 />
             )}
-            {person.alder < 21 && (
+            {skalViseMottarUtstyrsstipend && (
                 <MottarUtstyrsstipend
                     mottarUtstyrsstipend={mottarUtstyrsstipend}
                     oppdaterMottarUtstyrsstipend={oppdaterMottarUtstyrsstipend}

--- a/src/frontend/læremidler/steg/2-utdanning/Utdanning.tsx
+++ b/src/frontend/læremidler/steg/2-utdanning/Utdanning.tsx
@@ -23,6 +23,7 @@ import Side from '../../../components/Side';
 import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
 import LocaleTekstAvsnitt from '../../../components/Teksthåndtering/LocaleTekstAvsnitt';
 import { useLæremidlerSøknad } from '../../../context/LæremiddelSøknadContext';
+import { usePerson } from '../../../context/PersonContext';
 import { useRegisterAktiviteter } from '../../../context/RegisterAktiviteterContext';
 import { useSpråk } from '../../../context/SpråkContext';
 import { useValideringsfeil } from '../../../context/ValideringsfeilContext';
@@ -34,6 +35,7 @@ import { AnnenUtdanningType } from '../../typer/søknad';
 
 const Utdanning = () => {
     const { locale } = useSpråk();
+    const { person } = usePerson();
     const { utdanning, settUtdanning, settDokumentasjonsbehov } = useLæremidlerSøknad();
     const { valideringsfeil, settValideringsfeil } = useValideringsfeil();
     const { registerAktiviteter } = useRegisterAktiviteter();
@@ -184,12 +186,13 @@ const Utdanning = () => {
                     feilmelding={valideringsfeil.annenUtdanning}
                 />
             )}
-            {/* TODO: Vis kun om person under 21 år */}
-            <MottarUtstyrsstipend
-                mottarUtstyrsstipend={mottarUtstyrsstipend}
-                oppdaterMottarUtstyrsstipend={oppdaterMottarUtstyrsstipend}
-                feilmelding={valideringsfeil.mottarUtstyrsstipend}
-            />
+            {person.alder < 21 && (
+                <MottarUtstyrsstipend
+                    mottarUtstyrsstipend={mottarUtstyrsstipend}
+                    oppdaterMottarUtstyrsstipend={oppdaterMottarUtstyrsstipend}
+                    feilmelding={valideringsfeil.mottarUtstyrsstipend}
+                />
+            )}
             <HarFunksjonsnedsettelse
                 harFunksjonsnedsettelse={harFunksjonsnedsettelse}
                 oppdaterHarFunksjonsnedsettelse={oppdaterHarFunksjonsnedsettelse}

--- a/src/frontend/læremidler/tekster/utdanning.ts
+++ b/src/frontend/læremidler/tekster/utdanning.ts
@@ -110,7 +110,9 @@ export const utdanningTekster: AktivitetInnhold = {
             nb: 'Mottar du utstyrsstipend fra Statens lånekasse?',
         },
         beskrivelse: {
-            nb: 'Vi ser at du er under 21 år og går videregående. Da har du mest sannsynlig rett til utstyrstipend fra Lånekassen. ',
+            nb:
+                'Vi ser at du er under 21 år. ' +
+                'Hvis du tar videregående utdanning har du mest sannsynlig rett til utstyrsstipend fra Lånekassen. ',
         },
         alternativer: JaNeiTilTekst,
     },

--- a/src/frontend/mock/initiellPerson.ts
+++ b/src/frontend/mock/initiellPerson.ts
@@ -3,6 +3,7 @@ import { Person } from '../typer/person';
 export const initiellPerson: Person = {
     fornavn: '',
     visningsnavn: '',
+    alder: 0,
     adresse: '',
     barn: [],
 };

--- a/src/frontend/typer/person.ts
+++ b/src/frontend/typer/person.ts
@@ -2,6 +2,7 @@ import { Barn } from './barn';
 
 export interface Person {
     fornavn: string;
+    alder: number;
     visningsnavn: string;
     adresse: string;
     barn: Barn[];


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Lagt til alder i backend og viser kun spm hvis søker er under 21 år gammel

Burde dette spm kun bli vist hvis man har valgt "Videregående utdanning, eller forkurs på universitet" ? 