### PR TITLE
🐛 Vis parkeringsvarsel kun for gjeldende innsending

### DIFF
--- a/src/frontend/kjørelister/components/Vedleggside/VedleggUtils.ts
+++ b/src/frontend/kjørelister/components/Vedleggside/VedleggUtils.ts
@@ -1,10 +1,14 @@
 import { Dokument, VedleggstypeKjøreliste } from '../../../typer/skjema';
 import { Kjøreliste } from '../../types/Kjøreliste';
 
-export const harUtgiftOver100kr = (kjøreliste: Kjøreliste): boolean =>
-    kjøreliste.reisedagerPerUkeAvsnitt.some((kjørelisteUke) =>
-        kjørelisteUke.reisedager.some((reisedag) => (reisedag.parkeringsutgift.verdi ?? 0) > 100)
-    );
+export const harUtgiftOver100krIGjeldendeInnsending = (kjøreliste: Kjøreliste): boolean =>
+    kjøreliste.reisedagerPerUkeAvsnitt
+        .filter((uke) => !uke.sendtInnTidligere)
+        .some((kjørelisteUke) =>
+            kjørelisteUke.reisedager.some(
+                (reisedag) => (reisedag.parkeringsutgift.verdi ?? 0) > 100
+            )
+        );
 
 export const finnVedleggMedParkeringsutgifter = (kjøreliste: Kjøreliste): Dokument[] =>
     kjøreliste.dokumentasjon.find(

--- a/src/frontend/kjørelister/components/Vedleggside/Vedleggside.tsx
+++ b/src/frontend/kjørelister/components/Vedleggside/Vedleggside.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 
 import { Alert, Heading, VStack } from '@navikt/ds-react';
 
-import { finnVedleggMedParkeringsutgifter, harUtgiftOver100kr } from './VedleggUtils';
+import {
+    finnVedleggMedParkeringsutgifter,
+    harUtgiftOver100krIGjeldendeInnsending,
+} from './VedleggUtils';
 import { Filopplaster } from '../../../components/Filopplaster/Filopplaster';
 import { useKjøreliste } from '../../KjørelisteContext';
 import { KjørelisteRoutes } from '../../kjørelisteRoutes';
@@ -20,11 +23,11 @@ export const Vedleggside = () => {
             </VStack>
             <Filopplaster
                 opplastedeVedlegg={finnVedleggMedParkeringsutgifter(kjøreliste)}
-                tittel={`Vedlegg parkeringsutgift (${harUtgiftOver100kr(kjøreliste) ? 'obligatorisk' : 'valgfri'})`}
+                tittel={`Vedlegg parkeringsutgift (${harUtgiftOver100krIGjeldendeInnsending(kjøreliste) ? 'obligatorisk' : 'valgfri'})`}
                 leggTilDokument={leggTilDokument}
                 slettDokument={slettDokument}
             />
-            {harUtgiftOver100kr(kjøreliste) && (
+            {harUtgiftOver100krIGjeldendeInnsending(kjøreliste) && (
                 <Alert variant={'warning'}>
                     Du må legge ved dokumentasjon for de dagene hvor parkeringsutgiften overskrider
                     100kr før du sender inn kjørelisten. Hvis du ikke gjør det, kan det hende at du


### PR DESCRIPTION
## Beskrivelse

Varselet om parkeringsutgift over 100kr vises nå bare hvis det finnes en slik utgift på dager i **gjeldende innsending**. Tidligere ble alle uker sjekket, inkludert uker som allerede var sendt inn (`sendtInnTidligere: true`).

## Endringer

- `VedleggUtils.ts`: Filtrerer bort `sendtInnTidligere`-uker i `harUtgiftOver100krIGjeldendeInnsending`
- Omdøper `harUtgiftOver100kr` → `harUtgiftOver100krIGjeldendeInnsending` for å reflektere den nye oppførselen