### PR TITLE
🐛 Legg til mappingen mellom ulike land formater i koden da vi mister dette i webpack bygget

### DIFF
--- a/src/frontend/components/Landvelger/Landvelger.tsx
+++ b/src/frontend/components/Landvelger/Landvelger.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo } from 'react';
 
 import countries from 'i18n-iso-countries';
+import codesData from 'i18n-iso-countries/codes.json';
 import nbLocale from 'i18n-iso-countries/langs/nb.json';
 
 import { UNSAFE_Combobox } from '@navikt/ds-react';
@@ -11,6 +12,14 @@ import { SelectFelt } from '../../typer/skjema';
 import { TekstElement } from '../../typer/tekst';
 
 countries.registerLocale(nbLocale);
+
+// Webpack fjerner innholdet i codes.json fra i18n-iso-countries når den bygger,
+// noe som gjør at alpha2ToAlpha3 returnerer undefined. Her importerer og bygger vi mappingen direkte
+// for å sikre at dataene er inkludert i bundlen.
+const alpha2ToAlpha3Map: Record<string, string> = {};
+codesData.forEach(([alpha2, alpha3]) => {
+    alpha2ToAlpha3Map[alpha2] = alpha3;
+});
 
 interface Props {
     id?: string;
@@ -30,7 +39,7 @@ const utenNorskeOmråder = (country: [string, string]): boolean =>
     country[0] !== 'NOR' && country[0] !== 'SJM';
 
 const landkodeTilNavn = Object.entries(countries.getNames('nb', { select: 'official' }))
-    .map((country) => [countries.alpha2ToAlpha3(country[0]), country[1]] as [string, string])
+    .map((country) => [alpha2ToAlpha3Map[country[0]], country[1]] as [string, string])
     .reduce(
         (prev, curr) => {
             prev[curr[0]] = curr[1];


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Webpack sin `optimization.usedExports` fjernet innholdet fra `i18n-iso-countries/codes.json` når den bygget. Dette gjorde at vi mistet mappingen mellom formatene alpha-2 og alpha-3. Litt usikker på hva de formatene er og hvorfor vi trenger det, men ser ut som det eksplisitt ble lagt til her: https://github.com/navikt/tilleggsstonader-soknad/commit/38197cf

Nå lagrer vi mappingen i en variabel i koden og tar dermed vare på mappingen gjennom byggingen.

<img width="803" height="654" alt="image" src="https://github.com/user-attachments/assets/cb0c7737-e604-4b04-8b0b-f560cc4c34a8" />
