### PR TITLE
Bytter ut KnappeContainers som wrapper BodyShort med aksel-komponenter

### DIFF
--- a/src/frontend/barnetilsyn/Forside.tsx
+++ b/src/frontend/barnetilsyn/Forside.tsx
@@ -1,15 +1,14 @@
 import React, { useEffect, useState } from 'react';
 
 import { useLocation, useNavigate } from 'react-router';
-import { styled } from 'styled-components';
 
 import {
     Accordion,
     Alert,
     BodyLong,
-    BodyShort,
     Button,
     Heading,
+    HStack,
     Label,
     VStack,
 } from '@navikt/ds-react';
@@ -30,12 +29,6 @@ import { fellesTekster } from '../tekster/felles';
 import { Stønadstype } from '../typer/stønadstyper';
 import { erSnartNyttSkoleår } from '../utils/dato';
 import { hentNesteRoute } from '../utils/routes';
-
-const KnappeContainer = styled(BodyShort)`
-    display: flex;
-    gap: 1rem;
-    justify-content: center;
-`;
 
 const Forside: React.FC = () => {
     const navigate = useNavigate();
@@ -152,11 +145,11 @@ const Forside: React.FC = () => {
                     oppdaterHarBekreftet={(harBekreftet) => settHarBekreftet(harBekreftet)}
                     fjernFeilmelding={() => settSkalViseFeilmelding(false)}
                 />
-                <KnappeContainer>
+                <HStack justify={'center'}>
                     <Button onClick={startSøknad} variant="primary">
                         Start søknad
                     </Button>
-                </KnappeContainer>
+                </HStack>
             </VStack>
         </Container>
     );

--- a/src/frontend/components/Side.tsx
+++ b/src/frontend/components/Side.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 
-import { Alert, Button, ErrorSummary, VStack } from '@navikt/ds-react';
+import { Alert, Button, ErrorSummary, HGrid, VStack } from '@navikt/ds-react';
 import { ABreakpointMd } from '@navikt/ds-tokens/dist/tokens';
 
 import { StegIndikator } from './StegIndikator';
@@ -40,12 +40,6 @@ export const Container = styled.div`
         margin: auto;
         padding: 2rem 0;
     }
-`;
-
-const KnappeContainerMedFeilmelding = styled.div`
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 1rem;
 `;
 
 const Side: React.FC<Props> = ({ children, validerSteg, oppdaterSøknad }) => {
@@ -144,7 +138,7 @@ const Side: React.FC<Props> = ({ children, validerSteg, oppdaterSøknad }) => {
                 </ErrorSummary>
             )}
             <VStack gap="8">{children}</VStack>
-            <KnappeContainerMedFeilmelding>
+            <HGrid gap={'4'} columns={'1fr 1fr'}>
                 <Button variant="secondary" onClick={navigerTilForrigeSide}>
                     <LocaleTekst tekst={fellesTekster.forrige} />
                 </Button>
@@ -157,7 +151,7 @@ const Side: React.FC<Props> = ({ children, validerSteg, oppdaterSøknad }) => {
                         <LocaleTekst tekst={fellesTekster.neste} />
                     </Button>
                 )}
-            </KnappeContainerMedFeilmelding>
+            </HGrid>
             {sendInnFeil && (
                 <Alert variant={'error'}>
                     <LocaleTekst tekst={fellesTekster.send_inn_søknad_feil} />

--- a/src/frontend/læremidler/Forside.tsx
+++ b/src/frontend/læremidler/Forside.tsx
@@ -1,9 +1,8 @@
 import React, { useEffect, useState } from 'react';
 
 import { useLocation, useNavigate } from 'react-router';
-import { styled } from 'styled-components';
 
-import { Accordion, BodyLong, BodyShort, Button, Label, VStack } from '@navikt/ds-react';
+import { Accordion, BodyLong, Button, HStack, Label, VStack } from '@navikt/ds-react';
 
 import { ERouteLæremidler, routesLæremidler } from './routing/routesLæremidler';
 import { forsideTekster } from './tekster/forside';
@@ -20,12 +19,6 @@ import { usePerson } from '../context/PersonContext';
 import { fellesTekster } from '../tekster/felles';
 import { Stønadstype } from '../typer/stønadstyper';
 import { hentNesteRoute } from '../utils/routes';
-
-const KnappeContainer = styled(BodyShort)`
-    display: flex;
-    gap: 1rem;
-    justify-content: center;
-`;
 
 const Forside: React.FC = () => {
     const navigate = useNavigate();
@@ -120,11 +113,11 @@ const Forside: React.FC = () => {
                     oppdaterHarBekreftet={(harBekreftet) => settHarBekreftet(harBekreftet)}
                     fjernFeilmelding={() => settSkalViseFeilmelding(false)}
                 />
-                <KnappeContainer>
+                <HStack justify={'center'}>
                     <Button onClick={startSøknad} variant="primary">
                         Start søknad
                     </Button>
-                </KnappeContainer>
+                </HStack>
             </VStack>
         </Container>
     );


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Etter:
<img width="495" alt="image" src="https://github.com/user-attachments/assets/f9bd2914-5c2f-4a85-9bb2-34454dbbe92f">

Før:
<img width="459" alt="image" src="https://github.com/user-attachments/assets/4fb533fb-d647-4bfe-a4f5-1eb0a96d1ae3">


Etter:
<img width="514" alt="image" src="https://github.com/user-attachments/assets/a573879d-42e2-4247-964c-ea40fa14020e">

Før:
<img width="511" alt="image" src="https://github.com/user-attachments/assets/0e59d216-06f8-4882-953a-585dee51d885">


Etter:
<img width="539" alt="image" src="https://github.com/user-attachments/assets/51234c11-57a9-4c30-840b-3793f0d1e682">

Før:
<img width="536" alt="image" src="https://github.com/user-attachments/assets/a70e9e02-087b-4ca7-8557-f9006cdea998">
