### PR TITLE
Legger inn lenke til kjørelistene i arena slik at det er mulig å navigere dit selv om man har kjøreliste hos oss

### DIFF
--- a/src/frontend/kjørelister/KjørelisterApp.tsx
+++ b/src/frontend/kjørelister/KjørelisterApp.tsx
@@ -8,6 +8,7 @@ import styled from 'styled-components';
 import { VStack } from '@navikt/ds-react';
 import { BreakpointMd } from '@navikt/ds-tokens/js';
 
+import { KjørelisteArenaLenke } from './components/KjørelisteArenaLenke';
 import { KjørelisteHeader } from './components/KjørelisteHeader';
 import { Landingsside } from './components/Landingsside/Landingsside';
 import { KjørelisteInnhold } from './KjørelisteInnhold';
@@ -33,6 +34,7 @@ export const KjørelisterApp = () => {
                         <Route path="/" element={<Landingsside />} />
                         <Route path={'/:reiseId/*'} element={<KjørelisteInnhold />} />
                     </Routes>
+                    <KjørelisteArenaLenke />
                 </VStack>
             </Container>
         </QueryClientProvider>

--- a/src/frontend/kjørelister/components/KjørelisteArenaLenke.tsx
+++ b/src/frontend/kjørelister/components/KjørelisteArenaLenke.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import { ExternalLinkIcon } from '@navikt/aksel-icons';
+import { BodyShort, Heading, Link, VStack } from '@navikt/ds-react';
+
+export const KjørelisteArenaLenke = () => {
+    return (
+        <VStack gap="space-8">
+            <Heading level="2" size="medium">
+                Fant du ikke det du lette etter?
+            </Heading>
+            <BodyShort>
+                <Link href="https://www.nav.no/fyllut/nav111224b?sub=digital" target="_blank">
+                    Eldre kjørelister finner du her (åpnes i ny fane) <ExternalLinkIcon />
+                </Link>
+            </BodyShort>
+        </VStack>
+    );
+};


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det er mulig å ha kjørelister/rammevedtak både i ts-sak og arena. Så da er det greit å gi brukerne lenken til den gamle også dersom de blir rutet til oss: 

<img width="920" height="781" alt="image" src="https://github.com/user-attachments/assets/2c20d2fb-bd67-416b-9021-c57afdfaebf6" />
