### PR TITLE
🦺 Legg til validering på ingen negative utgifter

### DIFF
--- a/src/frontend/kjørelister/KjørelisteInnhold.tsx
+++ b/src/frontend/kjørelister/KjørelisteInnhold.tsx
@@ -12,6 +12,7 @@ import { Oppsummeringsside } from './components/Oppsummering/Oppsummeringsside';
 import { KjørelisteSkjema } from './components/Skjemaside/KjørelisteSkjema';
 import { Vedleggside } from './components/Vedleggside/Vedleggside';
 import { KjørelisteProvider } from './KjørelisteContext';
+import { ValideringsfeilProvider } from '../context/ValideringsfeilContext';
 
 export const KjørelisteInnhold = () => {
     const kjørelisteId = useParams<{ kjorelisteId: string }>().kjorelisteId as string;
@@ -39,13 +40,15 @@ export const KjørelisteInnhold = () => {
 
     return (
         <KjørelisteProvider rammevedtak={rammevedtak}>
-            <Routes>
-                <Route path={'/skjema'} element={<KjørelisteSkjema />} />
-                <Route path={'/vedlegg'} element={<Vedleggside />} />
-                <Route path={'/oppsummering'} element={<Oppsummeringsside />} />
-                <Route path={'/kvittering'} element={<Kvitteringsside />} />
-                <Route path={'/*'} element={<KjørelisteSkjema />} />
-            </Routes>
+            <ValideringsfeilProvider>
+                <Routes>
+                    <Route path={'/skjema'} element={<KjørelisteSkjema />} />
+                    <Route path={'/vedlegg'} element={<Vedleggside />} />
+                    <Route path={'/oppsummering'} element={<Oppsummeringsside />} />
+                    <Route path={'/kvittering'} element={<Kvitteringsside />} />
+                    <Route path={'/*'} element={<KjørelisteSkjema />} />
+                </Routes>
+            </ValideringsfeilProvider>
         </KjørelisteProvider>
     );
 };

--- a/src/frontend/kjørelister/components/Skjemaside/KjørelisteDag.tsx
+++ b/src/frontend/kjørelister/components/Skjemaside/KjørelisteDag.tsx
@@ -23,6 +23,10 @@ export const KjørelisteDag: React.FC<{ dato: Date }> = ({ dato }) => {
     const { kjøreliste, oppdaterHarReist, oppdaterParkeringsutgift } = useKjøreliste();
 
     const [harReist, settHarReist] = useState(kjøreliste.reisedager[dato.toISOString()].harReist);
+
+    const erNegativUtgift = (): boolean =>
+        (kjøreliste.reisedager[dato.toISOString()].parkeringsutgift ?? 0) < 0;
+
     return (
         <Card graybackground={erHelg(dato).toString()}>
             <Checkbox
@@ -34,9 +38,12 @@ export const KjørelisteDag: React.FC<{ dato: Date }> = ({ dato }) => {
             >{`${tilUkedag(dato)} ${tilTekstligDato(dato.toISOString())}`}</Checkbox>
             {harReist && (
                 <StyledTextField
+                    id={dato.toISOString()}
                     label={'Parkeringsutgifter (kr)'}
                     inputMode={'numeric'}
                     type={'number'}
+                    min={0}
+                    error={erNegativUtgift() && 'Utgiften må være et positivt tall'}
                     onChange={(e) => oppdaterParkeringsutgift(dato, Number(e.target.value))}
                 />
             )}

--- a/src/frontend/kjørelister/components/Skjemaside/KjørelisteSkjema.tsx
+++ b/src/frontend/kjørelister/components/Skjemaside/KjørelisteSkjema.tsx
@@ -4,11 +4,28 @@ import { VStack } from '@navikt/ds-react';
 
 import { Kjøreliste } from './Kjøreliste';
 import { KjørelisteMetadata } from './KjørelisteMetadata';
+import { useValideringsfeil } from '../../../context/ValideringsfeilContext';
+import { useKjøreliste } from '../../KjørelisteContext';
 import { KjørelisteNavigasjonsKnapper } from '../KjørelisteNavigasjonsKnapper';
 import { SlikFyllerDuUtKjørelister } from './SlikFyllerDuUtKjørelister';
 import { KjørelisteRoutes } from '../../kjørelisteRoutes';
 
 export function KjørelisteSkjema() {
+    const { kjøreliste } = useKjøreliste();
+    const { settValideringsfeil } = useValideringsfeil();
+
+    const validerKanGåVidere = () => {
+        const feil = Object.fromEntries(
+            Object.entries(kjøreliste.reisedager)
+                .filter(([, reisedag]) => (reisedag.parkeringsutgift ?? 0) < 0)
+                .map(([dato]) => [dato, { id: dato, melding: 'Utgiften må være et positivt tall' }])
+        );
+
+        settValideringsfeil(feil);
+
+        return Object.keys(feil).length === 0;
+    };
+
     return (
         <VStack gap="8">
             <KjørelisteMetadata />
@@ -17,6 +34,7 @@ export function KjørelisteSkjema() {
             <KjørelisteNavigasjonsKnapper
                 nesteSide={KjørelisteRoutes.VEDLEGG}
                 forrigeSide={KjørelisteRoutes.LANDINGSSIDE}
+                validerKanGåVidere={validerKanGåVidere}
             />
         </VStack>
     );


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skal ikke være mulig å sende inn negative parkeringsutgifter. Legger inn validering som sjekker at parkeringsutgiftene er positive for bruker får lov til å navigere til neste steg.

<img width="862" height="1001" alt="image" src="https://github.com/user-attachments/assets/83d2ccb7-e818-42c8-8904-8901aeb42be3" />
