### PR TITLE
✨ Legg til taxi-avsjekk for daglig reise

### DIFF
--- a/src/backend/redirectTilSkjema.ts
+++ b/src/backend/redirectTilSkjema.ts
@@ -38,13 +38,21 @@ function routeTilGammelLøsning(skjematype: SkjematypeFyllUt, res: Response) {
 }
 
 function dagligReiseAvsjekk(res: Response) {
-    res.redirect(302, `${BASE_PATH_SOKNAD}/daglig-reise/skjema`);
+    res.redirect(302, `${BASE_PATH_SOKNAD}/daglig-reise/skjema-offentlig-transport`);
 }
 
-function routeTilAvsjekk(skjematype: SkjematypeFyllUt, res: Response) {
+function dagligReiseAvsjekkTaxi(res: Response) {
+    res.redirect(302, `${BASE_PATH_SOKNAD}/daglig-reise/skjema-taxi`);
+}
+
+function routeTilAvsjekk(skjematype: SkjematypeFyllUt, aksjon: SkjemaRoutingAksjon, res: Response) {
     switch (skjematype) {
         case SkjematypeFyllUt.SØKNAD_DAGLIG_REISE:
-            dagligReiseAvsjekk(res);
+            if (aksjon === SkjemaRoutingAksjon.AVSJEKK_TAXI) {
+                dagligReiseAvsjekkTaxi(res);
+            } else {
+                dagligReiseAvsjekk(res);
+            }
             return;
         default:
             throw new Error(`Ingen avsjekk definert for skjematype: ${skjematype}`);
@@ -64,7 +72,9 @@ export const redirectTilSkjema = (skjematype: SkjematypeFyllUt) => {
                     routeTilGammelLøsning(skjematype, res);
                     return;
                 case SkjemaRoutingAksjon.AVSJEKK:
-                    routeTilAvsjekk(skjematype, res);
+                case SkjemaRoutingAksjon.AVSJEKK_OFFENTLIG_TRANSPORT:
+                case SkjemaRoutingAksjon.AVSJEKK_TAXI:
+                    routeTilAvsjekk(skjematype, aksjon, res);
                     return;
                 default:
                     logger.error(`Ukjent aksjon fra skjema-routing: ${aksjon}`);

--- a/src/backend/skjemaRouting.ts
+++ b/src/backend/skjemaRouting.ts
@@ -8,6 +8,8 @@ export enum SkjemaRoutingAksjon {
     NY_LØSNING = 'NY_LØSNING',
     GAMMEL_LØSNING = 'GAMMEL_LØSNING',
     AVSJEKK = 'AVSJEKK',
+    AVSJEKK_OFFENTLIG_TRANSPORT = 'AVSJEKK_OFFENTLIG_TRANSPORT',
+    AVSJEKK_TAXI = 'AVSJEKK_TAXI',
 }
 
 interface SkjemaRoutingResponse {

--- a/src/frontend/dagligReise/SkalBrukeTaxiAvsjekk.tsx
+++ b/src/frontend/dagligReise/SkalBrukeTaxiAvsjekk.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+
+import { Button, GuidePanel, Heading, Label, Radio, RadioGroup, VStack } from '@navikt/ds-react';
+
+import { taxiAvsjekkTekster } from './taxiAvsjekkTekster';
+import { omdirigerTilFyllut } from '../api/useFyllutRedirect';
+import { Container } from '../components/Side';
+import { LocaleReadMore } from '../components/Teksthåndtering/LocaleReadMore';
+import LocaleTekst from '../components/Teksthåndtering/LocaleTekst';
+import LocaleTekstAvsnitt from '../components/Teksthåndtering/LocaleTekstAvsnitt';
+import { SkjematypeFyllUt } from '../typer/stønadstyper';
+
+type RadioButtonValg = 'JA' | 'NEI';
+
+export const SkalBrukeTaxiAvsjekk: React.FC = () => {
+    const [svar, setSvar] = useState<RadioButtonValg | undefined>(undefined);
+    const [feilmeldingRadio, settFeilmeldingRadio] = useState('');
+
+    const handleChange = (value: RadioButtonValg) => {
+        setSvar(value);
+        settFeilmeldingRadio('');
+    };
+
+    async function startSøknad() {
+        if (!svar) {
+            settFeilmeldingRadio('Du må velge et av alternativene');
+            return;
+        }
+        await omdirigerTilFyllut(
+            SkjematypeFyllUt.SØKNAD_DAGLIG_REISE,
+            svar === 'JA' ? 'GAMMEL' : 'NY'
+        );
+    }
+
+    return (
+        <Container>
+            <VStack gap="space-8">
+                <Heading size="xlarge" as="h1">
+                    <LocaleTekst tekst={taxiAvsjekkTekster.banner_daglig_reise} />
+                </Heading>
+            </VStack>
+            <GuidePanel poster>
+                <Label>
+                    <LocaleTekst tekst={taxiAvsjekkTekster.veileder_tittel} />
+                </Label>
+                <LocaleTekstAvsnitt tekst={taxiAvsjekkTekster.veileder_innhold} />
+            </GuidePanel>
+            <div>
+                <RadioGroup
+                    legend={'Skal du reise med taxi?'}
+                    onChange={handleChange}
+                    error={feilmeldingRadio}
+                >
+                    <Radio value={'JA'} key={'JA'}>
+                        Ja
+                    </Radio>
+                    <Radio value={'NEI'} key={'NEI'}>
+                        Nei
+                    </Radio>
+                </RadioGroup>
+                <LocaleReadMore tekst={taxiAvsjekkTekster.hvorfor_spør_vi} />
+            </div>
+            <Button onClick={startSøknad} variant="primary">
+                Start
+            </Button>
+        </Container>
+    );
+};

--- a/src/frontend/dagligReise/taxiAvsjekkTekster.ts
+++ b/src/frontend/dagligReise/taxiAvsjekkTekster.ts
@@ -1,0 +1,28 @@
+import { LesMer, TekstElement } from '../typer/tekst';
+
+export interface TaxiAvsjekkInnhold {
+    banner_daglig_reise: TekstElement<string>;
+    hvorfor_spør_vi: LesMer<string>;
+    veileder_tittel: TekstElement<string>;
+    veileder_innhold: TekstElement<string[]>;
+}
+
+export const taxiAvsjekkTekster: TaxiAvsjekkInnhold = {
+    banner_daglig_reise: {
+        nb: 'Søknad om støtte til daglige reiser',
+    },
+    hvorfor_spør_vi: {
+        header: { nb: 'Hvorfor spør vi om dette?' },
+        innhold: {
+            nb: 'Vi trenger å vite om du skal reise med taxi for å kunne sende deg til riktig søknad.',
+        },
+    },
+    veileder_tittel: {
+        nb: 'Hei!',
+    },
+    veileder_innhold: {
+        nb: [
+            'Denne pengestøtten kan gis til deg som gjennomfører en arbeidsrettet aktivitet og er enslig mor/far, gjenlevende, mottar arbeidsavklaringspenger (AAP), uføretrygd, har nedsatt arbeidsevne, tiltakspenger, dagpenger, kvalifiseringsstønad eller sitter i fengsel og ellers ville hatt rett til tiltakspenger.',
+        ],
+    },
+};

--- a/src/frontend/index.tsx
+++ b/src/frontend/index.tsx
@@ -13,6 +13,7 @@ import { barnetilsynPath } from './barnetilsyn/routing/routesBarnetilsyn';
 import ScrollToTop from './components/ScrollToTop';
 import { SpråkProvider } from './context/SpråkContext';
 import { KanBrukeOffentligTransportAvsjekk } from './dagligReise/KanBrukeOffentligTransportAvsjekk';
+import { SkalBrukeTaxiAvsjekk } from './dagligReise/SkalBrukeTaxiAvsjekk';
 import { KjørelisterApp } from './kjørelister/KjørelisterApp';
 import LæremidlerApp from './læremidler/LæremidlerApp';
 import { læremidlerPath } from './læremidler/routing/routesLæremidler';
@@ -44,9 +45,10 @@ const AppRoutes = () => {
                     <Route path={`${reiseTilSamlingPath}/*`} element={<ReiseTilSamlingApp />} />
                 )}
                 <Route
-                    path="/daglig-reise/skjema"
+                    path="/daglig-reise/skjema-offentlig-transport"
                     element={<KanBrukeOffentligTransportAvsjekk />}
                 />
+                <Route path="/daglig-reise/skjema-taxi" element={<SkalBrukeTaxiAvsjekk />} />
                 <Route path={`/kjoreliste/*`} element={<KjørelisterApp />} />
                 <Route path={'*'} element={<Navigate to={barnetilsynPath} replace />} />
             </Routes>


### PR DESCRIPTION
Ny avsjekk-side som spør om bruker skal reise med taxi.
- Taxi → gammel løsning
- Ikke taxi → ny løsning

Oppdatert routing for `AVSJEKK_OFFENTLIG_TRANSPORT` og `AVSJEKK_TAXI`.

Ny komponent `SkalBrukeTaxiAvsjekk` og tilhørende route `/daglig-reise/skjema-taxi`.
Eksisterende offentlig transport-avsjekk flyttet til `/daglig-reise/skjema-offentlig-transport`.

## Deploy-rekkefølge
1. **kontrakter** (allerede pushet til main)
2. **soknad** – denne PR-en (consumer må deployes før producer)
3. **sak** – navikt/tilleggsstonader-sak#1175