### PR TITLE
Endre endepunkt for henting av aktivitet så man kan hente lenger tilb…

### DIFF
--- a/src/frontend/api/api.ts
+++ b/src/frontend/api/api.ts
@@ -28,11 +28,15 @@ export const hentPersonData = (medBarn: boolean): Promise<Person> => {
         .then((response) => response.data);
 };
 
-export const hentArbeidsrettedeAktiviteter = (): Promise<RegisterAktivitet[]> => {
+export const hentArbeidsrettedeAktiviteter = (
+    stønadstype: Stønadstype
+): Promise<RegisterAktivitet[]> => {
+    const url = `${Environment().apiProxyUrl}/aktivitet/v2`;
     return axios
-        .get<RegisterAktiviteterResponse>(`${Environment().apiProxyUrl}/aktivitet`, defaultConfig())
+        .post<RegisterAktiviteterResponse>(url, { stønadstype: stønadstype }, defaultConfig())
         .then((response) => response.data.aktiviteter);
 };
+
 export const hentBehandlingStatus = (stønadstype: Stønadstype): Promise<boolean> => {
     return axios
         .get<boolean>(

--- a/src/frontend/api/api.ts
+++ b/src/frontend/api/api.ts
@@ -31,7 +31,7 @@ export const hentPersonData = (medBarn: boolean): Promise<Person> => {
 export const hentArbeidsrettedeAktiviteter = (
     stønadstype: Stønadstype
 ): Promise<RegisterAktivitet[]> => {
-    const url = `${Environment().apiProxyUrl}/aktivitet/v2`;
+    const url = `${Environment().apiProxyUrl}/aktivitet`;
     return axios
         .post<RegisterAktiviteterResponse>(url, { stønadstype: stønadstype }, defaultConfig())
         .then((response) => response.data.aktiviteter);

--- a/src/frontend/barnetilsyn/BarnetilsynApp.tsx
+++ b/src/frontend/barnetilsyn/BarnetilsynApp.tsx
@@ -46,7 +46,7 @@ const BarnetilsynApp = () => {
         <PersonRouting stønadstype={Stønadstype.BARNETILSYN}>
             <ValideringsfeilProvider>
                 <PassAvBarnSøknadProvider>
-                    <RegisterAktiviteterProvider>
+                    <RegisterAktiviteterProvider stønadstype={Stønadstype.BARNETILSYN}>
                         <BarnetilsynInnhold />
                     </RegisterAktiviteterProvider>
                 </PassAvBarnSøknadProvider>

--- a/src/frontend/context/RegisterAktiviteterContext.tsx
+++ b/src/frontend/context/RegisterAktiviteterContext.tsx
@@ -1,26 +1,31 @@
 import { useEffect, useState } from 'react';
 
-import createUseContext from 'constate';
+import constate from 'constate';
 
 import { hentArbeidsrettedeAktiviteter } from '../api/api';
 import { mapTilRegisterAktiviteterObjektMedLabel } from '../components/Aktivitet/registerAktivitetUtil';
 import { RegisterAktivitetMedLabel } from '../typer/registerAktivitet';
+import { Stønadstype } from '../typer/stønadstyper';
 
-const [RegisterAktiviteterProvider, useRegisterAktiviteter] = createUseContext(() => {
+interface Props {
+    stønadstype: Stønadstype;
+}
+
+const [RegisterAktiviteterProvider, useRegisterAktiviteter] = constate(({ stønadstype }: Props) => {
     RegisterAktiviteterProvider.displayName = 'AKTIVITETER_PROVIDER';
 
     const [registerAktiviteter, settRegisterAktiviteter] =
         useState<Record<string, RegisterAktivitetMedLabel>>();
 
     useEffect(() => {
-        hentArbeidsrettedeAktiviteter()
+        hentArbeidsrettedeAktiviteter(stønadstype)
             .then((arbeidsrettedeAktiviteter) =>
                 settRegisterAktiviteter(
                     mapTilRegisterAktiviteterObjektMedLabel(arbeidsrettedeAktiviteter)
                 )
             )
             .catch(() => settRegisterAktiviteter({}));
-    }, []);
+    }, [stønadstype]);
 
     return {
         registerAktiviteter,

--- a/src/frontend/læremidler/LæremidlerApp.tsx
+++ b/src/frontend/læremidler/LæremidlerApp.tsx
@@ -44,7 +44,7 @@ const LæremidlerApp = () => {
         <PersonRouting stønadstype={Stønadstype.LÆREMIDLER}>
             <ValideringsfeilProvider>
                 <LæremidlerSøknadProvider>
-                    <RegisterAktiviteterProvider>
+                    <RegisterAktiviteterProvider stønadstype={Stønadstype.LÆREMIDLER}>
                         <LæremidlerInnhold />
                     </RegisterAktiviteterProvider>
                 </LæremidlerSøknadProvider>

--- a/src/frontend/læremidler/tekster/utdanning.ts
+++ b/src/frontend/læremidler/tekster/utdanning.ts
@@ -65,14 +65,14 @@ const hvilkenAktivitet: HvilkenAktivitet = {
         header_ingen_registrerte_aktiviteter:
             tekstArbeidsrettedeAktiviteter.lesMer.header_ingen_registrerte_aktiviteter,
         del1: {
-            nb: 'Vi henter tiltak og utdanning registrert på deg 3 måneder tilbake i tid. Er du enslig eller gjenlevende så er det ikke alltid dette er registert på en måte så vi klare å hente det.',
+            nb: 'Vi henter tiltak og utdanning registrert på deg 6 måneder tilbake i tid. Er du enslig eller gjenlevende så er det ikke alltid dette er registert på en måte så vi klare å hente det.',
         },
         del2: {
             nb: 'Går du på arbeidsavklaringspenger eller mottar uføretrygd, og utdanningen din mangler? Da anbefaler vi at du tar kontakt med veilederen din via aktivitetsplanen og ber om at den registreres. Du kan fortsatt søke nå, men det tar lengre tid for oss å behandle din søknad hvis vi må kontakte veilederen din for deg.',
         },
         del3: {
             nb: [
-                'Hvis du skal søke støtte i forbindelse med en utdanning som ble avsluttet for over 3 måneder siden, må du ',
+                'Hvis du skal søke støtte i forbindelse med en utdanning som ble avsluttet for over 6 måneder siden, må du ',
                 {
                     tekst: 'fylle ut papirsøknad',
                     url: 'https://www.nav.no/fyllut/nav111215b?sub=paper',


### PR DESCRIPTION
…ake i tid avhengig av stønadstype

### Hvorfor er denne endringen nødvendig? ✨
Skal vise aktiviteter 6mnd tilbake i tid i søknaden. 

Tar i bruk et nytt endepunkt hvor stønadstypen må sendes inn for å avgjøre hvor langt tilbake man skal vise aktiviteter fra.

Henger sammen med [PR 169 i søknad-api](https://github.com/navikt/tilleggsstonader-soknad-api/pull/169/files)