### PR TITLE
✨ Vis aktivitetsnavn fra rammevedtak på kjøreliste-siden

### DIFF
--- a/src/frontend/kjørelister/components/Landingsside/KjørelisteKort.tsx
+++ b/src/frontend/kjørelister/components/Landingsside/KjørelisteKort.tsx
@@ -4,7 +4,7 @@ import { BodyShort, LinkCard, Tag } from '@navikt/ds-react';
 
 import { formaterPeriodeTekstlig } from '../../../utils/formateringUtils';
 import { finnPath, KjørelisteRoutes } from '../../kjørelisteRoutes';
-import { Rammevedtak } from '../../types/Rammevedtak';
+import { formaterAktivitetsnavn, Rammevedtak } from '../../types/Rammevedtak';
 
 export const KjørelisteKort: React.FC<{ rammevedtak: Rammevedtak }> = ({ rammevedtak }) => {
     return (
@@ -13,7 +13,7 @@ export const KjørelisteKort: React.FC<{ rammevedtak: Rammevedtak }> = ({ rammev
                 <LinkCard.Anchor
                     href={`/tilleggsstonader/soknad${finnPath(rammevedtak.reiseId, KjørelisteRoutes.SKJEMA)}/`}
                 >
-                    {rammevedtak.aktivitetsnavn}
+                    {formaterAktivitetsnavn(rammevedtak.aktivitetsnavn)}
                 </LinkCard.Anchor>
             </LinkCard.Title>
             <LinkCard.Description>

--- a/src/frontend/kjørelister/components/Skjemaside/KjørelisteMetadata.tsx
+++ b/src/frontend/kjørelister/components/Skjemaside/KjørelisteMetadata.tsx
@@ -4,13 +4,16 @@ import { BodyShort, Heading, VStack } from '@navikt/ds-react';
 
 import { formaterPeriodeTekstlig } from '../../../utils/formateringUtils';
 import { useKjøreliste } from '../../KjørelisteContext';
+import { formaterAktivitetsnavn } from '../../types/Rammevedtak';
 
 export const KjørelisteMetadata = () => {
     const { rammevedtak } = useKjøreliste();
     return (
         <VStack gap="space-8">
             <Heading size={'medium'}>Denne kjørelisten gjelder</Heading>
-            <BodyShort weight={'semibold'}>{rammevedtak.aktivitetsnavn}</BodyShort>
+            <BodyShort weight={'semibold'}>
+                {formaterAktivitetsnavn(rammevedtak.aktivitetsnavn)}
+            </BodyShort>
             <BodyShort>{formaterPeriodeTekstlig(rammevedtak.fom, rammevedtak.tom)}</BodyShort>
             <BodyShort>{`Adresse: ${rammevedtak.aktivitetsadresse}`}</BodyShort>
             <BodyShort>{`${rammevedtak.reisedagerPerUke} dager per uke`}</BodyShort>

--- a/src/frontend/kjørelister/types/Rammevedtak.ts
+++ b/src/frontend/kjørelister/types/Rammevedtak.ts
@@ -15,3 +15,13 @@ export interface RammevedtakUke {
     innsendtDato: string | null;
     kanSendeInnKjøreliste: boolean;
 }
+
+export const aktivitetTypeTilTekst: Record<string, string> = {
+    TILTAK: 'Tiltak',
+    UTDANNING: 'Utdanning',
+    REELL_ARBEIDSSØKER: 'Reell arbeidssøker',
+    INGEN_AKTIVITET: 'Ingen relevant aktivitet',
+};
+
+export const formaterAktivitetsnavn = (aktivitetsnavn: string): string =>
+    aktivitetTypeTilTekst[aktivitetsnavn] ?? aktivitetsnavn;


### PR DESCRIPTION
## Beskrivelse

Viser aktivitetsnavn på landingssiden (kjøreliste) for daglig reise med privat bil.

### Endringer
- `formaterAktivitetsnavn()` i `Rammevedtak.ts` oversetter enum-verdier (f.eks. `TILTAK`) til lesbar norsk tekst
- `KjørelisteKort` og `KjørelisteMetadata` bruker formatert aktivitetsnavn
- Fallback til rå enum-verdi for ukjente verdier (fremtidssikring)

## Relaterte PRer
- sak: https://github.com/navikt/tilleggsstonader-sak/pull/1137
- sak-frontend: https://github.com/navikt/tilleggsstonader-sak-frontend/pull/1109

❗ Må testes i dev. Når vi tester lokalt bruker vi mocket verdier mot sak, og da har dette alltid funka

<img width="671" height="525" alt="image" src="https://github.com/user-attachments/assets/f2a595dc-6945-4828-bb61-87a684b2dca9" />
