### PR TITLE
Lagt till bekreftelseknapp på felles oppsummering

### DIFF
--- a/src/frontend/components/Oppsummering/OppsummeringSide.tsx
+++ b/src/frontend/components/Oppsummering/OppsummeringSide.tsx
@@ -1,0 +1,43 @@
+import React, { ReactNode, useState } from 'react';
+
+import { Checkbox, CheckboxGroup } from '@navikt/ds-react';
+
+import { useSpråk } from '../../context/SpråkContext';
+import { fellesOppsummeringTekster } from '../../tekster/oppsummering';
+import Side from '../Side';
+import LocaleTekst from '../Teksthåndtering/LocaleTekst';
+
+export const OppsummeringSide = ({ children }: { children: ReactNode }) => {
+    const { locale } = useSpråk();
+    const [harBekreftet, settHarBekreftet] = useState(false);
+    const [feilBekreftKnapp, settFeilBekreftKnapp] = useState<string>();
+
+    return (
+        <Side
+            validerSteg={() => {
+                if (!harBekreftet) {
+                    settFeilBekreftKnapp(fellesOppsummeringTekster.bekreft.feil[locale]);
+                    return false;
+                }
+                settFeilBekreftKnapp('');
+                return true;
+            }}
+        >
+            {children}
+            <CheckboxGroup
+                value={[harBekreftet]}
+                onChange={(verdier) => {
+                    settHarBekreftet(verdier.includes(true));
+                    settFeilBekreftKnapp('');
+                }}
+                legend={<LocaleTekst tekst={fellesOppsummeringTekster.bekreft.tittel} />}
+                hideLegend
+                error={feilBekreftKnapp}
+            >
+                <Checkbox value={true} error={!!feilBekreftKnapp}>
+                    <LocaleTekst tekst={fellesOppsummeringTekster.bekreft.tittel} />
+                </Checkbox>
+            </CheckboxGroup>
+        </Side>
+    );
+};

--- a/src/frontend/læremidler/steg/4-oppsummering/Oppsummering.tsx
+++ b/src/frontend/læremidler/steg/4-oppsummering/Oppsummering.tsx
@@ -5,22 +5,23 @@ import { Heading } from '@navikt/ds-react';
 import UtdanningOppsummering from './Utdanning';
 import HovedytelseOppsummering from '../../../components/Oppsummering/Hovedytelse/Hovedytelse';
 import OmDeg from '../../../components/Oppsummering/OmDeg';
-import Side from '../../../components/Side';
+import { OppsummeringSide } from '../../../components/Oppsummering/OppsummeringSide';
 import LocaleTekst from '../../../components/Teksthåndtering/LocaleTekst';
 import { useLæremidlerSøknad } from '../../../context/LæremiddelSøknadContext';
 import { oppsummeringTekster } from '../../tekster/oppsummering';
 
 const Oppsummering = () => {
     const { hovedytelse, utdanning } = useLæremidlerSøknad();
+
     return (
-        <Side>
+        <OppsummeringSide>
             <Heading size="medium">
                 <LocaleTekst tekst={oppsummeringTekster.tittel} />
             </Heading>
             <OmDeg />
             {hovedytelse && <HovedytelseOppsummering hovedytelse={hovedytelse} />}
             {utdanning && <UtdanningOppsummering utdanning={utdanning} />}
-        </Side>
+        </OppsummeringSide>
     );
 };
 

--- a/src/frontend/tekster/oppsummering.ts
+++ b/src/frontend/tekster/oppsummering.ts
@@ -13,6 +13,10 @@ interface OppsummeringInnhold {
         oppholdSiste12mnd: TekstElement<string>;
         oppholdNeste12mnd: TekstElement<string>;
     };
+    bekreft: {
+        tittel: TekstElement<string>;
+        feil: TekstElement<string>;
+    };
 }
 
 export const fellesOppsummeringTekster: OppsummeringInnhold = {
@@ -47,6 +51,15 @@ export const fellesOppsummeringTekster: OppsummeringInnhold = {
         },
         oppholdNeste12mnd: {
             nb: 'Opphold utenfor Norge neste 12 mnd',
+        },
+    },
+
+    bekreft: {
+        tittel: {
+            nb: 'Jeg bekrefter at jeg har lest og forstått informasjonen i søknaden og svart så godt jeg kan.',
+        },
+        feil: {
+            nb: 'Du må bekrefte for å sende inn søknaden',
         },
     },
 };


### PR DESCRIPTION
- Trekker ut OppsummeringSide i egen komponent for å få felles validering av bekreftelseknapp og valdiering på et sted

### Hvorfor er denne endringen nødvendig? ✨
https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-23428

![image](https://github.com/user-attachments/assets/a65eb760-3447-442e-be3c-b3ba516744c8)
