### PR TITLE
Legger på visning av at vedlegg lastes opp

### DIFF
--- a/src/frontend/components/Vedlegg/Vedlegg.tsx
+++ b/src/frontend/components/Vedlegg/Vedlegg.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import { styled } from 'styled-components';
 
@@ -39,7 +39,7 @@ const Vedlegg: React.FC<Props> = ({ dokumentasjon, settDokumentasjon, dokumentas
     const { locale } = useSpråk();
 
     const ref = useRef<HTMLDialogElement>(null);
-    const [ikkeOpplastedeDokumenter, settIkkeOpplastedeDokumenter] = React.useState<string[]>([]);
+    const [ikkeOpplastedeDokumenter, settIkkeOpplastedeDokumenter] = useState<string[]>([]);
 
     useEffect(() => {
         settDokumentasjon((prevState) =>

--- a/src/frontend/tekster/vedlegg.ts
+++ b/src/frontend/tekster/vedlegg.ts
@@ -28,6 +28,7 @@ interface VedleggInnhold {
         };
     };
     ingen_dokumentasjonsbehov: TekstElement<string>;
+    laster_opp: TekstElement<string>;
 }
 
 const formatKvalitetAccordian: VedleggInnhold['accordians']['format_kvalitet'] = {
@@ -87,6 +88,9 @@ export const vedleggTekster: VedleggInnhold = {
         format_kvalitet: formatKvalitetAccordian,
     },
     ingen_dokumentasjonsbehov: { nb: 'Du trenger ikke å legge ved noen dokumentasjon' },
+    laster_opp: {
+        nb: 'Laster opp vedlegg...',
+    },
 };
 
 interface VedleggManglerModalInnhold {


### PR DESCRIPTION
- Dette burde kanskje blitt håndtert på en annen måte, der man har et eneste state for vedlegg som har lastes opp/har blitt lastet opp
- Ulempen med denne løsningen er at vedleggene som listes opp er dokumentasjon og når et vedlegg nå blir lastet opp så fjernes det fra ikkeOpplastedeDokumenter og blir lagt inn i dokumentasjon, som gjør at brukeren kan oppleve at vedlegg bytter ordning hvis man laster opp flere samtidig

### Hvorfor er denne endringen nødvendig? ✨

Ønsket å teste om det var enkelt å legge til progress på vedlegg som lastes opp.
Dette er ikke en optimal løsning, men det viser iaf at vedlegg lastes opp for brukeren.
Ev om noen har forslag på hvordan man kan håndtere det bedre? 
Føle det fort ble kranglete då denne komponent oppdaterer staten på søknaden direkte når et vedlegg blitt lastet opp. Hvilket også gjør at man oppdaterer statet selv om man gått videre til neste steg (oppsummering) - som kanskje er litt rart 😬 

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-24162

https://github.com/user-attachments/assets/16222fe5-30bd-4696-a1f6-b5ef8288f414


