### PR TITLE
✨ Legg til kjøreliste-ruting i frontend

### DIFF
--- a/src/backend/fyllutUrls.ts
+++ b/src/backend/fyllutUrls.ts
@@ -3,9 +3,10 @@ import { miljø } from './miljø';
 export enum SkjematypeFyllUt {
     SØKNAD_BOUTGIFTER = 'SØKNAD_BOUTGIFTER',
     SØKNAD_DAGLIG_REISE = 'SØKNAD_DAGLIG_REISE',
+    DAGLIG_REISE_KJØRELISTE = 'DAGLIG_REISE_KJØRELISTE',
 }
 
-const SKJEMAKODER: Record<SkjematypeFyllUt, { ny: string; gammel: string }> = {
+const SKJEMAKODER: Record<SkjematypeFyllUt, { ny?: string; gammel: string }> = {
     [SkjematypeFyllUt.SØKNAD_BOUTGIFTER]: {
         ny: 'nav111219',
         gammel: 'nav111219b',
@@ -14,10 +15,19 @@ const SKJEMAKODER: Record<SkjematypeFyllUt, { ny: string; gammel: string }> = {
         ny: 'nav111221',
         gammel: 'nav111221b',
     },
+    [SkjematypeFyllUt.DAGLIG_REISE_KJØRELISTE]: {
+        gammel: 'nav111224b',
+    },
 };
 
-export const getFyllutUrl = (skjematype: SkjematypeFyllUt, versjon: 'NY' | 'GAMMEL'): string => {
-    const skjema = versjon === 'NY' ? SKJEMAKODER[skjematype].ny : SKJEMAKODER[skjematype].gammel;
+export const getFyllutUrl = (
+    skjematype: SkjematypeFyllUt,
+    versjon: 'NY' | 'GAMMEL'
+): string | undefined => {
+    const skjemakode =
+        versjon === 'NY' ? SKJEMAKODER[skjematype].ny : SKJEMAKODER[skjematype].gammel;
 
-    return miljø.fyllUtUrl(skjema);
+    if (!skjemakode) return undefined;
+
+    return miljø.fyllUtUrl(skjemakode);
 };

--- a/src/backend/redirectTilSkjema.ts
+++ b/src/backend/redirectTilSkjema.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express';
+import { NextFunction, Request, Response } from 'express';
 
 import { getFyllutUrl, SkjematypeFyllUt } from './fyllutUrls';
 import logger from './logger';
@@ -10,23 +10,29 @@ import { BASE_PATH_SOKNAD } from './url';
  *
  * Hvis [internRouteForNyLøsning] er angitt vil brukeren routes til en intern route i stedet for nytt FyllUt-skjema, noe
  * som er nyttig for eksempelvis daglige reiser.
+ *
+ * Hvis ny løsning ikke har en FyllUt-URL, kalles next() slik at requesten faller gjennom til SPA-handleren.
  */
 export const redirectTilSkjema = (
     skjematype: SkjematypeFyllUt,
     internRouteForNyLøsning?: string
 ) => {
-    return async (req: Request, res: Response) => {
+    return async (req: Request, res: Response, next: NextFunction) => {
         try {
-            const finnRedirectUrl = async () => {
-                const skalBehandlesINyLøsning = await skalBrukerTilNyLøsning(skjematype, req);
+            const skalBehandlesINyLøsning = await skalBrukerTilNyLøsning(skjematype, req);
 
-                if (skalBehandlesINyLøsning && internRouteForNyLøsning) {
-                    return `${BASE_PATH_SOKNAD}/${internRouteForNyLøsning}`;
-                }
+            if (skalBehandlesINyLøsning && internRouteForNyLøsning) {
+                res.redirect(302, `${BASE_PATH_SOKNAD}/${internRouteForNyLøsning}`);
+                return;
+            }
 
-                return getFyllutUrl(skjematype, skalBehandlesINyLøsning ? 'NY' : 'GAMMEL');
-            };
-            res.redirect(302, await finnRedirectUrl());
+            const fyllutUrl = getFyllutUrl(skjematype, skalBehandlesINyLøsning ? 'NY' : 'GAMMEL');
+
+            if (fyllutUrl) {
+                res.redirect(302, fyllutUrl);
+            } else {
+                next();
+            }
         } catch (error) {
             logger.error('Feil ved omdirigering:', error);
             res.status(500).send('Feil ved omdirigering');

--- a/src/backend/routes.ts
+++ b/src/backend/routes.ts
@@ -39,6 +39,13 @@ const routes = () => {
         redirectTilSkjema(SkjematypeFyllUt.SØKNAD_DAGLIG_REISE, 'daglig-reise/skjema')
     );
 
+    expressRouter.get(
+        new RegExp(`^${BASE_PATH_SOKNAD}/kjoreliste/?$`),
+        addRequestInfo(),
+        attachToken('tilleggsstonader-soknad-api'),
+        redirectTilSkjema(SkjematypeFyllUt.DAGLIG_REISE_KJØRELISTE)
+    );
+
     expressRouter.use(BASE_PATH_SOKNAD, express.static(buildPath, { index: false }));
 
     expressRouter.use(


### PR DESCRIPTION
## Endringer

Legger til redirect-rute for `/kjoreliste` som sender brukere til enten ny løsning (SPA) eller gammel FyllUt-løsning (`nav111224b`).

### Detaljer
- Ny `DAGLIG_REISE_KJØRELISTE` i `SkjematypeFyllUt`-enum med gammel skjemakode `nav111224b` (ingen ny FyllUt-kode)
- `redirectTilSkjema.ts`: Lagt til `NextFunction`-støtte — kaller `next()` når ny løsning ikke har FyllUt-URL, slik at requesten faller gjennom til SPA-handleren
- `routes.ts`: Ny redirect-rute for `/kjoreliste` før statisk/SPA-handler

### Flyt
1. Bruker besøker `/kjoreliste`
2. Routing-sjekk mot sak via soknad-api
3. Ny løsning → `next()` → SPA serveres direkte
4. Gammel løsning → redirect til FyllUt `nav111224b`

### Testing
⚠️ Ikke testet lokalt end-to-end. Express-backenden (routes.ts med redirect-logikken) kjører ikke lokalt med `yarn start:dev` — den kjører bare i produksjon/nais. Lokal utvikling bruker webpack-dev-server som serverer React-appen direkte uten å gå gjennom Express-rutene.

Se også: tilhørende backend-PR i tilleggsstonader-sak: https://github.com/navikt/tilleggsstonader-sak/pull/1156