### PR TITLE
Routing for daglig-reise privat bil

### DIFF
--- a/src/backend/redirectTilSkjema.ts
+++ b/src/backend/redirectTilSkjema.ts
@@ -20,17 +20,7 @@ function routeTilFyllUt(
     return false;
 }
 
-function routeTilNyLøsning(
-    skjematype: SkjematypeFyllUt,
-    res: Response,
-    next: NextFunction,
-    internRouteForNyLøsning?: string
-) {
-    if (internRouteForNyLøsning) {
-        res.redirect(302, `${BASE_PATH_SOKNAD}/${internRouteForNyLøsning}`);
-        return;
-    }
-
+function routeTilNyLøsning(skjematype: SkjematypeFyllUt, res: Response, next: NextFunction) {
     const bleRutetTilFyllUt = routeTilFyllUt(skjematype, 'NY', res);
 
     if (!bleRutetTilFyllUt) {
@@ -43,39 +33,32 @@ function routeTilGammelLøsning(skjematype: SkjematypeFyllUt, res: Response) {
 
     if (!bleRutetTilFyllUt) {
         logger.error(`Fant ikke FyllUt-URL for ${skjematype} med versjon GAMMEL`);
-        res.status(500).send(
-            `Feil ved omdirigering, Fant ikke FyllUt-URL for ${skjematype} med versjon GAMMEL`
-        );
+        res.status(500).send('Feil ved omdirigering');
     }
 }
 
-function routeTilAvsjekk(res: Response) {
+function routeTilDagligReiseAvsjekk(res: Response) {
     res.redirect(302, `${BASE_PATH_SOKNAD}/daglig-reise/skjema`);
 }
 
-export const redirectTilSkjema = (
-    skjematype: SkjematypeFyllUt,
-    internRouteForNyLøsning?: string
-) => {
+export const redirectTilSkjema = (skjematype: SkjematypeFyllUt) => {
     return async (req: Request, res: Response, next: NextFunction) => {
         try {
             const aksjon = await hentSkjemaRoutingAksjon(skjematype, req);
 
             switch (aksjon) {
                 case SkjemaRoutingAksjon.NY_LØSNING:
-                    routeTilNyLøsning(skjematype, res, next, internRouteForNyLøsning);
+                    routeTilNyLøsning(skjematype, res, next);
                     return;
                 case SkjemaRoutingAksjon.GAMMEL_LØSNING:
                     routeTilGammelLøsning(skjematype, res);
                     return;
                 case SkjemaRoutingAksjon.AVSJEKK:
-                    routeTilAvsjekk(res);
+                    routeTilDagligReiseAvsjekk(res);
                     return;
                 default:
                     logger.error(`Ukjent aksjon fra skjema-routing: ${aksjon}`);
-                    res.status(500).send(
-                        `Feil ved omdirigering. Ukjent aksjon fra skjema-routing: ${aksjon}`
-                    );
+                    res.status(500).send('Feil ved omdirigering');
             }
         } catch (error) {
             logger.error('Feil ved omdirigering:', error);

--- a/src/backend/redirectTilSkjema.ts
+++ b/src/backend/redirectTilSkjema.ts
@@ -37,8 +37,18 @@ function routeTilGammelLøsning(skjematype: SkjematypeFyllUt, res: Response) {
     }
 }
 
-function routeTilDagligReiseAvsjekk(res: Response) {
+function dagligReiseAvsjekk(res: Response) {
     res.redirect(302, `${BASE_PATH_SOKNAD}/daglig-reise/skjema`);
+}
+
+function routeTilAvsjekk(skjematype: SkjematypeFyllUt, res: Response) {
+    switch (skjematype) {
+        case SkjematypeFyllUt.SØKNAD_DAGLIG_REISE:
+            dagligReiseAvsjekk(res);
+            return;
+        default:
+            throw new Error(`Ingen avsjekk definert for skjematype: ${skjematype}`);
+    }
 }
 
 export const redirectTilSkjema = (skjematype: SkjematypeFyllUt) => {
@@ -54,7 +64,7 @@ export const redirectTilSkjema = (skjematype: SkjematypeFyllUt) => {
                     routeTilGammelLøsning(skjematype, res);
                     return;
                 case SkjemaRoutingAksjon.AVSJEKK:
-                    routeTilDagligReiseAvsjekk(res);
+                    routeTilAvsjekk(skjematype, res);
                     return;
                 default:
                     logger.error(`Ukjent aksjon fra skjema-routing: ${aksjon}`);

--- a/src/backend/redirectTilSkjema.ts
+++ b/src/backend/redirectTilSkjema.ts
@@ -31,15 +31,21 @@ function routeTilNyLøsning(
         return;
     }
 
-    if (!routeTilFyllUt(skjematype, 'NY', res)) {
+    const bleRutetTilFyllUt = routeTilFyllUt(skjematype, 'NY', res);
+
+    if (!bleRutetTilFyllUt) {
         next();
     }
 }
 
 function routeTilGammelLøsning(skjematype: SkjematypeFyllUt, res: Response) {
-    if (!routeTilFyllUt(skjematype, 'GAMMEL', res)) {
+    const bleRutetTilFyllUt = routeTilFyllUt(skjematype, 'GAMMEL', res);
+
+    if (!bleRutetTilFyllUt) {
         logger.error(`Fant ikke FyllUt-URL for ${skjematype} med versjon GAMMEL`);
-        res.status(500).send('Feil ved omdirigering');
+        res.status(500).send(
+            `Feil ved omdirigering, Fant ikke FyllUt-URL for ${skjematype} med versjon GAMMEL`
+        );
     }
 }
 
@@ -67,7 +73,9 @@ export const redirectTilSkjema = (
                     return;
                 default:
                     logger.error(`Ukjent aksjon fra skjema-routing: ${aksjon}`);
-                    res.status(500).send('Feil ved omdirigering');
+                    res.status(500).send(
+                        `Feil ved omdirigering. Ukjent aksjon fra skjema-routing: ${aksjon}`
+                    );
             }
         } catch (error) {
             logger.error('Feil ved omdirigering:', error);

--- a/src/backend/redirectTilSkjema.ts
+++ b/src/backend/redirectTilSkjema.ts
@@ -2,69 +2,76 @@ import { NextFunction, Request, Response } from 'express';
 
 import { getFyllutUrl, SkjematypeFyllUt } from './fyllutUrls';
 import logger from './logger';
-import { skalBrukerTilNyLøsning } from './skjemaRouting';
+import { hentSkjemaRoutingAksjon, SkjemaRoutingAksjon } from './skjemaRouting';
 import { BASE_PATH_SOKNAD } from './url';
 
-/**
- * Redirecter brukeren til enten nytt eller gammelt FyllUt-skjema.
- *
- * Hvis [internRouteForNyLøsning] er angitt vil brukeren routes til en intern route i stedet for nytt FyllUt-skjema, noe
- * som er nyttig for eksempelvis daglige reiser.
- *
- * Hvis ny løsning ikke har en FyllUt-URL, kalles next() slik at requesten faller gjennom til SPA-handleren.
- */
+function routeTilFyllUt(
+    skjematype: SkjematypeFyllUt,
+    versjon: 'NY' | 'GAMMEL',
+    res: Response
+): boolean {
+    const fyllutUrl = getFyllutUrl(skjematype, versjon);
+
+    if (fyllutUrl) {
+        res.redirect(302, fyllutUrl);
+        return true;
+    }
+
+    return false;
+}
+
+function routeTilNyLøsning(
+    skjematype: SkjematypeFyllUt,
+    res: Response,
+    next: NextFunction,
+    internRouteForNyLøsning?: string
+) {
+    if (internRouteForNyLøsning) {
+        res.redirect(302, `${BASE_PATH_SOKNAD}/${internRouteForNyLøsning}`);
+        return;
+    }
+
+    if (!routeTilFyllUt(skjematype, 'NY', res)) {
+        next();
+    }
+}
+
+function routeTilGammelLøsning(skjematype: SkjematypeFyllUt, res: Response) {
+    if (!routeTilFyllUt(skjematype, 'GAMMEL', res)) {
+        logger.error(`Fant ikke FyllUt-URL for ${skjematype} med versjon GAMMEL`);
+        res.status(500).send('Feil ved omdirigering');
+    }
+}
+
+function routeTilAvsjekk(res: Response) {
+    res.redirect(302, `${BASE_PATH_SOKNAD}/daglig-reise/skjema`);
+}
+
 export const redirectTilSkjema = (
     skjematype: SkjematypeFyllUt,
     internRouteForNyLøsning?: string
 ) => {
     return async (req: Request, res: Response, next: NextFunction) => {
         try {
-            const skalBehandlesINyLøsning = await skalBrukerTilNyLøsning(skjematype, req);
+            const aksjon = await hentSkjemaRoutingAksjon(skjematype, req);
 
-            if (skalBehandlesINyLøsning && internRouteForNyLøsning) {
-                res.redirect(302, `${BASE_PATH_SOKNAD}/${internRouteForNyLøsning}`);
-                return;
-            }
-
-            const fyllutUrl = getFyllutUrl(skjematype, skalBehandlesINyLøsning ? 'NY' : 'GAMMEL');
-
-            if (fyllutUrl) {
-                res.redirect(302, fyllutUrl);
-            } else {
-                next();
+            switch (aksjon) {
+                case SkjemaRoutingAksjon.NY_LØSNING:
+                    routeTilNyLøsning(skjematype, res, next, internRouteForNyLøsning);
+                    return;
+                case SkjemaRoutingAksjon.GAMMEL_LØSNING:
+                    routeTilGammelLøsning(skjematype, res);
+                    return;
+                case SkjemaRoutingAksjon.AVSJEKK:
+                    routeTilAvsjekk(res);
+                    return;
+                default:
+                    logger.error(`Ukjent aksjon fra skjema-routing: ${aksjon}`);
+                    res.status(500).send('Feil ved omdirigering');
             }
         } catch (error) {
             logger.error('Feil ved omdirigering:', error);
             res.status(500).send('Feil ved omdirigering');
-        }
-    };
-};
-
-export const redirectTilDagligReiseSkjema = () => {
-    return async (req: Request, res: Response) => {
-        try {
-            const skjematype = SkjematypeFyllUt.SØKNAD_DAGLIG_REISE;
-            const harAAP = await skalBrukerTilNyLøsning(skjematype, req);
-
-            if (harAAP) {
-                const fyllutUrl = getFyllutUrl(skjematype, 'NY');
-                if (fyllutUrl) {
-                    res.redirect(302, fyllutUrl);
-                } else {
-                    logger.error(
-                        'Feil ved omdirigering til daglig reise skjema: klarte ikke å finne fyll-ut url'
-                    );
-                    res.status(500).send(
-                        'Feil ved omdirigering til daglig reise skjema: klarte ikke å finne fyll-ut url'
-                    );
-                }
-            } else {
-                res.redirect(302, `${BASE_PATH_SOKNAD}/daglig-reise/skjema`);
-                return;
-            }
-        } catch (error) {
-            logger.error('Feil ved omdirigering til daglig reise skjema:', error);
-            res.status(500).send('Feil ved omdirigering til daglig reise skjema');
         }
     };
 };

--- a/src/backend/redirectTilSkjema.ts
+++ b/src/backend/redirectTilSkjema.ts
@@ -39,3 +39,32 @@ export const redirectTilSkjema = (
         }
     };
 };
+
+export const redirectTilDagligReiseSkjema = () => {
+    return async (req: Request, res: Response) => {
+        try {
+            const skjematype = SkjematypeFyllUt.SØKNAD_DAGLIG_REISE;
+            const harAAP = await skalBrukerTilNyLøsning(skjematype, req);
+
+            if (harAAP) {
+                const fyllutUrl = getFyllutUrl(skjematype, 'NY');
+                if (fyllutUrl) {
+                    res.redirect(302, fyllutUrl);
+                } else {
+                    logger.error(
+                        'Feil ved omdirigering til daglig reise skjema: klarte ikke å finne fyll-ut url'
+                    );
+                    res.status(500).send(
+                        'Feil ved omdirigering til daglig reise skjema: klarte ikke å finne fyll-ut url'
+                    );
+                }
+            } else {
+                res.redirect(302, `${BASE_PATH_SOKNAD}/daglig-reise/skjema`);
+                return;
+            }
+        } catch (error) {
+            logger.error('Feil ved omdirigering til daglig reise skjema:', error);
+            res.status(500).send('Feil ved omdirigering til daglig reise skjema');
+        }
+    };
+};

--- a/src/backend/routes.ts
+++ b/src/backend/routes.ts
@@ -7,7 +7,7 @@ import { getFyllutUrl, SkjematypeFyllUt } from './fyllutUrls';
 import logger from './logger';
 import { miljø } from './miljø';
 import { addRequestInfo, doProxy } from './proxy';
-import { redirectTilDagligReiseSkjema, redirectTilSkjema } from './redirectTilSkjema';
+import { redirectTilSkjema } from './redirectTilSkjema';
 import attachToken from './tokenProxy';
 import { BASE_PATH_SOKNAD } from './url';
 import { matchAllPathsExcluding } from './utils';
@@ -36,7 +36,7 @@ const routes = () => {
         new RegExp(`^${BASE_PATH_SOKNAD}/daglig-reise/?$`),
         addRequestInfo(),
         attachToken('tilleggsstonader-soknad-api'),
-        redirectTilDagligReiseSkjema()
+        redirectTilSkjema(SkjematypeFyllUt.SØKNAD_DAGLIG_REISE)
     );
 
     expressRouter.get(

--- a/src/backend/routes.ts
+++ b/src/backend/routes.ts
@@ -7,7 +7,7 @@ import { getFyllutUrl, SkjematypeFyllUt } from './fyllutUrls';
 import logger from './logger';
 import { miljø } from './miljø';
 import { addRequestInfo, doProxy } from './proxy';
-import { redirectTilSkjema } from './redirectTilSkjema';
+import { redirectTilDagligReiseSkjema, redirectTilSkjema } from './redirectTilSkjema';
 import attachToken from './tokenProxy';
 import { BASE_PATH_SOKNAD } from './url';
 import { matchAllPathsExcluding } from './utils';
@@ -36,7 +36,7 @@ const routes = () => {
         new RegExp(`^${BASE_PATH_SOKNAD}/daglig-reise/?$`),
         addRequestInfo(),
         attachToken('tilleggsstonader-soknad-api'),
-        redirectTilSkjema(SkjematypeFyllUt.SØKNAD_DAGLIG_REISE, 'daglig-reise/skjema')
+        redirectTilDagligReiseSkjema()
     );
 
     expressRouter.get(

--- a/src/backend/skjemaRouting.ts
+++ b/src/backend/skjemaRouting.ts
@@ -28,6 +28,10 @@ export async function hentSkjemaRoutingAksjon(
             body: JSON.stringify({ skjematype }),
         });
 
+        if (!response.ok) {
+            throw new Error(`Skjema-routing svarte med ${response.status}`);
+        }
+
         const data: SkjemaRoutingResponse = await response.json();
         return data.aksjon;
     } catch (error) {

--- a/src/backend/skjemaRouting.ts
+++ b/src/backend/skjemaRouting.ts
@@ -19,7 +19,7 @@ export async function hentSkjemaRoutingAksjon(
     req: Request
 ): Promise<SkjemaRoutingAksjon> {
     try {
-        const response = await fetch(`${miljø.apiUrl}/skjema-routing`, {
+        const response = await fetch(`${miljø.apiUrl}/skjema-routing/v2`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',

--- a/src/backend/skjemaRouting.ts
+++ b/src/backend/skjemaRouting.ts
@@ -4,14 +4,20 @@ import { SkjematypeFyllUt } from './fyllutUrls';
 import logger from './logger';
 import { miljø } from './miljø';
 
-interface SkjemaRoutingResponse {
-    skalBehandlesINyLøsning: boolean;
+export enum SkjemaRoutingAksjon {
+    NY_LØSNING = 'NY_LØSNING',
+    GAMMEL_LØSNING = 'GAMMEL_LØSNING',
+    AVSJEKK = 'AVSJEKK',
 }
 
-export async function skalBrukerTilNyLøsning(
+interface SkjemaRoutingResponse {
+    aksjon: SkjemaRoutingAksjon;
+}
+
+export async function hentSkjemaRoutingAksjon(
     skjematype: SkjematypeFyllUt,
     req: Request
-): Promise<boolean> {
+): Promise<SkjemaRoutingAksjon> {
     try {
         const response = await fetch(`${miljø.apiUrl}/skjema-routing`, {
             method: 'POST',
@@ -23,7 +29,7 @@ export async function skalBrukerTilNyLøsning(
         });
 
         const data: SkjemaRoutingResponse = await response.json();
-        return data.skalBehandlesINyLøsning;
+        return data.aksjon;
     } catch (error) {
         logger.error(`Feil ved sjekk av routing for ${skjematype}:`, error);
         throw error;


### PR DESCRIPTION
## Summary

- Erstatter boolean-basert routing (`skalBrukerTilNyLøsning`) med `SkjemaRoutingAksjon`-enum (`NY_LØSNING`, `GAMMEL_LØSNING`, `AVSJEKK`) fra API-et, slik at routing-logikken styres av backend
- Validerer API-respons (`response.ok`), fjerner ubrukt `internRouteForNyLøsning`-parameter, og sanitiser feilmeldinger mot sluttbruker