### PR TITLE
Tar i mot reisedager per uke, slik at disse kan variere per uke. Viser antall reisedager for en gitt uke. Sender også med denne label'en ved innsending av kjøreliste

### DIFF
--- a/src/frontend/kjørelister/KjørelisteContext.tsx
+++ b/src/frontend/kjørelister/KjørelisteContext.tsx
@@ -116,8 +116,10 @@ const initialiserKjøreliste = (
                 };
             });
             return {
-                ukeLabel: `Uke ${rammevedtakUke.ukeNummer} (${tilTekstligDato(rammevedtakUke.fom)} - ${tilTekstligDato(rammevedtakUke.tom)})`,
+                ukeLabel: `Uke ${rammevedtakUke.ukeNummer}`,
                 spørsmål: 'Hvilke dager kjørte du?',
+                reisedagerLabel: `Ukentlige reisedager: ${rammevedtakUke.reisedagerPerUke}`,
+                antallReisedagerIUke: rammevedtakUke.reisedagerPerUke,
                 reisedager: reisedager,
                 sendtInnTidligere: rammevedtakUke.innsendtDato != null,
             };

--- a/src/frontend/kjørelister/components/Landingsside/KjørelisteKort.tsx
+++ b/src/frontend/kjørelister/components/Landingsside/KjørelisteKort.tsx
@@ -21,7 +21,6 @@ export const KjørelisteKort: React.FC<{ rammevedtak: Rammevedtak }> = ({ rammev
                     Periode med kjøring: {formaterPeriodeTekstlig(rammevedtak.fom, rammevedtak.tom)}
                 </BodyShort>
                 <BodyShort>Adresse: {rammevedtak.aktivitetsadresse}</BodyShort>
-                <BodyShort>{rammevedtak.reisedagerPerUke} dager per uke</BodyShort>
             </LinkCard.Description>
             <LinkCard.Footer>
                 <Tag

--- a/src/frontend/kjørelister/components/Skjemaside/KjørelisteMetadata.tsx
+++ b/src/frontend/kjørelister/components/Skjemaside/KjørelisteMetadata.tsx
@@ -13,7 +13,6 @@ export const KjørelisteMetadata = () => {
             <BodyShort weight={'semibold'}>{rammevedtak.aktivitetsnavn}</BodyShort>
             <BodyShort>{formaterPeriodeTekstlig(rammevedtak.fom, rammevedtak.tom)}</BodyShort>
             <BodyShort>{`Adresse: ${rammevedtak.aktivitetsadresse}`}</BodyShort>
-            <BodyShort>{`${rammevedtak.reisedagerPerUke} dager per uke`}</BodyShort>
         </VStack>
     );
 };

--- a/src/frontend/kjørelister/components/Skjemaside/KjørelisteUke.tsx
+++ b/src/frontend/kjørelister/components/Skjemaside/KjørelisteUke.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 
-import { Accordion, Alert, BodyShort, HStack, Tag, VStack } from '@navikt/ds-react';
+import { Accordion, Alert, BodyShort, Heading, HStack, Tag, VStack } from '@navikt/ds-react';
 
 import { KjørelisteDag } from './KjørelisteDag';
-import { useKjøreliste } from '../../KjørelisteContext';
 import {
     finnAntallDagerReist,
     harReist,
@@ -16,14 +15,18 @@ import { WideAccordionHeader } from '../WideAccordionHeader';
 export const KjørelisteUke: React.FC<{
     ukeMedReisedag: UkeMedReisedager;
 }> = ({ ukeMedReisedag }) => {
-    const { rammevedtak } = useKjøreliste();
     const { sendtInnTidligere } = ukeMedReisedag;
 
     return (
         <Accordion.Item>
             <WideAccordionHeader>
                 <HStack justify={'space-between'}>
-                    <HStack gap="space-8">{ukeMedReisedag.ukeLabel}</HStack>
+                    <HStack justify={'space-between'} gap={'space-0 space-16'} align={'center'}>
+                        <Heading size={'small'}>{ukeMedReisedag.ukeLabel}</Heading>
+                        <BodyShort weight={'regular'} size={'medium'}>
+                            {ukeMedReisedag.reisedagerLabel}
+                        </BodyShort>
+                    </HStack>
                     {sendtInnTidligere ? (
                         <Tag variant={'success'} size={'small'}>
                             Sendt inn
@@ -55,15 +58,11 @@ export const KjørelisteUke: React.FC<{
                             har kjørt denne dagen vil en saksbehandler manuelt behandle saken din.
                         </Alert>
                     )}
-                    {!sendtInnTidligere &&
-                        harValgtFlereDagerEnnRammevedtak(
-                            rammevedtak,
-                            ukeMedReisedag.reisedager
-                        ) && (
-                            <Alert variant="warning">
-                                {`Du har fått innvilget stønad for daglige reiser med egen bil for ${rammevedtak.reisedagerPerUke} dager i uken, men du har registrert ${finnAntallDagerReist(ukeMedReisedag.reisedager)} dager. Sjekk at du har fylt inn alt riktig. Hvis det stemmer at du har kjørt flere dager denne uken vil en saksbehandler manuelt behandle saken din.`}
-                            </Alert>
-                        )}
+                    {!sendtInnTidligere && harValgtFlereDagerEnnRammevedtak(ukeMedReisedag) && (
+                        <Alert variant="warning">
+                            {`Du har fått innvilget stønad for daglige reiser med egen bil for ${ukeMedReisedag.antallReisedagerIUke} dager i uken, men du har registrert ${finnAntallDagerReist(ukeMedReisedag.reisedager)} dager. Sjekk at du har fylt inn alt riktig. Hvis det stemmer at du har kjørt flere dager denne uken vil en saksbehandler manuelt behandle saken din.`}
+                        </Alert>
+                    )}
                 </VStack>
             </Accordion.Content>
         </Accordion.Item>

--- a/src/frontend/kjørelister/kjørelisteUtils.ts
+++ b/src/frontend/kjørelister/kjørelisteUtils.ts
@@ -1,6 +1,5 @@
-import { Reisedag } from './types/Kjøreliste';
+import { Reisedag, UkeMedReisedager } from './types/Kjøreliste';
 import { erHelg } from '../utils/datoUtils';
-import { Rammevedtak } from './types/Rammevedtak';
 
 export const harReist = (reisedager: Reisedag[]): boolean =>
     reisedager.some((reisedag) => reisedag.harKjørt);
@@ -11,7 +10,5 @@ export const harValgtHelgedag = (reisedager: Reisedag[]) =>
 export const finnAntallDagerReist = (reisedager: Reisedag[]) =>
     reisedager.filter((reisedag) => reisedag.harKjørt).length;
 
-export const harValgtFlereDagerEnnRammevedtak = (
-    rammevedtak: Rammevedtak,
-    reisedager: Reisedag[]
-) => rammevedtak.reisedagerPerUke < finnAntallDagerReist(reisedager);
+export const harValgtFlereDagerEnnRammevedtak = (ukeMedReisedager: UkeMedReisedager) =>
+    ukeMedReisedager.antallReisedagerIUke < finnAntallDagerReist(ukeMedReisedager.reisedager);

--- a/src/frontend/kjørelister/types/Kjøreliste.ts
+++ b/src/frontend/kjørelister/types/Kjøreliste.ts
@@ -10,6 +10,8 @@ export interface Kjøreliste {
 
 export interface UkeMedReisedager {
     ukeLabel: string;
+    reisedagerLabel: string;
+    antallReisedagerIUke: number;
     spørsmål: string;
     reisedager: Reisedag[];
     sendtInnTidligere: boolean;

--- a/src/frontend/kjørelister/types/Rammevedtak.ts
+++ b/src/frontend/kjørelister/types/Rammevedtak.ts
@@ -2,7 +2,6 @@ export interface Rammevedtak {
     reiseId: string;
     fom: string;
     tom: string;
-    reisedagerPerUke: number;
     aktivitetsadresse: string;
     aktivitetsnavn: string;
     uker: RammevedtakUke[];
@@ -12,6 +11,7 @@ export interface RammevedtakUke {
     ukeNummer: number;
     fom: string;
     tom: string;
+    reisedagerPerUke: number;
     innsendtDato: string | null;
     kanSendeInnKjøreliste: boolean;
 }


### PR DESCRIPTION
###Hvorfor er denne endringen nødvendig? ✨

Tilrettelegger for innføring av delperioder på rammevedtaket, slik at det kan være forskjellig antall reisedager per uke

Backend: https://github.com/navikt/tilleggsstonader-soknad-api/pull/258