### PR TITLE
Reise til samling - routes og introside

### DIFF
--- a/src/frontend/api/Environment.ts
+++ b/src/frontend/api/Environment.ts
@@ -18,6 +18,7 @@ interface IModellversjon {
 const StønadstypeTilPapirskjema: Record<Stønadstype, string> = {
     BARNETILSYN: 'nav111215b',
     LÆREMIDLER: 'nav111216b',
+    REISE_TIL_SAMLING: 'nav111217b',
 };
 
 const urlPapirsøknadProd = (stønadstype: Stønadstype) =>

--- a/src/frontend/api/api.ts
+++ b/src/frontend/api/api.ts
@@ -54,6 +54,8 @@ const stønadstypeTilPath = (stønadstype: Stønadstype): string => {
             return 'pass-av-barn';
         case Stønadstype.LÆREMIDLER:
             return 'laremidler';
+        case Stønadstype.REISE_TIL_SAMLING:
+            return 'reise-til-samling';
     }
 };
 

--- a/src/frontend/barnetilsyn/Søknadsdialog.tsx
+++ b/src/frontend/barnetilsyn/Søknadsdialog.tsx
@@ -3,11 +3,14 @@ import React from 'react';
 import { Route, Routes } from 'react-router';
 
 import Forside from './Forside';
-import { Header } from '../components/Header';
+import Kvittering from '../components/Kvittering/Kvittering';
 import RedirectTilStart from '../components/RedirectTilStart';
 import { RootRoute } from '../components/RootRoute';
+import { SøknadsskjemaHeader } from '../components/SøknadsskjemaHeader';
 import { usePassAvBarnSøknad } from '../context/PassAvBarnSøknadContext';
 import { fellesTekster } from '../tekster/felles';
+import { stønadstypeTilSkjemaId } from '../typer/skjemanavn';
+import { Stønadstype } from '../typer/stønadstyper';
 import { barnetilsynPath } from './routing/routesBarnetilsyn';
 import HovedytelsePassBarn from './steg/2-hovedytelse/HovedytelsePassBarn';
 import Aktivitet from './steg/3-aktivitet/Aktivitet';
@@ -15,12 +18,14 @@ import DineBarn from './steg/4-dine-barn/DineBarn';
 import PassAvDineBarn from './steg/5-pass-av-dine-barn/PassAvDineBarn';
 import VedleggPassAvBarn from './steg/6-vedlegg/VedleggPassAvBarn';
 import Oppsummering from './steg/7-oppsummering/Oppsummering';
-import Kvittering from '../components/Kvittering/Kvittering';
 
 const Søknadsdialog: React.FC = () => {
     return (
         <>
-            <Header tittel={fellesTekster.banner_bt} />
+            <SøknadsskjemaHeader
+                tittel={fellesTekster.banner_bt}
+                skjemaId={stønadstypeTilSkjemaId[Stønadstype.BARNETILSYN]}
+            />
             <Routes>
                 <Route path={'/'} element={<RootRoute forside={<Forside />} />} />
                 <Route path={'*'} element={<SøknadsdialogInnhold />} />

--- a/src/frontend/components/RootRoute.tsx
+++ b/src/frontend/components/RootRoute.tsx
@@ -6,6 +6,7 @@ import { RoutesBarnetilsyn } from '../barnetilsyn/routing/routesBarnetilsyn';
 import { usePerson } from '../context/PersonContext';
 import { useSøknad } from '../context/SøknadContext';
 import { routesLæremidler } from '../læremidler/routing/routesLæremidler';
+import { routesReiseTilSamling } from '../reiseTilSamling/routing/routesReiseTilSamling';
 import { IRoute } from '../typer/routes';
 import { Stønadstype } from '../typer/stønadstyper';
 
@@ -16,6 +17,7 @@ interface RootRouteProps {
 const route: Record<Stønadstype, IRoute> = {
     [Stønadstype.BARNETILSYN]: RoutesBarnetilsyn[0],
     [Stønadstype.LÆREMIDLER]: routesLæremidler[0],
+    [Stønadstype.REISE_TIL_SAMLING]: routesReiseTilSamling[0],
 };
 
 export const RootRoute: React.FC<RootRouteProps> = ({ forside }) => {

--- a/src/frontend/components/SøknadsskjemaHeader.tsx
+++ b/src/frontend/components/SøknadsskjemaHeader.tsx
@@ -4,8 +4,6 @@ import { BodyShort, Heading, VStack } from '@navikt/ds-react';
 import { BreakpointMdDown } from '@navikt/ds-tokens/js';
 
 import LocaleTekst from './Teksthåndtering/LocaleTekst';
-import { useSøknad } from '../context/SøknadContext';
-import { stønadstypeTilSkjemaId } from '../typer/skjemanavn';
 import { TekstElement } from '../typer/tekst';
 
 const Container = styled.div`
@@ -18,13 +16,14 @@ const Container = styled.div`
     }
 `;
 
-export const Header: React.FC<{ tittel: TekstElement<string> }> = ({ tittel }) => {
-    const { stønadstype } = useSøknad();
-
+export const SøknadsskjemaHeader: React.FC<{ tittel: TekstElement<string>; skjemaId: string }> = ({
+    tittel,
+    skjemaId,
+}) => {
     return (
         <Container>
             <VStack gap="space-8">
-                <BodyShort>{stønadstypeTilSkjemaId[stønadstype]}</BodyShort>
+                <BodyShort>{skjemaId}</BodyShort>
                 <Heading size="xlarge" as="h1">
                     <LocaleTekst tekst={tittel} />
                 </Heading>

--- a/src/frontend/index.tsx
+++ b/src/frontend/index.tsx
@@ -16,6 +16,8 @@ import { KanBrukeOffentligTransportAvsjekk } from './dagligReise/KanBrukeOffentl
 import { KjørelisterApp } from './kjørelister/KjørelisterApp';
 import LæremidlerApp from './læremidler/LæremidlerApp';
 import { læremidlerPath } from './læremidler/routing/routesLæremidler';
+import { ReiseTilSamlingApp } from './reiseTilSamling/ReiseTilSamlingApp';
+import { reiseTilSamlingPath } from './reiseTilSamling/routing/routesReiseTilSamling';
 import { erProd } from './utils/miljø';
 
 initSentry();
@@ -26,6 +28,7 @@ const root = createRoot(rootElement!);
 
 const AppRoutes = () => {
     const kanBrukeKjøreliste = !erProd();
+    const kanBrukeReiseTilSamling = !erProd();
     return (
         <BrowserRouter basename={process.env.PUBLIC_URL}>
             <ScrollToTop />
@@ -37,6 +40,9 @@ const AppRoutes = () => {
                     element={<Navigate to={barnetilsynPath} replace />}
                 />
                 <Route path={`/${læremidlerPath}/*`} element={<LæremidlerApp />} />
+                {kanBrukeReiseTilSamling && (
+                    <Route path={`${reiseTilSamlingPath}/*`} element={<ReiseTilSamlingApp />} />
+                )}
                 <Route
                     path="/daglig-reise/skjema"
                     element={<KanBrukeOffentligTransportAvsjekk />}

--- a/src/frontend/læremidler/Søknadsdialog.tsx
+++ b/src/frontend/læremidler/Søknadsdialog.tsx
@@ -4,8 +4,8 @@ import { Route, Routes } from 'react-router';
 
 import Forside from './Forside';
 import { læremidlerPath } from './routing/routesLæremidler';
-import { Header } from '../components/Header';
 import { RootRoute } from '../components/RootRoute';
+import { SøknadsskjemaHeader } from '../components/SøknadsskjemaHeader';
 import HovedytelseLæremidler from './steg/1-hovedytelse/HovedytelseLæremidler';
 import Utdanning from './steg/2-utdanning/Utdanning';
 import VedleggLæremidler from './steg/3-vedlegg/VedleggLæremidler';
@@ -14,11 +14,16 @@ import Kvittering from '../components/Kvittering/Kvittering';
 import RedirectTilStart from '../components/RedirectTilStart';
 import { useLæremidlerSøknad } from '../context/LæremiddelSøknadContext';
 import { fellesTekster } from '../tekster/felles';
+import { stønadstypeTilSkjemaId } from '../typer/skjemanavn';
+import { Stønadstype } from '../typer/stønadstyper';
 
 const Søknadsdialog: React.FC = () => {
     return (
         <>
-            <Header tittel={fellesTekster.banner_læremidler} />
+            <SøknadsskjemaHeader
+                tittel={fellesTekster.banner_læremidler}
+                skjemaId={stønadstypeTilSkjemaId[Stønadstype.LÆREMIDLER]}
+            />
             <Routes>
                 <Route path={'/'} element={<RootRoute forside={<Forside />} />} />
                 <Route path={'*'} element={<SøknadsdialogInnhold />} />

--- a/src/frontend/reiseTilSamling/Forside.tsx
+++ b/src/frontend/reiseTilSamling/Forside.tsx
@@ -1,0 +1,127 @@
+import React, { useState } from 'react';
+
+import { useNavigate } from 'react-router-dom';
+
+import {
+    Accordion,
+    Box,
+    BodyLong,
+    BodyShort,
+    Button,
+    GuidePanel,
+    HStack,
+    VStack,
+} from '@navikt/ds-react';
+
+import { RouteTilPath } from './routing/routesReiseTilSamling';
+import { forsideTekster } from './tekster/forside';
+import BekreftelseCheckbox from '../components/BekreftelseCheckbox';
+import { InfoPunktliste } from '../components/InfoPunktliste';
+import { Container } from '../components/Side';
+import { LocaleHeading } from '../components/Teksthåndtering/LocaleHeading';
+import LocaleInlineLenke from '../components/Teksthåndtering/LocaleInlineLenke';
+import { LocalePunktliste } from '../components/Teksthåndtering/LocalePunktliste';
+import LocaleTekst from '../components/Teksthåndtering/LocaleTekst';
+import { fellesTekster } from '../tekster/felles';
+
+export const Forside: React.FC = () => {
+    const navigate = useNavigate();
+    const [harBekreftet, settHarBekreftet] = useState(false);
+    const [skalViseFeilmelding, settSkalViseFeilmelding] = useState(false);
+
+    const startSøknad = () => {
+        if (!harBekreftet) {
+            settSkalViseFeilmelding(true);
+            return;
+        }
+
+        navigate(RouteTilPath.PLACEHOLDER);
+    };
+
+    return (
+        <Container>
+            <GuidePanel poster>
+                <BodyShort spacing>
+                    <strong>
+                        <LocaleTekst tekst={forsideTekster.veileder_tittel} />
+                    </strong>
+                </BodyShort>
+                <BodyShort spacing>
+                    <strong>
+                        <LocaleTekst tekst={forsideTekster.veileder_innhold_tittel} />
+                    </strong>
+                </BodyShort>
+                <LocalePunktliste innhold={forsideTekster.veileder_innhold_punkter} />
+                <BodyShort spacing>
+                    <LocaleTekst tekst={forsideTekster.veileder_innhold_mellomtekst} />
+                </BodyShort>
+                <LocalePunktliste innhold={forsideTekster.veileder_innhold_fortsettelse_punkter} />
+            </GuidePanel>
+            <div>
+                <LocaleHeading
+                    tekst={forsideTekster.kan_soke_tittel}
+                    level="2"
+                    size="large"
+                    spacing
+                />
+                <LocalePunktliste innhold={forsideTekster.kan_soke_innhold} />
+                <Box paddingBlock="space-16">
+                    <LocaleHeading
+                        tekst={forsideTekster.kan_ikke_soke_tittel}
+                        level="3"
+                        size="small"
+                        spacing
+                    />
+                    <BodyLong>
+                        <LocaleInlineLenke tekst={forsideTekster.kan_ikke_soke_tekst} />
+                    </BodyLong>
+                </Box>
+            </div>
+            <div>
+                <LocaleHeading
+                    tekst={forsideTekster.for_du_soker_tittel}
+                    level="2"
+                    size="large"
+                    spacing
+                />
+                <LocalePunktliste innhold={forsideTekster.for_du_soker_innhold} />
+            </div>
+            <div>
+                <LocaleHeading
+                    tekst={forsideTekster.var_klar_over_tittel}
+                    level="2"
+                    size="large"
+                    spacing
+                />
+                <LocalePunktliste innhold={forsideTekster.var_klar_over_innhold} />
+            </div>
+            <Accordion>
+                <Accordion.Item>
+                    <Accordion.Header>
+                        <LocaleTekst tekst={forsideTekster.info_som_hentes_tittel} />
+                    </Accordion.Header>
+                    <Accordion.Content>
+                        <InfoPunktliste liste={forsideTekster.info_som_hentes_punktlister} />
+                        <LocaleInlineLenke tekst={forsideTekster.info_som_hentes_personvern} />
+                    </Accordion.Content>
+                </Accordion.Item>
+            </Accordion>
+            <VStack>
+                <BodyLong>
+                    <LocaleInlineLenke tekst={fellesTekster.viktig_med_rett_opplysninger} />
+                </BodyLong>
+                <BekreftelseCheckbox
+                    skalViseFeilmelding={skalViseFeilmelding}
+                    harBekreftet={harBekreftet}
+                    oppdaterHarBekreftet={settHarBekreftet}
+                    fjernFeilmelding={() => settSkalViseFeilmelding(false)}
+                />
+                <HStack justify="center">
+                    <Button onClick={startSøknad} variant="primary">
+                        Start søknad
+                    </Button>
+                </HStack>
+            </VStack>
+        </Container>
+    );
+};

--- a/src/frontend/reiseTilSamling/Forside.tsx
+++ b/src/frontend/reiseTilSamling/Forside.tsx
@@ -47,9 +47,7 @@ export const Forside: React.FC = () => {
                     </strong>
                 </BodyShort>
                 <BodyShort spacing>
-                    <strong>
-                        <LocaleTekst tekst={forsideTekster.veileder_innhold_tittel} />
-                    </strong>
+                    <LocaleTekst tekst={forsideTekster.veileder_innhold_tittel} />
                 </BodyShort>
                 <LocalePunktliste innhold={forsideTekster.veileder_innhold_punkter} />
                 <BodyShort spacing>

--- a/src/frontend/reiseTilSamling/NesteStegPlaceholder.tsx
+++ b/src/frontend/reiseTilSamling/NesteStegPlaceholder.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import { useNavigate } from 'react-router-dom';
+
+import { BodyLong, Button, Heading, VStack } from '@navikt/ds-react';
+
+import { Container } from '../components/Side';
+import { reiseTilSamlingPath } from './routing/routesReiseTilSamling';
+
+export const NesteStegPlaceholder: React.FC = () => {
+    const navigate = useNavigate();
+
+    return (
+        <Container>
+            <VStack gap="space-16">
+                <Heading size="large" level="1">
+                    Dette er neste steg
+                </Heading>
+                <BodyLong>Resten av søknadsflyten for reise til samling kommer senere.</BodyLong>
+                <Button variant="secondary" onClick={() => navigate(reiseTilSamlingPath)}>
+                    Tilbake
+                </Button>
+            </VStack>
+        </Container>
+    );
+};

--- a/src/frontend/reiseTilSamling/ReiseTilSamlingApp.tsx
+++ b/src/frontend/reiseTilSamling/ReiseTilSamlingApp.tsx
@@ -1,0 +1,16 @@
+import React, { useEffect } from 'react';
+
+import Søknadsdialog from './Søknadsdialog';
+import { useSpråk } from '../context/SpråkContext';
+import { teksterStønad } from '../tekster/stønad';
+import { Stønadstype } from '../typer/stønadstyper';
+
+export const ReiseTilSamlingApp = () => {
+    const { locale } = useSpråk();
+
+    useEffect(() => {
+        document.title = teksterStønad.tittelHtml[Stønadstype.REISE_TIL_SAMLING][locale];
+    }, [locale]);
+
+    return <Søknadsdialog />;
+};

--- a/src/frontend/reiseTilSamling/Søknadsdialog.tsx
+++ b/src/frontend/reiseTilSamling/Søknadsdialog.tsx
@@ -5,7 +5,9 @@ import { useLocation } from 'react-router-dom';
 import { Forside } from './Forside';
 import { NesteStegPlaceholder } from './NesteStegPlaceholder';
 import { forsideTekster } from './tekster/forside';
-import { Header } from '../components/Header';
+import { SøknadsskjemaHeader } from '../components/SøknadsskjemaHeader';
+import { stønadstypeTilSkjemaId } from '../typer/skjemanavn';
+import { Stønadstype } from '../typer/stønadstyper';
 import { RouteTilPath } from './routing/routesReiseTilSamling';
 
 const Søknadsdialog: React.FC = () => {
@@ -13,7 +15,10 @@ const Søknadsdialog: React.FC = () => {
 
     return (
         <>
-            <Header tittel={forsideTekster.banner_tittel} />
+            <SøknadsskjemaHeader
+                tittel={forsideTekster.banner_tittel}
+                skjemaId={stønadstypeTilSkjemaId[Stønadstype.REISE_TIL_SAMLING]}
+            />
             {location.pathname.endsWith(RouteTilPath.PLACEHOLDER) ? (
                 <NesteStegPlaceholder />
             ) : (

--- a/src/frontend/reiseTilSamling/Søknadsdialog.tsx
+++ b/src/frontend/reiseTilSamling/Søknadsdialog.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import { useLocation } from 'react-router-dom';
+
+import { Forside } from './Forside';
+import { NesteStegPlaceholder } from './NesteStegPlaceholder';
+import { forsideTekster } from './tekster/forside';
+import { Header } from '../components/Header';
+import { RouteTilPath } from './routing/routesReiseTilSamling';
+
+const Søknadsdialog: React.FC = () => {
+    const location = useLocation();
+
+    return (
+        <>
+            <Header tittel={forsideTekster.banner_tittel} />
+            {location.pathname.endsWith(RouteTilPath.PLACEHOLDER) ? (
+                <NesteStegPlaceholder />
+            ) : (
+                <Forside />
+            )}
+        </>
+    );
+};
+
+export default Søknadsdialog;

--- a/src/frontend/reiseTilSamling/routing/routesReiseTilSamling.ts
+++ b/src/frontend/reiseTilSamling/routing/routesReiseTilSamling.ts
@@ -1,0 +1,22 @@
+import { IRoute } from '../../typer/routes';
+
+export enum ERouteReiseTilSamling {
+    FORSIDE = 'FORSIDE',
+    PLACEHOLDER = 'PLACEHOLDER',
+}
+
+export const reiseTilSamlingPath = '/reise-til-samling';
+
+export const RouteTilPath: Record<ERouteReiseTilSamling, string> = {
+    FORSIDE: reiseTilSamlingPath,
+    PLACEHOLDER: reiseTilSamlingPath + '/placeholder',
+};
+
+export const routesReiseTilSamling: IRoute[] = [
+    { path: reiseTilSamlingPath, label: 'Forside', route: ERouteReiseTilSamling.FORSIDE },
+    {
+        path: RouteTilPath.PLACEHOLDER,
+        label: 'Placeholder',
+        route: ERouteReiseTilSamling.PLACEHOLDER,
+    },
+];

--- a/src/frontend/reiseTilSamling/tekster/forside.ts
+++ b/src/frontend/reiseTilSamling/tekster/forside.ts
@@ -1,0 +1,123 @@
+import { InlineLenke, Punktliste, TekstElement } from '../../typer/tekst';
+
+interface ForsideInnhold {
+    banner_tittel: TekstElement<string>;
+    veileder_tittel: TekstElement<string>;
+    veileder_innhold_tittel: TekstElement<string>;
+    veileder_innhold_punkter: TekstElement<string[]>;
+    veileder_innhold_mellomtekst: TekstElement<string>;
+    veileder_innhold_fortsettelse_punkter: TekstElement<string[]>;
+    kan_soke_tittel: TekstElement<string>;
+    kan_soke_innhold: TekstElement<string[]>;
+    kan_ikke_soke_tittel: TekstElement<string>;
+    kan_ikke_soke_tekst: TekstElement<InlineLenke>;
+    for_du_soker_tittel: TekstElement<string>;
+    for_du_soker_innhold: TekstElement<string[]>;
+    var_klar_over_tittel: TekstElement<string>;
+    var_klar_over_innhold: TekstElement<string[]>;
+    info_som_hentes_tittel: TekstElement<string>;
+    info_som_hentes_punktlister: Punktliste[];
+    info_som_hentes_personvern: TekstElement<InlineLenke>;
+}
+
+export const forsideTekster: ForsideInnhold = {
+    banner_tittel: {
+        nb: 'Søknad om støtte ved reise til samling',
+    },
+    veileder_tittel: {
+        nb: 'Hei!',
+    },
+    veileder_innhold_tittel: {
+        nb: 'Denne pengestøtten kan gis til deg som:',
+    },
+    veileder_innhold_punkter: {
+        nb: ['deltar på et arbeidsrettet tiltak eller utdanning godkjent av Nav'],
+    },
+    veileder_innhold_mellomtekst: {
+        nb: 'og samtidig er',
+    },
+    veileder_innhold_fortsettelse_punkter: {
+        nb: [
+            'enslig mor/far, gjenlevende, mottar arbeidsavklaringspenger (AAP), uføretrygd, har nedsatt arbeidsevne, tiltakspenger, dagpenger, kvalifiseringsstønad eller sitter i fengsel mens du deltar i arbeidsrettet tiltak.',
+        ],
+    },
+    kan_soke_tittel: {
+        nb: 'Her kan du søke om',
+    },
+    kan_soke_innhold: {
+        nb: [
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ',
+            'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. ',
+        ],
+    },
+    kan_ikke_soke_tittel: {
+        nb: 'Dette kan du ikke søke om her',
+    },
+    kan_ikke_soke_tekst: {
+        nb: [
+            'Hvis du er under 18 år, skal søke på vegne av andre og/eller skal søke pengestøtte for en aktivitet som ble avsluttet for mer enn 3 måneder siden, må du sende inn søknad på papir og fylle ut ',
+            {
+                tekst: 'dette skjemaet i stedet',
+                url: 'https://www.nav.no/fyllut/nav111217b?sub=paper',
+                variant: 'neutral',
+            },
+            ' (åpnes i ny fane).',
+        ],
+    },
+    for_du_soker_tittel: {
+        nb: 'Før du søker',
+    },
+    for_du_soker_innhold: {
+        nb: [
+            'Du må vite adressen du skal møte opp på, da du må skrive den inn i søknaden.',
+            'Hvis du søker om å få dekket reiseutgifter under 6 km av helsemessige årsaker, må du dokumentere dette med legeerklæring eller annen uttalelse fra helsepersonell.',
+            'Du må gi beskjed til oss hvis situasjonen din endrer seg, for eksempel hvis du avbryter tiltaket eller utdanningen.',
+            'Hvis du får penger du ikke har rett på, kan vi kreve at du betaler de tilbake.',
+        ],
+    },
+    var_klar_over_tittel: {
+        nb: 'Vær klar over',
+    },
+    var_klar_over_innhold: {
+        nb: [
+            'De fleste feltene i skjemaet er obligatoriske å fylle ut. Felt som ikke er obligatoriske er merket med: (valgfritt).',
+            'Bruk av offentlig PC: Hvis du fyller ut skjemaet på en offentlig PC, for eksempel på et bibliotek, er det viktig at du lukker nettleseren når du er ferdig. Dette vil forhindre at uvedkommende får tak i opplysningene du har fylt ut i skjemaet.',
+        ],
+    },
+    info_som_hentes_tittel: {
+        nb: 'Informasjon vi henter om deg',
+    },
+    info_som_hentes_punktlister: [
+        {
+            tittel: {
+                nb: 'I tillegg til den informasjonen du oppgir i søknaden, henter vi:',
+            },
+            innhold: {
+                nb: [
+                    'Person- og adresseinformasjon fra Folkeregisteret',
+                    'Informasjon om utdanning eller tiltak avtalt med veileder i Nav',
+                    'Hvilke andre ytelser du mottar fra Nav',
+                ],
+            },
+        },
+        {
+            tittel: {
+                nb: 'Ved behov sjekker vi:',
+            },
+            innhold: {
+                nb: ['om du er medlem i folketrygden'],
+            },
+        },
+    ],
+    info_som_hentes_personvern: {
+        nb: [
+            'Nav er ansvarlig for å behandle personopplysningene dine. Vi deler ikke informasjonen du gir oss i søknaden med noen andre. ',
+            {
+                tekst: 'Personvernerklæringen på nav.no',
+                url: 'https://www.nav.no/personvernerklaering',
+                variant: 'neutral',
+            },
+            ' gir mer informasjon om hvordan vi behandler personopplysningene dine.',
+        ],
+    },
+};

--- a/src/frontend/tekster/harEksisterendeBehandling.ts
+++ b/src/frontend/tekster/harEksisterendeBehandling.ts
@@ -38,6 +38,9 @@ export const harEksisterendeBehandlingTekster: HarEksistendeBehandlingInnhold = 
         [Stønadstype.LÆREMIDLER]: {
             nb: 'Hvis du har begynt på en ny utdanning eller opplæring, eller det gjelder et nytt skoleår, kan du sende ny søknad.',
         },
+        [Stønadstype.REISE_TIL_SAMLING]: {
+            nb: 'Hvis du har deltatt på en ny samling, kan du sende ny søknad.',
+        },
     },
     alert_for_stønadstype: {
         nb: 'Du har allerede sendt oss en søknad om støtte til [0]. ',

--- a/src/frontend/tekster/stønad.ts
+++ b/src/frontend/tekster/stønad.ts
@@ -13,5 +13,8 @@ export const teksterStønad: StønadInnhold = {
         LÆREMIDLER: {
             nb: 'Søknad om støtte til læremidler',
         },
+        REISE_TIL_SAMLING: {
+            nb: 'Søknad om støtte ved reise til samling',
+        },
     },
 };

--- a/src/frontend/typer/routes.ts
+++ b/src/frontend/typer/routes.ts
@@ -1,7 +1,8 @@
 import { ERouteBarnetilsyn } from '../barnetilsyn/routing/routesBarnetilsyn';
 import { ERouteLæremidler } from '../læremidler/routing/routesLæremidler';
+import { ERouteReiseTilSamling } from '../reiseTilSamling/routing/routesReiseTilSamling';
 
-export type RouteType = ERouteBarnetilsyn | ERouteLæremidler;
+export type RouteType = ERouteBarnetilsyn | ERouteLæremidler | ERouteReiseTilSamling;
 
 export interface IRoute {
     route: RouteType;

--- a/src/frontend/typer/skjemanavn.ts
+++ b/src/frontend/typer/skjemanavn.ts
@@ -3,9 +3,11 @@ import { Stønadstype } from './stønadstyper';
 export const stønadstypeTilSkjemaId: Record<Stønadstype, string> = {
     [Stønadstype.BARNETILSYN]: 'NAV 11-12.15',
     [Stønadstype.LÆREMIDLER]: 'NAV 11-12.16',
+    [Stønadstype.REISE_TIL_SAMLING]: 'NAV 11-12.17',
 };
 
 export const stønadstypeTilSkjemanavn: Record<Stønadstype, string> = {
     [Stønadstype.BARNETILSYN]: 'Pass av barn',
     [Stønadstype.LÆREMIDLER]: 'Læremidler',
+    [Stønadstype.REISE_TIL_SAMLING]: 'Reise til samling',
 };

--- a/src/frontend/typer/stønadstyper.ts
+++ b/src/frontend/typer/stønadstyper.ts
@@ -2,6 +2,7 @@
 export enum Stønadstype {
     BARNETILSYN = 'BARNETILSYN',
     LÆREMIDLER = 'LÆREMIDLER',
+    REISE_TIL_SAMLING = 'REISE_TIL_SAMLING',
 }
 
 export enum SkjematypeFyllUt {

--- a/src/frontend/utils/routeUtils.ts
+++ b/src/frontend/utils/routeUtils.ts
@@ -10,6 +10,11 @@ import {
     routesLæremidler,
     RouteTilPath as RouteToPathLæremidler,
 } from '../læremidler/routing/routesLæremidler';
+import {
+    reiseTilSamlingPath,
+    RouteTilPath as RouteToPathReiseTilSamling,
+    routesReiseTilSamling,
+} from '../reiseTilSamling/routing/routesReiseTilSamling';
 import { IRoute, RouteType } from '../typer/routes';
 import { Stønadstype } from '../typer/stønadstyper';
 
@@ -19,6 +24,8 @@ export const hentRoutes = (stønadstype: Stønadstype): IRoute[] => {
             return RoutesBarnetilsyn;
         case Stønadstype.LÆREMIDLER:
             return routesLæremidler;
+        case Stønadstype.REISE_TIL_SAMLING:
+            return routesReiseTilSamling;
     }
 };
 
@@ -38,6 +45,8 @@ export const hentStartRoute = (stønadstype: Stønadstype) => {
             return barnetilsynPath;
         case Stønadstype.LÆREMIDLER:
             return læremidlerPath;
+        case Stønadstype.REISE_TIL_SAMLING:
+            return reiseTilSamlingPath;
     }
 };
 
@@ -51,5 +60,7 @@ export const finnOppsummeringRoute = (stønadstype: Stønadstype): string => {
             return RouteToPathPassAvBarn.OPPSUMMERING;
         case Stønadstype.LÆREMIDLER:
             return RouteToPathLæremidler.OPPSUMMERING;
+        case Stønadstype.REISE_TIL_SAMLING:
+            return RouteToPathReiseTilSamling.PLACEHOLDER;
     }
 };

--- a/tests/søknader/reiseTilSamling/happyPath.spec.ts
+++ b/tests/søknader/reiseTilSamling/happyPath.spec.ts
@@ -1,0 +1,33 @@
+import { expect, Page, test } from '@playwright/test';
+
+import { søknadBaseUrl } from '../../utils/utils';
+import { forventIngenWcagViolations } from '../../utils/wcag';
+
+const urlSøknad = `${søknadBaseUrl}/reise-til-samling`;
+
+const fjernWebpackOverlay = async (page: Page) => {
+    await page.evaluate(() => {
+        document.querySelector('#webpack-dev-server-client-overlay')?.remove();
+    });
+};
+
+test('At reise til samling viser førstesiden og går til neste steg', async ({ page }) => {
+    await page.goto(urlSøknad);
+    await fjernWebpackOverlay(page);
+
+    await expect(
+        page.getByRole('heading', { name: 'Søknad om støtte ved reise til samling' })
+    ).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Start søknad' })).toBeVisible();
+
+    await forventIngenWcagViolations(page);
+
+    await page.getByLabel('Jeg bekrefter at jeg vil svare så riktig som jeg kan.').check();
+    await page.getByRole('button', { name: 'Start søknad' }).click();
+    await fjernWebpackOverlay(page);
+
+    await expect(page).toHaveURL(`${urlSøknad}/placeholder`);
+    await expect(page.getByRole('heading', { name: 'Dette er neste steg' })).toBeVisible();
+
+    await forventIngenWcagViolations(page);
+});

--- a/webpack/webpack.development.js
+++ b/webpack/webpack.development.js
@@ -15,6 +15,9 @@ const developmentConfig = merge(common, {
         static: '/dist_development',
         port: 8080,
         open: openBrowser,
+        client: {
+            overlay: false,
+        },
         devMiddleware: { publicPath: publicPath },
         historyApiFallback: {
             index: publicPath,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

- Lager ny søknadstype: `REISE_TIL_SAMLING`
- Ny route: `reise-til-samling` som er skrudd av i prod 
- Introside etter ny mal (der mye av tekstene må oppdateres)

<img width="1108" height="1242" alt="image" src="https://github.com/user-attachments/assets/6dd52575-fa8c-4366-bac6-bfffacb81362" />
<img width="816" height="1338" alt="image" src="https://github.com/user-attachments/assets/6e9d2e62-a91f-446a-9f7d-95a4782b1c27" />
