### PR TITLE
HarBehandling stønadsspesifike tekster

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "ci": "yarn --prefer-offline --frozen-lockfile && yarn --cwd src/backend ci",
-    "build": "PUBLIC_URL=/tilleggsstonader/soknad webpack --config ./webpack/webpack.production.js && yarn --cwd src/backend build",
+    "build": "yarn lint && PUBLIC_URL=/tilleggsstonader/soknad webpack --config ./webpack/webpack.production.js && yarn --cwd src/backend build",
     "build:dev": "PUBLIC_URL=/tilleggsstonader/soknad webpack --config ./webpack/webpack.development.js",
     "start:dev": "PUBLIC_URL=/tilleggsstonader/soknad webpack serve --config ./webpack/webpack.development.js",
     "postinstall": "husky",

--- a/src/frontend/barnetilsyn/HarBehandlingSide.tsx
+++ b/src/frontend/barnetilsyn/HarBehandlingSide.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 
-import { styled } from 'styled-components';
-
 import { ChevronRightIcon } from '@navikt/aksel-icons';
-import { Alert, BodyLong, BodyShort, Button, Heading, VStack } from '@navikt/ds-react';
+import { Alert, BodyLong, Button, Heading, HStack, VStack } from '@navikt/ds-react';
 
 import { AvsluttOgLoggUtKnapp } from '../components/AvsluttOgLoggUtKnapp';
 import { Container } from '../components/Side';
@@ -13,12 +11,6 @@ import { harEksisterendeBehandlingTekster } from '../tekster/harEksisterendeBeha
 import { kvitteringTekster } from '../tekster/kvittering';
 import { stønadstypeTilSkjemanavn } from '../typer/skjemanavn';
 import { Stønadstype } from '../typer/stønadstyper';
-
-const KnappeContainer = styled(BodyShort)`
-    display: flex;
-    gap: 1rem;
-    justify-content: center;
-`;
 
 interface SøknadsideProps {
     startSøknad: () => void;
@@ -75,16 +67,12 @@ const HarBehandlingSide: React.FC<SøknadsideProps> = ({
                     />
                 </BodyLong>
             </VStack>
-            <KnappeContainer
-                style={{
-                    justifyContent: 'flex-start',
-                }}
-            >
+            <HStack gap={'4'} justify="start">
                 <AvsluttOgLoggUtKnapp />
                 <Button onClick={startSøknad} variant="primary" icon={<ChevronRightIcon />}>
                     <LocaleTekst tekst={harEksisterendeBehandlingTekster.startNySøknad} />
                 </Button>
-            </KnappeContainer>
+            </HStack>
         </Container>
     );
 };

--- a/src/frontend/barnetilsyn/HarBehandlingSide.tsx
+++ b/src/frontend/barnetilsyn/HarBehandlingSide.tsx
@@ -7,7 +7,6 @@ import { AvsluttOgLoggUtKnapp } from '../components/AvsluttOgLoggUtKnapp';
 import { Container } from '../components/Side';
 import LocaleInlineLenke from '../components/Teksthåndtering/LocaleInlineLenke';
 import LocaleTekst from '../components/Teksthåndtering/LocaleTekst';
-import { useSpråk } from '../context/SpråkContext';
 import { harEksisterendeBehandlingTekster } from '../tekster/harEksisterendeBehandling';
 import { kvitteringTekster } from '../tekster/kvittering';
 import { stønadstypeTilSkjemanavn } from '../typer/skjemanavn';
@@ -28,8 +27,6 @@ const HarBehandlingSide: React.FC<SøknadsideProps> = ({
     startSøknad,
     stønadstype,
 }: SøknadsideProps) => {
-    const { locale } = useSpråk();
-
     return (
         <Container>
             <VStack gap="4">
@@ -77,7 +74,7 @@ const HarBehandlingSide: React.FC<SøknadsideProps> = ({
             >
                 <AvsluttOgLoggUtKnapp />
                 <Button onClick={startSøknad} variant="primary" icon={<ChevronRightIcon />}>
-                    {harEksisterendeBehandlingTekster.startNySøknad[locale]}
+                    <LocaleTekst tekst={harEksisterendeBehandlingTekster.startNySøknad} />
                 </Button>
             </KnappeContainer>
         </Container>

--- a/src/frontend/barnetilsyn/HarBehandlingSide.tsx
+++ b/src/frontend/barnetilsyn/HarBehandlingSide.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import { styled } from 'styled-components';
 
 import { ChevronRightIcon } from '@navikt/aksel-icons';
@@ -64,7 +66,13 @@ const HarBehandlingSide: React.FC<SøknadsideProps> = ({
                     />
                 </Heading>
                 <BodyLong>
-                    <VilFortsattSendeSøknadTekst stønadstype={stønadstype} />
+                    <LocaleTekst
+                        tekst={
+                            harEksisterendeBehandlingTekster.vil_forstatt_sende_søknad_innhold[
+                                stønadstype
+                            ]
+                        }
+                    />
                 </BodyLong>
             </VStack>
             <KnappeContainer
@@ -80,14 +88,5 @@ const HarBehandlingSide: React.FC<SøknadsideProps> = ({
         </Container>
     );
 };
-
-function VilFortsattSendeSøknadTekst({ stønadstype }: { stønadstype: Stønadstype }) {
-    const tekst =
-        stønadstype === Stønadstype.BARNETILSYN
-            ? harEksisterendeBehandlingTekster.vil_forstatt_sende_søknad_innhold_tilsyn_barn
-            : harEksisterendeBehandlingTekster.vil_forstatt_sende_søknad_innhold_læremidler;
-
-    return <LocaleTekst tekst={tekst} />;
-}
 
 export default HarBehandlingSide;

--- a/src/frontend/tekster/harEksisterendeBehandling.ts
+++ b/src/frontend/tekster/harEksisterendeBehandling.ts
@@ -1,17 +1,19 @@
+import { Stønadstype } from '../typer/stønadstyper';
 import { InlineLenke, TekstElement } from '../typer/tekst';
 
-interface søknadsideInnhold {
+interface HarEksistendeBehandlingInnhold {
     spørsmål_om_søknaden: TekstElement<string>;
     spørsmål_om_søknaden_innhold: TekstElement<InlineLenke>;
     vil_forstatt_sende_søknad: TekstElement<string>;
-    vil_forstatt_sende_søknad_innhold_tilsyn_barn: TekstElement<string>;
-    vil_forstatt_sende_søknad_innhold_læremidler: TekstElement<string>;
+    vil_forstatt_sende_søknad_innhold: {
+        [key in Stønadstype]: TekstElement<string>;
+    };
     alert_for_stønadstype: TekstElement<string>;
     alert_innhold: TekstElement<InlineLenke>;
     startNySøknad: TekstElement<string>;
 }
 
-export const harEksisterendeBehandlingTekster: søknadsideInnhold = {
+export const harEksisterendeBehandlingTekster: HarEksistendeBehandlingInnhold = {
     spørsmål_om_søknaden: {
         nb: 'Spørsmål om søknaden eller saksbehandlingstid?',
     },
@@ -29,11 +31,13 @@ export const harEksisterendeBehandlingTekster: søknadsideInnhold = {
     vil_forstatt_sende_søknad: {
         nb: 'Vil du likevel sende ny søknad?',
     },
-    vil_forstatt_sende_søknad_innhold_tilsyn_barn: {
-        nb: 'Hvis du har begynt på nytt tiltak, ny utdanning eller det er et nytt skole/barnehageår kan du sende ny søknad.',
-    },
-    vil_forstatt_sende_søknad_innhold_læremidler: {
-        nb: 'Hvis du har begynt på en ny utdanning eller opplæring, eller det gjelder et nytt skoleår, kan du sende ny søknad.',
+    vil_forstatt_sende_søknad_innhold: {
+        [Stønadstype.BARNETILSYN]: {
+            nb: 'Hvis du har begynt på nytt tiltak, ny utdanning eller det er et nytt skole/barnehageår kan du sende ny søknad.',
+        },
+        [Stønadstype.LÆREMIDLER]: {
+            nb: 'Hvis du har begynt på en ny utdanning eller opplæring, eller det gjelder et nytt skoleår, kan du sende ny søknad.',
+        },
     },
     alert_for_stønadstype: {
         nb: 'Du har allerede sendt oss en søknad om støtte til [0]. ',


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Se commit for commit

Føler en `if else` for tekster er "skummelt", då det er stor risiko at dette er funksjonalitet som ikke blir testet når man legger til en ny stønadstype. 
Så la til mapping per stønadstype, som gir en mer typesikker tekst dersom man legger til ny stønad, eller må forholde seg til ny tekst dersom man legger til ny stønadstype
https://github.com/navikt/tilleggsstonader-soknad/commit/1ad60f409f7ab7bd710c037b5de2e3470284cf66