### PR TITLE
Viser ny komponenter etter alle api kall

### DIFF
--- a/src/frontend/components/PersonRouting.tsx
+++ b/src/frontend/components/PersonRouting.tsx
@@ -27,7 +27,7 @@ export const PersonRouting: React.FC<{ stønadstype: Stønadstype; children: Rea
     const [harLastetPerson, settHarLastetPerson] = useState<boolean>(false);
     const [feilmelding, settFeilmelding] = useState<string>();
 
-    const { harBehandling, status } = useSjekkBehandlingStatus(stønadstype);
+    const { harBehandling, harLastetBehandlingsstatus } = useSjekkBehandlingStatus(stønadstype);
 
     useEffect(() => {
         hentPersonData(skalHenteMedBarn(stønadstype))
@@ -52,7 +52,7 @@ export const PersonRouting: React.FC<{ stønadstype: Stønadstype; children: Rea
     if (!harLastetPerson) {
         return null;
     }
-    if (harLastetPerson && status) {
+    if (harLastetPerson && harLastetBehandlingsstatus) {
         return (
             <PersonProvider person={person} harBehandling={harBehandling}>
                 {children}

--- a/src/frontend/components/PersonRouting.tsx
+++ b/src/frontend/components/PersonRouting.tsx
@@ -27,7 +27,7 @@ export const PersonRouting: React.FC<{ stønadstype: Stønadstype; children: Rea
     const [harLastetPerson, settHarLastetPerson] = useState<boolean>(false);
     const [feilmelding, settFeilmelding] = useState<string>();
 
-    const { harBehandling } = useSjekkBehandlingStatus(stønadstype);
+    const { harBehandling, status } = useSjekkBehandlingStatus(stønadstype);
 
     useEffect(() => {
         hentPersonData(skalHenteMedBarn(stønadstype))
@@ -52,10 +52,11 @@ export const PersonRouting: React.FC<{ stønadstype: Stønadstype; children: Rea
     if (!harLastetPerson) {
         return null;
     }
-
-    return (
-        <PersonProvider person={person} harBehandling={harBehandling}>
-            {children}
-        </PersonProvider>
-    );
+    if (harLastetPerson && status) {
+        return (
+            <PersonProvider person={person} harBehandling={harBehandling}>
+                {children}
+            </PersonProvider>
+        );
+    }
 };

--- a/src/frontend/components/Søknadside/SjekkBehandlingStatus.tsx
+++ b/src/frontend/components/Søknadside/SjekkBehandlingStatus.tsx
@@ -5,15 +5,19 @@ import { Stønadstype } from '../../typer/stønadstyper';
 
 const useSjekkBehandlingStatus = (stonadstype: Stønadstype) => {
     const [harBehandling, setHarBehandling] = useState<boolean | false>(false);
+    const [status, setStatus] = useState<boolean | false>(false);
 
     useEffect(() => {
         hentBehandlingStatus(stonadstype)
             .then(setHarBehandling)
             .catch(() => {
                 setHarBehandling(false);
+            })
+            .finally(() => {
+                setStatus(true);
             });
     }, [stonadstype]);
-    return { harBehandling };
+    return { harBehandling, status };
 };
 
 export default useSjekkBehandlingStatus;

--- a/src/frontend/components/Søknadside/SjekkBehandlingStatus.tsx
+++ b/src/frontend/components/Søknadside/SjekkBehandlingStatus.tsx
@@ -4,8 +4,8 @@ import { hentBehandlingStatus } from '../../api/api';
 import { Stønadstype } from '../../typer/stønadstyper';
 
 const useSjekkBehandlingStatus = (stonadstype: Stønadstype) => {
-    const [harBehandling, setHarBehandling] = useState<boolean | false>(false);
-    const [status, setStatus] = useState<boolean | false>(false);
+    const [harBehandling, setHarBehandling] = useState<boolean>(false);
+    const [harLastetBehandlingsstatus, setHarLastetBehandlingsstatus] = useState<boolean>(false);
 
     useEffect(() => {
         hentBehandlingStatus(stonadstype)
@@ -14,10 +14,10 @@ const useSjekkBehandlingStatus = (stonadstype: Stønadstype) => {
                 setHarBehandling(false);
             })
             .finally(() => {
-                setStatus(true);
+                setHarLastetBehandlingsstatus(true);
             });
     }, [stonadstype]);
-    return { harBehandling, status };
+    return { harBehandling, harLastetBehandlingsstatus };
 };
 
 export default useSjekkBehandlingStatus;


### PR DESCRIPTION

<img width="791" alt="Screenshot 2024-12-02 at 13 49 20" src="https://github.com/user-attachments/assets/97487089-1711-48cf-9230-00659c7ad532">
### Hvorfor er denne endringen nødvendig? ✨


Ny komponent skal kalles etter at både personopplysninger og har-behandling endepunkt har blitt ferdig
