### PR TITLE
✨ Legg til taxi-avsjekk for daglig reise

### DIFF
--- a/src/backend/redirectTilSkjema.ts
+++ b/src/backend/redirectTilSkjema.ts
@@ -38,13 +38,21 @@ function routeTilGammelLøsning(skjematype: SkjematypeFyllUt, res: Response) {
 }
 
 function dagligReiseAvsjekk(res: Response) {
-    res.redirect(302, `${BASE_PATH_SOKNAD}/daglig-reise/skjema`);
+    res.redirect(302, `${BASE_PATH_SOKNAD}/daglig-reise/skjema-offentlig-transport`);
 }
 
-function routeTilAvsjekk(skjematype: SkjematypeFyllUt, res: Response) {
+function dagligReiseAvsjekkTaxi(res: Response) {
+    res.redirect(302, `${BASE_PATH_SOKNAD}/daglig-reise/skjema-taxi`);
+}
+
+function routeTilAvsjekk(skjematype: SkjematypeFyllUt, aksjon: SkjemaRoutingAksjon, res: Response) {
     switch (skjematype) {
         case SkjematypeFyllUt.SØKNAD_DAGLIG_REISE:
-            dagligReiseAvsjekk(res);
+            if (aksjon === SkjemaRoutingAksjon.AVSJEKK_TAXI) {
+                dagligReiseAvsjekkTaxi(res);
+            } else {
+                dagligReiseAvsjekk(res);
+            }
             return;
         default:
             throw new Error(`Ingen avsjekk definert for skjematype: ${skjematype}`);
@@ -64,7 +72,9 @@ export const redirectTilSkjema = (skjematype: SkjematypeFyllUt) => {
                     routeTilGammelLøsning(skjematype, res);
                     return;
                 case SkjemaRoutingAksjon.AVSJEKK:
-                    routeTilAvsjekk(skjematype, res);
+                case SkjemaRoutingAksjon.AVSJEKK_OFFENTLIG_TRANSPORT:
+                case SkjemaRoutingAksjon.AVSJEKK_TAXI:
+                    routeTilAvsjekk(skjematype, aksjon, res);
                     return;
                 default:
                     logger.error(`Ukjent aksjon fra skjema-routing: ${aksjon}`);

--- a/src/backend/redirectTilSkjema.ts
+++ b/src/backend/redirectTilSkjema.ts
@@ -21,6 +21,11 @@ function routeTilFyllUt(
 }
 
 function routeTilNyLøsning(skjematype: SkjematypeFyllUt, res: Response, next: NextFunction) {
+    if (skjematype === SkjematypeFyllUt.SØKNAD_DAGLIG_REISE) {
+        res.redirect(302, `${BASE_PATH_SOKNAD}/daglig-reise/skjema-taxi`);
+        return;
+    }
+
     const bleRutetTilFyllUt = routeTilFyllUt(skjematype, 'NY', res);
 
     if (!bleRutetTilFyllUt) {
@@ -37,22 +42,10 @@ function routeTilGammelLøsning(skjematype: SkjematypeFyllUt, res: Response) {
     }
 }
 
-function dagligReiseAvsjekk(res: Response) {
-    res.redirect(302, `${BASE_PATH_SOKNAD}/daglig-reise/skjema-offentlig-transport`);
-}
-
-function dagligReiseAvsjekkTaxi(res: Response) {
-    res.redirect(302, `${BASE_PATH_SOKNAD}/daglig-reise/skjema-taxi`);
-}
-
-function routeTilAvsjekk(skjematype: SkjematypeFyllUt, aksjon: SkjemaRoutingAksjon, res: Response) {
+function routeTilAvsjekk(skjematype: SkjematypeFyllUt, res: Response) {
     switch (skjematype) {
         case SkjematypeFyllUt.SØKNAD_DAGLIG_REISE:
-            if (aksjon === SkjemaRoutingAksjon.AVSJEKK_TAXI) {
-                dagligReiseAvsjekkTaxi(res);
-            } else {
-                dagligReiseAvsjekk(res);
-            }
+            res.redirect(302, `${BASE_PATH_SOKNAD}/daglig-reise/skjema-offentlig-transport`);
             return;
         default:
             throw new Error(`Ingen avsjekk definert for skjematype: ${skjematype}`);
@@ -72,9 +65,7 @@ export const redirectTilSkjema = (skjematype: SkjematypeFyllUt) => {
                     routeTilGammelLøsning(skjematype, res);
                     return;
                 case SkjemaRoutingAksjon.AVSJEKK:
-                case SkjemaRoutingAksjon.AVSJEKK_OFFENTLIG_TRANSPORT:
-                case SkjemaRoutingAksjon.AVSJEKK_TAXI:
-                    routeTilAvsjekk(skjematype, aksjon, res);
+                    routeTilAvsjekk(skjematype, res);
                     return;
                 default:
                     logger.error(`Ukjent aksjon fra skjema-routing: ${aksjon}`);

--- a/src/backend/skjemaRouting.ts
+++ b/src/backend/skjemaRouting.ts
@@ -8,6 +8,8 @@ export enum SkjemaRoutingAksjon {
     NY_LØSNING = 'NY_LØSNING',
     GAMMEL_LØSNING = 'GAMMEL_LØSNING',
     AVSJEKK = 'AVSJEKK',
+    AVSJEKK_OFFENTLIG_TRANSPORT = 'AVSJEKK_OFFENTLIG_TRANSPORT',
+    AVSJEKK_TAXI = 'AVSJEKK_TAXI',
 }
 
 interface SkjemaRoutingResponse {

--- a/src/backend/skjemaRouting.ts
+++ b/src/backend/skjemaRouting.ts
@@ -8,8 +8,6 @@ export enum SkjemaRoutingAksjon {
     NY_LØSNING = 'NY_LØSNING',
     GAMMEL_LØSNING = 'GAMMEL_LØSNING',
     AVSJEKK = 'AVSJEKK',
-    AVSJEKK_OFFENTLIG_TRANSPORT = 'AVSJEKK_OFFENTLIG_TRANSPORT',
-    AVSJEKK_TAXI = 'AVSJEKK_TAXI',
 }
 
 interface SkjemaRoutingResponse {

--- a/src/frontend/dagligReise/DagligReiseAvsjekk.tsx
+++ b/src/frontend/dagligReise/DagligReiseAvsjekk.tsx
@@ -1,0 +1,90 @@
+import React, { useState } from 'react';
+
+import { Button, GuidePanel, Heading, Label, Radio, RadioGroup, VStack } from '@navikt/ds-react';
+
+import { omdirigerTilFyllut } from '../api/useFyllutRedirect';
+import { Container } from '../components/Side';
+import { LocaleReadMore } from '../components/Teksthåndtering/LocaleReadMore';
+import LocaleTekst from '../components/Teksthåndtering/LocaleTekst';
+import LocaleTekstAvsnitt from '../components/Teksthåndtering/LocaleTekstAvsnitt';
+import { SkjematypeFyllUt } from '../typer/stønadstyper';
+import { LesMer, TekstElement } from '../typer/tekst';
+
+export interface AvsjekkTekster {
+    banner_daglig_reise: TekstElement<string>;
+    hvorfor_spør_vi: LesMer<string>;
+    veileder_tittel: TekstElement<string>;
+    veileder_innhold: TekstElement<string[]>;
+}
+
+interface DagligReiseAvsjekkProps {
+    tekster: AvsjekkTekster;
+    legend: string;
+    description?: string;
+    jaBetyrNyLøsning: boolean;
+}
+
+type RadioButtonValg = 'JA' | 'NEI';
+
+export const DagligReiseAvsjekk: React.FC<DagligReiseAvsjekkProps> = ({
+    tekster,
+    legend,
+    description,
+    jaBetyrNyLøsning,
+}) => {
+    const [svar, setSvar] = useState<RadioButtonValg | undefined>(undefined);
+    const [feilmeldingRadio, settFeilmeldingRadio] = useState('');
+
+    const handleChange = (value: RadioButtonValg) => {
+        setSvar(value);
+        settFeilmeldingRadio('');
+    };
+
+    async function startSøknad() {
+        if (!svar) {
+            settFeilmeldingRadio('Du må velge et av alternativene');
+            return;
+        }
+        const jaVersjon = jaBetyrNyLøsning ? 'NY' : 'GAMMEL';
+        const neiVersjon = jaBetyrNyLøsning ? 'GAMMEL' : 'NY';
+        await omdirigerTilFyllut(
+            SkjematypeFyllUt.SØKNAD_DAGLIG_REISE,
+            svar === 'JA' ? jaVersjon : neiVersjon
+        );
+    }
+
+    return (
+        <Container>
+            <VStack gap="space-8">
+                <Heading size="xlarge" as="h1">
+                    <LocaleTekst tekst={tekster.banner_daglig_reise} />
+                </Heading>
+            </VStack>
+            <GuidePanel poster>
+                <Label>
+                    <LocaleTekst tekst={tekster.veileder_tittel} />
+                </Label>
+                <LocaleTekstAvsnitt tekst={tekster.veileder_innhold} />
+            </GuidePanel>
+            <div>
+                <RadioGroup
+                    legend={legend}
+                    description={description}
+                    onChange={handleChange}
+                    error={feilmeldingRadio}
+                >
+                    <Radio value={'JA'} key={'JA'}>
+                        Ja
+                    </Radio>
+                    <Radio value={'NEI'} key={'NEI'}>
+                        Nei
+                    </Radio>
+                </RadioGroup>
+                <LocaleReadMore tekst={tekster.hvorfor_spør_vi} />
+            </div>
+            <Button onClick={startSøknad} variant="primary">
+                Start
+            </Button>
+        </Container>
+    );
+};

--- a/src/frontend/dagligReise/KanBrukeOffentligTransportAvsjekk.tsx
+++ b/src/frontend/dagligReise/KanBrukeOffentligTransportAvsjekk.tsx
@@ -1,71 +1,13 @@
-import React, { useState } from 'react';
+import React from 'react';
 
-import { Button, GuidePanel, Heading, Label, Radio, RadioGroup, VStack } from '@navikt/ds-react';
+import { DagligReiseAvsjekk } from './DagligReiseAvsjekk';
+import { dagligReiseTekster } from './offentligTransportAvsjekkTekster';
 
-import { dagligReiseTekster } from './tekster';
-import { omdirigerTilFyllut } from '../api/useFyllutRedirect';
-import { Container } from '../components/Side';
-import { LocaleReadMore } from '../components/Teksthåndtering/LocaleReadMore';
-import LocaleTekst from '../components/Teksthåndtering/LocaleTekst';
-import LocaleTekstAvsnitt from '../components/Teksthåndtering/LocaleTekstAvsnitt';
-import { SkjematypeFyllUt } from '../typer/stønadstyper';
-
-type RadioButtonValg = 'JA' | 'NEI';
-
-export const KanBrukeOffentligTransportAvsjekk: React.FC = () => {
-    const [svar, setSvar] = useState<RadioButtonValg | undefined>(undefined);
-    const [feilmeldingRadio, settFeilmeldingRadio] = useState('');
-
-    const handleChange = (value: RadioButtonValg) => {
-        setSvar(value);
-        settFeilmeldingRadio('');
-    };
-
-    async function startSøknad() {
-        if (!svar) {
-            settFeilmeldingRadio('Du må velge et av alternativene');
-            return;
-        }
-        await omdirigerTilFyllut(
-            SkjematypeFyllUt.SØKNAD_DAGLIG_REISE,
-            svar === 'JA' ? 'NY' : 'GAMMEL'
-        );
-    }
-
-    return (
-        <Container>
-            <VStack gap="space-8">
-                <Heading size="xlarge" as="h1">
-                    <LocaleTekst tekst={dagligReiseTekster.banner_daglig_reise} />
-                </Heading>
-            </VStack>
-            <GuidePanel poster>
-                <Label>
-                    <LocaleTekst tekst={dagligReiseTekster.veileder_tittel} />
-                </Label>
-                <LocaleTekstAvsnitt tekst={dagligReiseTekster.veileder_innhold} />
-            </GuidePanel>
-            <div>
-                <RadioGroup
-                    legend={'Kan du reise med offentlig transport hele veien?'}
-                    description={
-                        'Med offentlig transport menes buss, tog, trikk, t-bane, ferge og lignende.'
-                    }
-                    onChange={handleChange}
-                    error={feilmeldingRadio}
-                >
-                    <Radio value={'JA'} key={'JA'}>
-                        Ja
-                    </Radio>
-                    <Radio value={'NEI'} key={'NEI'}>
-                        Nei
-                    </Radio>
-                </RadioGroup>
-                <LocaleReadMore tekst={dagligReiseTekster.hvorfor_spør_vi} />
-            </div>
-            <Button onClick={startSøknad} variant="primary">
-                Start
-            </Button>
-        </Container>
-    );
-};
+export const KanBrukeOffentligTransportAvsjekk: React.FC = () => (
+    <DagligReiseAvsjekk
+        tekster={dagligReiseTekster}
+        legend={'Kan du reise med offentlig transport hele veien?'}
+        description={'Med offentlig transport menes buss, tog, trikk, t-bane, ferge og lignende.'}
+        jaBetyrNyLøsning={true}
+    />
+);

--- a/src/frontend/dagligReise/SkalBrukeTaxiAvsjekk.tsx
+++ b/src/frontend/dagligReise/SkalBrukeTaxiAvsjekk.tsx
@@ -1,68 +1,12 @@
-import React, { useState } from 'react';
+import React from 'react';
 
-import { Button, GuidePanel, Heading, Label, Radio, RadioGroup, VStack } from '@navikt/ds-react';
-
+import { DagligReiseAvsjekk } from './DagligReiseAvsjekk';
 import { taxiAvsjekkTekster } from './taxiAvsjekkTekster';
-import { omdirigerTilFyllut } from '../api/useFyllutRedirect';
-import { Container } from '../components/Side';
-import { LocaleReadMore } from '../components/Teksthåndtering/LocaleReadMore';
-import LocaleTekst from '../components/Teksthåndtering/LocaleTekst';
-import LocaleTekstAvsnitt from '../components/Teksthåndtering/LocaleTekstAvsnitt';
-import { SkjematypeFyllUt } from '../typer/stønadstyper';
 
-type RadioButtonValg = 'JA' | 'NEI';
-
-export const SkalBrukeTaxiAvsjekk: React.FC = () => {
-    const [svar, setSvar] = useState<RadioButtonValg | undefined>(undefined);
-    const [feilmeldingRadio, settFeilmeldingRadio] = useState('');
-
-    const handleChange = (value: RadioButtonValg) => {
-        setSvar(value);
-        settFeilmeldingRadio('');
-    };
-
-    async function startSøknad() {
-        if (!svar) {
-            settFeilmeldingRadio('Du må velge et av alternativene');
-            return;
-        }
-        await omdirigerTilFyllut(
-            SkjematypeFyllUt.SØKNAD_DAGLIG_REISE,
-            svar === 'JA' ? 'GAMMEL' : 'NY'
-        );
-    }
-
-    return (
-        <Container>
-            <VStack gap="space-8">
-                <Heading size="xlarge" as="h1">
-                    <LocaleTekst tekst={taxiAvsjekkTekster.banner_daglig_reise} />
-                </Heading>
-            </VStack>
-            <GuidePanel poster>
-                <Label>
-                    <LocaleTekst tekst={taxiAvsjekkTekster.veileder_tittel} />
-                </Label>
-                <LocaleTekstAvsnitt tekst={taxiAvsjekkTekster.veileder_innhold} />
-            </GuidePanel>
-            <div>
-                <RadioGroup
-                    legend={'Skal du reise med taxi?'}
-                    onChange={handleChange}
-                    error={feilmeldingRadio}
-                >
-                    <Radio value={'JA'} key={'JA'}>
-                        Ja
-                    </Radio>
-                    <Radio value={'NEI'} key={'NEI'}>
-                        Nei
-                    </Radio>
-                </RadioGroup>
-                <LocaleReadMore tekst={taxiAvsjekkTekster.hvorfor_spør_vi} />
-            </div>
-            <Button onClick={startSøknad} variant="primary">
-                Start
-            </Button>
-        </Container>
-    );
-};
+export const SkalBrukeTaxiAvsjekk: React.FC = () => (
+    <DagligReiseAvsjekk
+        tekster={taxiAvsjekkTekster}
+        legend={'Skal du reise med taxi?'}
+        jaBetyrNyLøsning={false}
+    />
+);

--- a/src/frontend/dagligReise/SkalBrukeTaxiAvsjekk.tsx
+++ b/src/frontend/dagligReise/SkalBrukeTaxiAvsjekk.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+
+import { Button, GuidePanel, Heading, Label, Radio, RadioGroup, VStack } from '@navikt/ds-react';
+
+import { taxiAvsjekkTekster } from './taxiAvsjekkTekster';
+import { omdirigerTilFyllut } from '../api/useFyllutRedirect';
+import { Container } from '../components/Side';
+import { LocaleReadMore } from '../components/Teksthåndtering/LocaleReadMore';
+import LocaleTekst from '../components/Teksthåndtering/LocaleTekst';
+import LocaleTekstAvsnitt from '../components/Teksthåndtering/LocaleTekstAvsnitt';
+import { SkjematypeFyllUt } from '../typer/stønadstyper';
+
+type RadioButtonValg = 'JA' | 'NEI';
+
+export const SkalBrukeTaxiAvsjekk: React.FC = () => {
+    const [svar, setSvar] = useState<RadioButtonValg | undefined>(undefined);
+    const [feilmeldingRadio, settFeilmeldingRadio] = useState('');
+
+    const handleChange = (value: RadioButtonValg) => {
+        setSvar(value);
+        settFeilmeldingRadio('');
+    };
+
+    async function startSøknad() {
+        if (!svar) {
+            settFeilmeldingRadio('Du må velge et av alternativene');
+            return;
+        }
+        await omdirigerTilFyllut(
+            SkjematypeFyllUt.SØKNAD_DAGLIG_REISE,
+            svar === 'JA' ? 'GAMMEL' : 'NY'
+        );
+    }
+
+    return (
+        <Container>
+            <VStack gap="space-8">
+                <Heading size="xlarge" as="h1">
+                    <LocaleTekst tekst={taxiAvsjekkTekster.banner_daglig_reise} />
+                </Heading>
+            </VStack>
+            <GuidePanel poster>
+                <Label>
+                    <LocaleTekst tekst={taxiAvsjekkTekster.veileder_tittel} />
+                </Label>
+                <LocaleTekstAvsnitt tekst={taxiAvsjekkTekster.veileder_innhold} />
+            </GuidePanel>
+            <div>
+                <RadioGroup
+                    legend={'Skal du reise med taxi?'}
+                    onChange={handleChange}
+                    error={feilmeldingRadio}
+                >
+                    <Radio value={'JA'} key={'JA'}>
+                        Ja
+                    </Radio>
+                    <Radio value={'NEI'} key={'NEI'}>
+                        Nei
+                    </Radio>
+                </RadioGroup>
+                <LocaleReadMore tekst={taxiAvsjekkTekster.hvorfor_spør_vi} />
+            </div>
+            <Button onClick={startSøknad} variant="primary">
+                Start
+            </Button>
+        </Container>
+    );
+};

--- a/src/frontend/dagligReise/offentligTransportAvsjekkTekster.ts
+++ b/src/frontend/dagligReise/offentligTransportAvsjekkTekster.ts
@@ -1,13 +1,6 @@
-import { LesMer, TekstElement } from '../typer/tekst';
+import { AvsjekkTekster } from './DagligReiseAvsjekk';
 
-export interface DagligReiseInnhold {
-    banner_daglig_reise: TekstElement<string>;
-    hvorfor_spør_vi: LesMer<string>;
-    veileder_tittel: TekstElement<string>;
-    veileder_innhold: TekstElement<string[]>;
-}
-
-export const dagligReiseTekster: DagligReiseInnhold = {
+export const dagligReiseTekster: AvsjekkTekster = {
     banner_daglig_reise: {
         nb: 'Søknad om støtte til daglige reiser',
     },

--- a/src/frontend/dagligReise/taxiAvsjekkTekster.ts
+++ b/src/frontend/dagligReise/taxiAvsjekkTekster.ts
@@ -1,13 +1,6 @@
-import { LesMer, TekstElement } from '../typer/tekst';
+import { AvsjekkTekster } from './DagligReiseAvsjekk';
 
-export interface TaxiAvsjekkInnhold {
-    banner_daglig_reise: TekstElement<string>;
-    hvorfor_spør_vi: LesMer<string>;
-    veileder_tittel: TekstElement<string>;
-    veileder_innhold: TekstElement<string[]>;
-}
-
-export const taxiAvsjekkTekster: TaxiAvsjekkInnhold = {
+export const taxiAvsjekkTekster: AvsjekkTekster = {
     banner_daglig_reise: {
         nb: 'Søknad om støtte til daglige reiser',
     },

--- a/src/frontend/dagligReise/taxiAvsjekkTekster.ts
+++ b/src/frontend/dagligReise/taxiAvsjekkTekster.ts
@@ -1,0 +1,28 @@
+import { LesMer, TekstElement } from '../typer/tekst';
+
+export interface TaxiAvsjekkInnhold {
+    banner_daglig_reise: TekstElement<string>;
+    hvorfor_spør_vi: LesMer<string>;
+    veileder_tittel: TekstElement<string>;
+    veileder_innhold: TekstElement<string[]>;
+}
+
+export const taxiAvsjekkTekster: TaxiAvsjekkInnhold = {
+    banner_daglig_reise: {
+        nb: 'Søknad om støtte til daglige reiser',
+    },
+    hvorfor_spør_vi: {
+        header: { nb: 'Hvorfor spør vi om dette?' },
+        innhold: {
+            nb: 'Vi trenger å vite om du skal reise med taxi for å kunne sende deg til riktig søknad.',
+        },
+    },
+    veileder_tittel: {
+        nb: 'Hei!',
+    },
+    veileder_innhold: {
+        nb: [
+            'Denne pengestøtten kan gis til deg som gjennomfører en arbeidsrettet aktivitet og er enslig mor/far, gjenlevende, mottar arbeidsavklaringspenger (AAP), uføretrygd, har nedsatt arbeidsevne, tiltakspenger, dagpenger, kvalifiseringsstønad eller sitter i fengsel og ellers ville hatt rett til tiltakspenger.',
+        ],
+    },
+};

--- a/src/frontend/index.tsx
+++ b/src/frontend/index.tsx
@@ -13,6 +13,7 @@ import { barnetilsynPath } from './barnetilsyn/routing/routesBarnetilsyn';
 import ScrollToTop from './components/ScrollToTop';
 import { SpråkProvider } from './context/SpråkContext';
 import { KanBrukeOffentligTransportAvsjekk } from './dagligReise/KanBrukeOffentligTransportAvsjekk';
+import { SkalBrukeTaxiAvsjekk } from './dagligReise/SkalBrukeTaxiAvsjekk';
 import { KjørelisterApp } from './kjørelister/KjørelisterApp';
 import LæremidlerApp from './læremidler/LæremidlerApp';
 import { læremidlerPath } from './læremidler/routing/routesLæremidler';
@@ -44,9 +45,10 @@ const AppRoutes = () => {
                     <Route path={`${reiseTilSamlingPath}/*`} element={<ReiseTilSamlingApp />} />
                 )}
                 <Route
-                    path="/daglig-reise/skjema"
+                    path="/daglig-reise/skjema-offentlig-transport"
                     element={<KanBrukeOffentligTransportAvsjekk />}
                 />
+                <Route path="/daglig-reise/skjema-taxi" element={<SkalBrukeTaxiAvsjekk />} />
                 <Route path={`/kjoreliste/*`} element={<KjørelisterApp />} />
                 <Route path={'*'} element={<Navigate to={barnetilsynPath} replace />} />
             </Routes>


### PR DESCRIPTION
Brukere som får `NY_LØSNING` for daglig reise blir nå sendt til taxi-avsjekk først.
- Skal reise med taxi → gammel løsning
- Skal ikke reise med taxi → ny løsning

Brukere som får `AVSJEKK` rutes som før til offentlig transport-avsjekk.

### Endringer
- Ny generisk `DagligReiseAvsjekk`-komponent som deles mellom taxi- og offentlig transport-avsjekk
- Ny `SkalBrukeTaxiAvsjekk`-komponent og route `/daglig-reise/skjema-taxi`
- Offentlig transport-avsjekk flyttet til `/daglig-reise/skjema-offentlig-transport`
