### PR TITLE
Endret bekreftelsestekst i felles

### DIFF
--- a/src/frontend/tekster/felles.ts
+++ b/src/frontend/tekster/felles.ts
@@ -21,7 +21,7 @@ export interface FellesInnhold {
 export const fellesTekster: FellesInnhold = {
     vi_stoler_tittel: { nb: 'Vi stoler på deg' },
     vi_stoler_innhold: {
-        nb: 'Jeg bekrefter at jeg vil svare så godt jeg kan på spørsmålene i søknaden.',
+        nb: 'Jeg bekrefter at jeg vil svare så riktig som jeg kan.',
     },
     vi_stoler_feilmelding: {
         nb: 'Du må bekrefte at du vil gi så riktige opplysninger som mulig.',


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
<img width="665" alt="Screenshot 2024-11-01 at 09 48 39" src="https://github.com/user-attachments/assets/23bd0267-eb91-41b4-87e8-e571dd9eeca0">
