### PR TITLE
Fjerner checkbox på oppsummeringen om at man bekrefter at man har les…

### DIFF
--- a/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/frontend/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
@@ -1,20 +1,10 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 
 import { ChevronLeftIcon, PaperclipIcon } from '@navikt/aksel-icons';
-import {
-    Accordion,
-    BodyLong,
-    BodyShort,
-    Button,
-    Checkbox,
-    CheckboxGroup,
-    Heading,
-    Label,
-    VStack,
-} from '@navikt/ds-react';
+import { Accordion, BodyLong, BodyShort, Button, Heading, Label, VStack } from '@navikt/ds-react';
 import { AccordionItemProps } from '@navikt/ds-react/esm/accordion/AccordionItem';
 
 import ArbeidOgOppholdOppsummering from './ArbeidOgOppholdOppsummering';
@@ -267,20 +257,9 @@ const Oppsummering = () => {
     const { hovedytelse, aktivitet, valgteBarnIdenter, barnMedBarnepass, dokumentasjon } =
         usePassAvBarnSøknad();
     const { person } = usePerson();
-    const [harBekreftet, settHarBekreftet] = useState(false);
-    const [feil, settFeil] = useState<string>('');
 
     return (
-        <Side
-            validerSteg={() => {
-                if (!harBekreftet) {
-                    settFeil('Du må bekrefte for å sende inn søknaden');
-                    return false;
-                }
-                settFeil('');
-                return true;
-            }}
-        >
+        <Side>
             <Heading size={'medium'}>
                 <LocaleTekst tekst={oppsummeringTekster.tittel} />
             </Heading>
@@ -295,21 +274,6 @@ const Oppsummering = () => {
                 <PassAvBarn person={person} barnMedBarnepass={barnMedBarnepass} />
                 <Vedlegg dokumentasjon={dokumentasjon} />
             </Accordion>
-
-            <CheckboxGroup
-                value={[harBekreftet]}
-                onChange={(verdier) => {
-                    settHarBekreftet(verdier.includes(true));
-                    settFeil('');
-                }}
-                legend={<LocaleTekst tekst={oppsummeringTekster.bekreft_checkboks} />}
-                hideLegend
-                error={feil}
-            >
-                <Checkbox value={true} error={!!feil}>
-                    <LocaleTekst tekst={oppsummeringTekster.bekreft_checkboks} />
-                </Checkbox>
-            </CheckboxGroup>
         </Side>
     );
 };

--- a/src/frontend/barnetilsyn/tekster/oppsummering.ts
+++ b/src/frontend/barnetilsyn/tekster/oppsummering.ts
@@ -3,7 +3,6 @@ import { InlineLenke, LesMer, TekstElement } from '../../typer/tekst';
 interface OppsummeringInnhold {
     tittel: TekstElement<string>;
     guide_innhold: TekstElement<string>;
-    bekreft_checkboks: TekstElement<string>;
 
     accordians: {
         om_deg: {
@@ -48,10 +47,6 @@ export const oppsummeringTekster: OppsummeringInnhold = {
     },
     guide_innhold: {
         nb: 'Se over søknaden din før du sender den inn. Alt du har fylt inn er lagret. Hvis noe er feil, så kan du gå tilbake og endre det.',
-    },
-
-    bekreft_checkboks: {
-        nb: 'Jeg bekrefter at jeg har lest og forstått informasjonen i søknaden og svart så godt jeg kan.',
     },
 
     accordians: {

--- a/src/frontend/components/Oppsummering/OppsummeringSide.tsx
+++ b/src/frontend/components/Oppsummering/OppsummeringSide.tsx
@@ -1,43 +1,7 @@
-import React, { ReactNode, useState } from 'react';
+import React, { ReactNode } from 'react';
 
-import { Checkbox, CheckboxGroup } from '@navikt/ds-react';
-
-import { useSpråk } from '../../context/SpråkContext';
-import { fellesOppsummeringTekster } from '../../tekster/oppsummering';
 import Side from '../Side';
-import LocaleTekst from '../Teksthåndtering/LocaleTekst';
 
 export const OppsummeringSide = ({ children }: { children: ReactNode }) => {
-    const { locale } = useSpråk();
-    const [harBekreftet, settHarBekreftet] = useState(false);
-    const [feilBekreftet, settFeilBekreftet] = useState<string>();
-
-    return (
-        <Side
-            validerSteg={() => {
-                if (!harBekreftet) {
-                    settFeilBekreftet(fellesOppsummeringTekster.bekreft.feil[locale]);
-                    return false;
-                }
-                settFeilBekreftet('');
-                return true;
-            }}
-        >
-            {children}
-            <CheckboxGroup
-                value={[harBekreftet]}
-                onChange={(verdier) => {
-                    settHarBekreftet(verdier.includes(true));
-                    settFeilBekreftet(undefined);
-                }}
-                legend={<LocaleTekst tekst={fellesOppsummeringTekster.bekreft.tittel} />}
-                hideLegend
-                error={feilBekreftet}
-            >
-                <Checkbox value={true} error={!!feilBekreftet}>
-                    <LocaleTekst tekst={fellesOppsummeringTekster.bekreft.tittel} />
-                </Checkbox>
-            </CheckboxGroup>
-        </Side>
-    );
+    return <Side>{children}</Side>;
 };

--- a/src/frontend/tekster/oppsummering.ts
+++ b/src/frontend/tekster/oppsummering.ts
@@ -15,10 +15,6 @@ interface OppsummeringInnhold {
     };
     vedlegg_tittel: TekstElement<string>;
     ingen_vedlegg: TekstElement<string>;
-    bekreft: {
-        tittel: TekstElement<string>;
-        feil: TekstElement<string>;
-    };
 }
 
 export const fellesOppsummeringTekster: OppsummeringInnhold = {
@@ -57,13 +53,4 @@ export const fellesOppsummeringTekster: OppsummeringInnhold = {
     },
     vedlegg_tittel: { nb: 'Vedlegg' },
     ingen_vedlegg: { nb: 'Ingen vedlegg' },
-
-    bekreft: {
-        tittel: {
-            nb: 'Jeg bekrefter at jeg har lest og forstått informasjonen i søknaden og svart så godt jeg kan.',
-        },
-        feil: {
-            nb: 'Du må bekrefte for å sende inn søknaden',
-        },
-    },
 };


### PR DESCRIPTION
…t og svart riktig.

- Ny søknadsstandarden i Nav sier at det kun skal være en bekreftelse før utfylling av søknaden

### Hvorfor er denne endringen nødvendig? ✨

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-23544

## Læremidler
### Etter
<img width="582" alt="image" src="https://github.com/user-attachments/assets/009dbc72-bb06-467e-8bb3-158f063aa0b0">
### Før
<img width="550" alt="image" src="https://github.com/user-attachments/assets/bfe6c934-be92-4313-871f-d47f09d335c5">


## Tilsyn barn
### Etter
<img width="568" alt="image" src="https://github.com/user-attachments/assets/b8745972-09b0-4a4d-ac16-ed07c09996ef">
### Før
<img width="551" alt="image" src="https://github.com/user-attachments/assets/a180ba5b-b980-4857-b6ad-df90648ea4d2">
