### PR TITLE
logNavigereEvent med riktig stønadstype

### DIFF
--- a/src/frontend/components/Teksthåndtering/LocaleInlineLenke.tsx
+++ b/src/frontend/components/Teksthåndtering/LocaleInlineLenke.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import { Link } from '@navikt/ds-react';
 
 import { logNavigereEvent } from '../../api/amplitude';
@@ -8,28 +10,22 @@ import { InlineLenke, Lenke, StyledTekst, TekstElement } from '../../typer/tekst
 const LocaleInlineLenke: React.FC<{ tekst: TekstElement<InlineLenke> }> = ({ tekst }) => {
     const { locale } = useSpråk();
 
-    return (
-        <>
-            {tekst[locale].map((tekstElement, indeks) =>
-                tekstTilLenkeEllerTekst(tekstElement, indeks)
-            )}
-        </>
-    );
+    return tekst[locale].map((tekstElement, indeks) => (
+        <React.Fragment key={indeks}>{tekstTilLenkeEllerTekst(tekstElement)}</React.Fragment>
+    ));
 };
 
 export const tekstTilLenkeEllerTekst = (
     tekstElement: string | StyledTekst | Lenke,
-    indeks: number
 ) => {
     if (typeof tekstElement === 'string') {
-        return <span key={indeks}>{tekstElement}</span>;
+        return <span>{tekstElement}</span>;
     }
     if ('url' in tekstElement) {
         return (
             <Link
                 inlineText
                 href={tekstElement.url}
-                key={indeks}
                 variant={tekstElement.variant}
                 target="_blank"
                 onClick={() =>
@@ -41,7 +37,7 @@ export const tekstTilLenkeEllerTekst = (
         );
     }
     return (
-        <span key={indeks} style={{ fontWeight: tekstElement.style }}>
+        <span style={{ fontWeight: tekstElement.style }}>
             {tekstElement.tekst}
         </span>
     );

--- a/src/frontend/components/Teksthåndtering/LocaleInlineLenke.tsx
+++ b/src/frontend/components/Teksthåndtering/LocaleInlineLenke.tsx
@@ -5,25 +5,21 @@ import { Link } from '@navikt/ds-react';
 import { logNavigereEvent } from '../../api/amplitude';
 import { useSpråk } from '../../context/SpråkContext';
 import { useSøknad } from '../../context/SøknadContext';
-import { Stønadstype } from '../../typer/stønadstyper';
 import { InlineLenke, Lenke, StyledTekst, TekstElement } from '../../typer/tekst';
 
 const LocaleInlineLenke: React.FC<{ tekst: TekstElement<InlineLenke> }> = ({ tekst }) => {
     const { locale } = useSpråk();
 
-    const { stønadstype } = useSøknad();
-
     return tekst[locale].map((tekstElement, indeks) => (
-        <React.Fragment key={indeks}>
-            {tekstTilLenkeEllerTekst(tekstElement, stønadstype)}
-        </React.Fragment>
+        <LenkeEllerTekst key={indeks} tekstElement={tekstElement} />
     ));
 };
 
-export const tekstTilLenkeEllerTekst = (
-    tekstElement: string | StyledTekst | Lenke,
-    stønadstype: Stønadstype
-) => {
+export const LenkeEllerTekst: React.FC<{ tekstElement: string | StyledTekst | Lenke }> = ({
+    tekstElement,
+}) => {
+    const { stønadstype } = useSøknad();
+
     if (typeof tekstElement === 'string') {
         return <span>{tekstElement}</span>;
     }
@@ -34,19 +30,13 @@ export const tekstTilLenkeEllerTekst = (
                 href={tekstElement.url}
                 variant={tekstElement.variant}
                 target="_blank"
-                onClick={() =>
-                    logNavigereEvent(stønadstype, tekstElement.url, tekstElement.tekst)
-                }
+                onClick={() => logNavigereEvent(stønadstype, tekstElement.url, tekstElement.tekst)}
             >
                 {tekstElement.tekst}
             </Link>
         );
     }
-    return (
-        <span style={{ fontWeight: tekstElement.style }}>
-            {tekstElement.tekst}
-        </span>
-    );
+    return <span style={{ fontWeight: tekstElement.style }}>{tekstElement.tekst}</span>;
 };
 
 export default LocaleInlineLenke;

--- a/src/frontend/components/Teksthåndtering/LocaleInlineLenke.tsx
+++ b/src/frontend/components/Teksthåndtering/LocaleInlineLenke.tsx
@@ -4,19 +4,25 @@ import { Link } from '@navikt/ds-react';
 
 import { logNavigereEvent } from '../../api/amplitude';
 import { useSpråk } from '../../context/SpråkContext';
+import { useSøknad } from '../../context/SøknadContext';
 import { Stønadstype } from '../../typer/stønadstyper';
 import { InlineLenke, Lenke, StyledTekst, TekstElement } from '../../typer/tekst';
 
 const LocaleInlineLenke: React.FC<{ tekst: TekstElement<InlineLenke> }> = ({ tekst }) => {
     const { locale } = useSpråk();
 
+    const { stønadstype } = useSøknad();
+
     return tekst[locale].map((tekstElement, indeks) => (
-        <React.Fragment key={indeks}>{tekstTilLenkeEllerTekst(tekstElement)}</React.Fragment>
+        <React.Fragment key={indeks}>
+            {tekstTilLenkeEllerTekst(tekstElement, stønadstype)}
+        </React.Fragment>
     ));
 };
 
 export const tekstTilLenkeEllerTekst = (
     tekstElement: string | StyledTekst | Lenke,
+    stønadstype: Stønadstype
 ) => {
     if (typeof tekstElement === 'string') {
         return <span>{tekstElement}</span>;
@@ -29,7 +35,7 @@ export const tekstTilLenkeEllerTekst = (
                 variant={tekstElement.variant}
                 target="_blank"
                 onClick={() =>
-                    logNavigereEvent(Stønadstype.BARNETILSYN, tekstElement.url, tekstElement.tekst)
+                    logNavigereEvent(stønadstype, tekstElement.url, tekstElement.tekst)
                 }
             >
                 {tekstElement.tekst}

--- a/src/frontend/components/Teksthåndtering/LocalePunktliste.tsx
+++ b/src/frontend/components/Teksthåndtering/LocalePunktliste.tsx
@@ -4,6 +4,8 @@ import { Label, List } from '@navikt/ds-react';
 
 import { tekstTilLenkeEllerTekst } from './LocaleInlineLenke';
 import { useSpråk } from '../../context/SpråkContext';
+import { useSøknad } from '../../context/SøknadContext';
+import { Stønadstype } from '../../typer/stønadstyper';
 import { InlineLenke, TekstElement } from '../../typer/tekst';
 
 const LocalePunktliste: React.FC<{
@@ -12,19 +14,20 @@ const LocalePunktliste: React.FC<{
     tittelSomLabel?: boolean;
 }> = ({ tittel, innhold, tittelSomLabel = false }) => {
     const { locale } = useSpråk();
+    const { stønadstype } = useSøknad();
     const punkter = innhold[locale];
 
     return tittelSomLabel ? (
         <React.Fragment>
             <Label>{tittel && tittel[locale]}</Label>
-            <List>{lagPunktliste(punkter)}</List>
+            <List>{lagPunktliste(punkter, stønadstype)}</List>
         </React.Fragment>
     ) : (
-        <List title={tittel && tittel[locale]}>{lagPunktliste(punkter)}</List>
+        <List title={tittel && tittel[locale]}>{lagPunktliste(punkter, stønadstype)}</List>
     );
 };
 
-const lagPunktliste = (punkter: (string | InlineLenke)[]) =>
+const lagPunktliste = (punkter: (string | InlineLenke)[], stønadstype: Stønadstype) =>
     punkter.map((punkt, indeks) =>
         typeof punkt === 'string' ? (
             <List.Item key={indeks}>{punkt}</List.Item>
@@ -32,7 +35,7 @@ const lagPunktliste = (punkter: (string | InlineLenke)[]) =>
             <List.Item key={indeks}>
                 {punkt.map((tekstElement, indeks) => (
                     <React.Fragment key={indeks}>
-                        {tekstTilLenkeEllerTekst(tekstElement)}
+                        {tekstTilLenkeEllerTekst(tekstElement, stønadstype)}
                     </React.Fragment>
                 ))}
             </List.Item>

--- a/src/frontend/components/Teksthåndtering/LocalePunktliste.tsx
+++ b/src/frontend/components/Teksthåndtering/LocalePunktliste.tsx
@@ -30,7 +30,11 @@ const lagPunktliste = (punkter: (string | InlineLenke)[]) =>
             <List.Item key={indeks}>{punkt}</List.Item>
         ) : (
             <List.Item key={indeks}>
-                {punkt.map((tekstElement, indeks) => tekstTilLenkeEllerTekst(tekstElement, indeks))}
+                {punkt.map((tekstElement, indeks) => (
+                    <React.Fragment key={indeks}>
+                        {tekstTilLenkeEllerTekst(tekstElement)}
+                    </React.Fragment>
+                ))}
             </List.Item>
         )
     );

--- a/src/frontend/components/Teksthåndtering/LocalePunktliste.tsx
+++ b/src/frontend/components/Teksthåndtering/LocalePunktliste.tsx
@@ -2,10 +2,8 @@ import React from 'react';
 
 import { Label, List } from '@navikt/ds-react';
 
-import { tekstTilLenkeEllerTekst } from './LocaleInlineLenke';
+import { LenkeEllerTekst } from './LocaleInlineLenke';
 import { useSpråk } from '../../context/SpråkContext';
-import { useSøknad } from '../../context/SøknadContext';
-import { Stønadstype } from '../../typer/stønadstyper';
 import { InlineLenke, TekstElement } from '../../typer/tekst';
 
 const LocalePunktliste: React.FC<{
@@ -14,29 +12,26 @@ const LocalePunktliste: React.FC<{
     tittelSomLabel?: boolean;
 }> = ({ tittel, innhold, tittelSomLabel = false }) => {
     const { locale } = useSpråk();
-    const { stønadstype } = useSøknad();
     const punkter = innhold[locale];
 
     return tittelSomLabel ? (
         <React.Fragment>
             <Label>{tittel && tittel[locale]}</Label>
-            <List>{lagPunktliste(punkter, stønadstype)}</List>
+            <List>{lagPunktliste(punkter)}</List>
         </React.Fragment>
     ) : (
-        <List title={tittel && tittel[locale]}>{lagPunktliste(punkter, stønadstype)}</List>
+        <List title={tittel && tittel[locale]}>{lagPunktliste(punkter)}</List>
     );
 };
 
-const lagPunktliste = (punkter: (string | InlineLenke)[], stønadstype: Stønadstype) =>
+const lagPunktliste = (punkter: (string | InlineLenke)[]) =>
     punkter.map((punkt, indeks) =>
         typeof punkt === 'string' ? (
             <List.Item key={indeks}>{punkt}</List.Item>
         ) : (
             <List.Item key={indeks}>
                 {punkt.map((tekstElement, indeks) => (
-                    <React.Fragment key={indeks}>
-                        {tekstTilLenkeEllerTekst(tekstElement, stønadstype)}
-                    </React.Fragment>
+                    <LenkeEllerTekst key={indeks} tekstElement={tekstElement} />
                 ))}
             </List.Item>
         )


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Stønadstypen var hardkodet.
Når vi logger event til amplitude er det ønskelig å logge ut fra hvilken søknad man er i. 
Det brukes fra
```typescript
loggEventMedSkjema = (
skjemanavn: stønadstypeTilSkjemanavn[stønadstype],
skjemaId: stønadstypeTilSkjemaId[stønadstype],
```
https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-23557

Kommer få merge conflict med
* https://github.com/navikt/tilleggsstonader-soknad/pull/426

* https://github.com/navikt/tilleggsstonader-soknad/pull/426#discussion_r1870259537