### PR TITLE
🐛 Bugfix i vedleggstekst

### DIFF
--- a/src/frontend/barnetilsyn/steg/6-vedlegg/VedleggPassAvBarn.tsx
+++ b/src/frontend/barnetilsyn/steg/6-vedlegg/VedleggPassAvBarn.tsx
@@ -1,13 +1,42 @@
 import React from 'react';
 
-import Vedlegg from '../../../components/Vedlegg/Vedlegg';
+import Vedlegg, { DokumentasjonFeltMedVedleggstekst } from '../../../components/Vedlegg/Vedlegg';
 import { usePassAvBarnSøknad } from '../../../context/PassAvBarnSøknadContext';
+import { usePerson } from '../../../context/PersonContext';
+import { useSpråk } from '../../../context/SpråkContext';
+import { DokumentasjonFelt, VedleggstypePassAvBarn } from '../../../typer/skjema';
+import { hentBeskjedMedEttParameter } from '../../../utils/tekster';
+import { typerVedleggTeksterPassAvBarn } from '../../tekster/vedlegg';
 
 const VedleggPassAvBarn = () => {
     const { dokumentasjon, settDokumentasjon, dokumentasjonsbehov } = usePassAvBarnSøknad();
+    const { person } = usePerson();
+    const { locale } = useSpråk();
+
+    const finnBarnSomVedleggGjelder = (dokumentasjonsfelt: DokumentasjonFelt) => {
+        return dokumentasjonsfelt?.barnId
+            ? person.barn.find((barn) => barn.ident === dokumentasjonsfelt?.barnId)
+            : undefined;
+    };
+
+    const dokumentasjonMedTittelOgBeskrivelse: DokumentasjonFeltMedVedleggstekst[] =
+        dokumentasjon.map((dokumentasjon) => {
+            const barnetsFornavn = finnBarnSomVedleggGjelder(dokumentasjon)?.fornavn ?? 'barnet';
+            const vedleggstekster =
+                typerVedleggTeksterPassAvBarn[dokumentasjon.type as VedleggstypePassAvBarn];
+            return {
+                ...dokumentasjon,
+                tittel: hentBeskjedMedEttParameter(barnetsFornavn, vedleggstekster.tittel[locale]),
+                beskrivelse: hentBeskjedMedEttParameter(
+                    barnetsFornavn,
+                    vedleggstekster.beskrivelse[locale]
+                ),
+            };
+        });
+
     return (
         <Vedlegg
-            dokumentasjon={dokumentasjon}
+            dokumentasjon={dokumentasjonMedTittelOgBeskrivelse}
             settDokumentasjon={settDokumentasjon}
             dokumentasjonsbehov={dokumentasjonsbehov}
         />

--- a/src/frontend/barnetilsyn/steg/6-vedlegg/VedleggPassAvBarn.tsx
+++ b/src/frontend/barnetilsyn/steg/6-vedlegg/VedleggPassAvBarn.tsx
@@ -4,9 +4,9 @@ import Vedlegg, { DokumentasjonFeltMedVedleggstekst } from '../../../components/
 import { usePassAvBarnSøknad } from '../../../context/PassAvBarnSøknadContext';
 import { usePerson } from '../../../context/PersonContext';
 import { useSpråk } from '../../../context/SpråkContext';
-import { DokumentasjonFelt, VedleggstypePassAvBarn } from '../../../typer/skjema';
+import { typerVedleggTekster } from '../../../tekster/vedlegg';
+import { DokumentasjonFelt } from '../../../typer/skjema';
 import { hentBeskjedMedEttParameter } from '../../../utils/tekster';
-import { typerVedleggTeksterPassAvBarn } from '../../tekster/vedlegg';
 
 const VedleggPassAvBarn = () => {
     const { dokumentasjon, settDokumentasjon, dokumentasjonsbehov } = usePassAvBarnSøknad();
@@ -22,8 +22,7 @@ const VedleggPassAvBarn = () => {
     const dokumentasjonMedTittelOgBeskrivelse: DokumentasjonFeltMedVedleggstekst[] =
         dokumentasjon.map((dokumentasjon) => {
             const barnetsFornavn = finnBarnSomVedleggGjelder(dokumentasjon)?.fornavn ?? 'barnet';
-            const vedleggstekster =
-                typerVedleggTeksterPassAvBarn[dokumentasjon.type as VedleggstypePassAvBarn];
+            const vedleggstekster = typerVedleggTekster[dokumentasjon.type];
             return {
                 ...dokumentasjon,
                 tittel: hentBeskjedMedEttParameter(barnetsFornavn, vedleggstekster.tittel[locale]),

--- a/src/frontend/barnetilsyn/tekster/vedlegg.ts
+++ b/src/frontend/barnetilsyn/tekster/vedlegg.ts
@@ -1,8 +1,8 @@
 import { VedleggstypePassAvBarn } from '../../typer/skjema';
-import { Vedlegg } from '../../typer/tekst';
+import { Vedleggstekst } from '../../typer/tekst';
 
 export type TekstTypeVedlegg = {
-    [key in VedleggstypePassAvBarn]: Vedlegg;
+    [key in VedleggstypePassAvBarn]: Vedleggstekst;
 };
 
 export const typerVedleggTeksterPassAvBarn: TekstTypeVedlegg = {

--- a/src/frontend/components/Filopplaster/Filopplaster.tsx
+++ b/src/frontend/components/Filopplaster/Filopplaster.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { ReactNode, useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -19,7 +19,6 @@ import { useSpråk } from '../../context/SpråkContext';
 import { fellesTekster } from '../../tekster/felles';
 import { teksterFeilmeldinger } from '../../tekster/filopplasting';
 import { Dokument } from '../../typer/skjema';
-import { TekstElement } from '../../typer/tekst';
 import LocaleTekst from '../Teksthåndtering/LocaleTekst';
 
 type AvslåttFil = FileRejected & { feil: unknown };
@@ -33,7 +32,7 @@ const FilListe = styled(List).attrs({ as: 'ul' })`
 export const Filopplaster: React.FC<{
     opplastedeVedlegg: Dokument[];
     tittel: string;
-    beskrivelse: TekstElement<string>;
+    beskrivelse: ReactNode;
     leggTilDokument: (vedlegg: Dokument) => void;
     slettDokument: (vedlegg: string) => void;
 }> = ({ opplastedeVedlegg, tittel, beskrivelse, leggTilDokument, slettDokument }) => {
@@ -84,7 +83,7 @@ export const Filopplaster: React.FC<{
         <VStack gap="6">
             <FileUpload.Dropzone
                 label={tittel}
-                description={<LocaleTekst tekst={beskrivelse} />}
+                description={beskrivelse}
                 accept={TILLATE_FILENDELSER}
                 maxSizeInBytes={MAX_FILSTØRRELSE}
                 fileLimit={{

--- a/src/frontend/components/Filopplaster/Filopplaster.tsx
+++ b/src/frontend/components/Filopplaster/Filopplaster.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from 'react';
+import React, { useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -32,7 +32,7 @@ const FilListe = styled(List).attrs({ as: 'ul' })`
 export const Filopplaster: React.FC<{
     opplastedeVedlegg: Dokument[];
     tittel: string;
-    beskrivelse: ReactNode;
+    beskrivelse: string;
     leggTilDokument: (vedlegg: Dokument) => void;
     slettDokument: (vedlegg: string) => void;
 }> = ({ opplastedeVedlegg, tittel, beskrivelse, leggTilDokument, slettDokument }) => {

--- a/src/frontend/components/Vedlegg/Vedlegg.tsx
+++ b/src/frontend/components/Vedlegg/Vedlegg.tsx
@@ -7,11 +7,9 @@ import { BodyShort, Heading } from '@navikt/ds-react';
 import Dokumentasjonskrav from './Dokumentasjonskrav';
 import { fjernVedlegg, leggTilVedlegg, opprettDokumentasjonsfelt } from './utils';
 import VedleggManglerModal from './VedleggManglerModal';
-import { usePerson } from '../../context/PersonContext';
 import { useSpråk } from '../../context/SpråkContext';
-import { typerVedleggTekster, vedleggTekster } from '../../tekster/vedlegg';
+import { vedleggTekster } from '../../tekster/vedlegg';
 import { Dokument, DokumentasjonFelt, Dokumentasjonsbehov } from '../../typer/skjema';
-import { hentBeskjedMedEttParameter } from '../../utils/tekster';
 import { Filopplaster } from '../Filopplaster/Filopplaster';
 import { PellePanel } from '../PellePanel/PellePanel';
 import Side from '../Side';
@@ -26,15 +24,19 @@ const VedleggContainer = styled.div`
     margin: 1rem 0;
 `;
 
+export type DokumentasjonFeltMedVedleggstekst = DokumentasjonFelt & {
+    tittel: string;
+    beskrivelse: string;
+};
+
 interface Props {
-    dokumentasjon: DokumentasjonFelt[];
+    dokumentasjon: DokumentasjonFeltMedVedleggstekst[];
     settDokumentasjon: React.Dispatch<React.SetStateAction<DokumentasjonFelt[]>>;
     dokumentasjonsbehov: Dokumentasjonsbehov[];
 }
 
 const Vedlegg: React.FC<Props> = ({ dokumentasjon, settDokumentasjon, dokumentasjonsbehov }) => {
     const { locale } = useSpråk();
-    const { person } = usePerson();
 
     const ref = useRef<HTMLDialogElement>(null);
     const [ikkeOpplastedeDokumenter, settIkkeOpplastedeDokumenter] = React.useState<string[]>([]);
@@ -74,12 +76,6 @@ const Vedlegg: React.FC<Props> = ({ dokumentasjon, settDokumentasjon, dokumentas
         return true;
     };
 
-    const finnBarnSomVedleggGjelder = (dokumentasjonsfelt: DokumentasjonFelt) => {
-        return dokumentasjonsfelt?.barnId
-            ? person.barn.find((barn) => barn.ident === dokumentasjonsfelt?.barnId)
-            : undefined;
-    };
-
     return (
         <Side validerSteg={validerSteg}>
             <Heading size={'medium'}>
@@ -101,18 +97,8 @@ const Vedlegg: React.FC<Props> = ({ dokumentasjon, settDokumentasjon, dokumentas
                             <section key={dok.label}>
                                 <Filopplaster
                                     opplastedeVedlegg={dok.opplastedeVedlegg}
-                                    tittel={hentBeskjedMedEttParameter(
-                                        finnBarnSomVedleggGjelder(dok)?.fornavn ?? '',
-                                        typerVedleggTekster[dok.type].tittel[locale]
-                                    )}
-                                    beskrivelse={
-                                        <LocaleTekst
-                                            tekst={typerVedleggTekster[dok.type].beskrivelse}
-                                            argument0={
-                                                finnBarnSomVedleggGjelder(dok)?.fornavn ?? ''
-                                            }
-                                        />
-                                    }
+                                    tittel={dok.tittel}
+                                    beskrivelse={dok.beskrivelse}
                                     leggTilDokument={(dokument: Dokument) =>
                                         leggTilDokument(dok, dokument)
                                     }

--- a/src/frontend/læremidler/steg/3-vedlegg/VedleggLæremidler.tsx
+++ b/src/frontend/læremidler/steg/3-vedlegg/VedleggLæremidler.tsx
@@ -1,13 +1,29 @@
 import React from 'react';
 
-import Vedlegg from '../../../components/Vedlegg/Vedlegg';
+import Vedlegg, { DokumentasjonFeltMedVedleggstekst } from '../../../components/Vedlegg/Vedlegg';
 import { useLæremidlerSøknad } from '../../../context/LæremiddelSøknadContext';
+import { useSpråk } from '../../../context/SpråkContext';
+import { VedleggstypeLæremidler } from '../../../typer/skjema';
+import { typerVedleggTeksterLæremidler } from '../../tekster/vedlegg';
 
 const VedleggLæremidler = () => {
     const { dokumentasjon, settDokumentasjon, dokumentasjonsbehov } = useLæremidlerSøknad();
+    const { locale } = useSpråk();
+
+    const dokumentasjonMedTittelOgBeskrivelse: DokumentasjonFeltMedVedleggstekst[] =
+        dokumentasjon.map((dokumentasjon) => {
+            const vedleggstekster =
+                typerVedleggTeksterLæremidler[dokumentasjon.type as VedleggstypeLæremidler];
+            return {
+                ...dokumentasjon,
+                tittel: vedleggstekster.tittel[locale],
+                beskrivelse: vedleggstekster.beskrivelse[locale],
+            };
+        });
+
     return (
         <Vedlegg
-            dokumentasjon={dokumentasjon}
+            dokumentasjon={dokumentasjonMedTittelOgBeskrivelse}
             settDokumentasjon={settDokumentasjon}
             dokumentasjonsbehov={dokumentasjonsbehov}
         />

--- a/src/frontend/læremidler/steg/3-vedlegg/VedleggLæremidler.tsx
+++ b/src/frontend/læremidler/steg/3-vedlegg/VedleggLæremidler.tsx
@@ -3,8 +3,7 @@ import React from 'react';
 import Vedlegg, { DokumentasjonFeltMedVedleggstekst } from '../../../components/Vedlegg/Vedlegg';
 import { useLæremidlerSøknad } from '../../../context/LæremiddelSøknadContext';
 import { useSpråk } from '../../../context/SpråkContext';
-import { VedleggstypeLæremidler } from '../../../typer/skjema';
-import { typerVedleggTeksterLæremidler } from '../../tekster/vedlegg';
+import { typerVedleggTekster } from '../../../tekster/vedlegg';
 
 const VedleggLæremidler = () => {
     const { dokumentasjon, settDokumentasjon, dokumentasjonsbehov } = useLæremidlerSøknad();
@@ -12,8 +11,7 @@ const VedleggLæremidler = () => {
 
     const dokumentasjonMedTittelOgBeskrivelse: DokumentasjonFeltMedVedleggstekst[] =
         dokumentasjon.map((dokumentasjon) => {
-            const vedleggstekster =
-                typerVedleggTeksterLæremidler[dokumentasjon.type as VedleggstypeLæremidler];
+            const vedleggstekster = typerVedleggTekster[dokumentasjon.type];
             return {
                 ...dokumentasjon,
                 tittel: vedleggstekster.tittel[locale],

--- a/src/frontend/læremidler/tekster/vedlegg.ts
+++ b/src/frontend/læremidler/tekster/vedlegg.ts
@@ -1,8 +1,8 @@
 import { VedleggstypeLæremidler } from '../../typer/skjema';
-import { Vedlegg } from '../../typer/tekst';
+import { Vedleggstekst } from '../../typer/tekst';
 
 type TekstTypeVedlegg = {
-    [key in VedleggstypeLæremidler]: Vedlegg;
+    [key in VedleggstypeLæremidler]: Vedleggstekst;
 };
 
 export const typerVedleggTeksterLæremidler: TekstTypeVedlegg = {

--- a/src/frontend/typer/tekst.ts
+++ b/src/frontend/typer/tekst.ts
@@ -39,7 +39,7 @@ export type CheckboxGruppe<T extends string> = {
     alternativer: Alternativer<T>;
 };
 
-export type Vedlegg = {
+export type Vedleggstekst = {
     tittel: TekstElement<string>;
     liste_tittel?: TekstElement<string>;
     beskrivelse: TekstElement<string>;

--- a/tests/søknader/passAvBarn/happyPath.spec.ts
+++ b/tests/søknader/passAvBarn/happyPath.spec.ts
@@ -97,7 +97,7 @@ test('At enkel gjennomkjøring av tilsyn barn fungerer', async ({ page }) => {
 
     await expect(page).toHaveURL(PassAvBarnUrls.VEDLEGG);
     await lastOppFil(page, 'Faktura fra SFO/AKS/barnehage');
-    await lastOppFil(page, 'Skriftlig uttalelse fra helsepersonell for [0]');
+    await lastOppFil(page, 'Skriftlig uttalelse fra helsepersonell for Espen');
     await forventIngenWcagViolations(page);
     await klikkPåKnapp(page, 'Neste');
     // Modal om at det mangler vedlegg


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Vi hadde en bug i vedleggsteksten der fornavet til barnet ikke ble flettet inn som det skulle. 

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-24150)

Før: 
![image](https://github.com/user-attachments/assets/b73685a4-33d3-4489-ae60-b75a70ea12ad)


Etter: 
![image](https://github.com/user-attachments/assets/12e4d48c-02e5-4913-a260-73d3ef43412e)
