### PR TITLE
♻️ Stønadstype -> Skjematype

### DIFF
--- a/src/frontend/api/Environment.ts
+++ b/src/frontend/api/Environment.ts
@@ -16,9 +16,9 @@ interface IModellversjon {
 }
 
 const SkjematypeTilPapirskjema: Record<Skjematype, string> = {
-    SØKNAD_BARNETILSYN: 'nav111215b',
-    SØKNAD_LÆREMIDLER: 'nav111216b',
-    SØKNAD_REISE_TIL_SAMLING: 'nav111217b',
+    [Skjematype.SØKNAD_BARNETILSYN]: 'nav111215b',
+    [Skjematype.SØKNAD_LÆREMIDLER]: 'nav111216b',
+    [Skjematype.SØKNAD_REISE_TIL_SAMLING]: 'nav111217b',
 };
 
 const urlPapirsøknadProd = (skjematype: Skjematype) =>

--- a/src/frontend/api/Environment.ts
+++ b/src/frontend/api/Environment.ts
@@ -15,17 +15,17 @@ interface IModellversjon {
     barnetilsyn: number;
 }
 
-const StønadstypeTilPapirskjema: Record<Skjematype, string> = {
-    BARNETILSYN: 'nav111215b',
-    LÆREMIDLER: 'nav111216b',
-    REISE_TIL_SAMLING: 'nav111217b',
+const SkjematypeTilPapirskjema: Record<Skjematype, string> = {
+    SØKNAD_BARNETILSYN: 'nav111215b',
+    SØKNAD_LÆREMIDLER: 'nav111216b',
+    SØKNAD_REISE_TIL_SAMLING: 'nav111217b',
 };
 
 const urlPapirsøknadProd = (skjematype: Skjematype) =>
-    `https://www.nav.no/fyllut/${StønadstypeTilPapirskjema[skjematype]}?sub=paper`;
+    `https://www.nav.no/fyllut/${SkjematypeTilPapirskjema[skjematype]}?sub=paper`;
 
 const urlPapirsøknadDev = (skjematype: Skjematype) =>
-    `https://skjemadelingslenke.ekstern.dev.nav.no/fyllut/${StønadstypeTilPapirskjema[skjematype]}?sub=paper`;
+    `https://skjemadelingslenke.ekstern.dev.nav.no/fyllut/${SkjematypeTilPapirskjema[skjematype]}?sub=paper`;
 
 export const Environment = (): EnvironmentProps => {
     const modellVersjon = { overgangsstønad: 7, barnetilsyn: 2, skolepenger: 2 };

--- a/src/frontend/api/api.ts
+++ b/src/frontend/api/api.ts
@@ -38,7 +38,7 @@ export const hentArbeidsrettedeAktiviteter = (
         axios
             // TODO: For at dette kallet skal fungere for reise til samling, må endepunktet tilpasses slik at det tar i mot skjematype i stedet for stønadstype
             // https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=Nav-29433
-            .post<RegisterAktiviteterResponse>(url, { stønadstype: skjematype }, defaultConfig())
+            .post<RegisterAktiviteterResponse>(url, { skjematype: skjematype }, defaultConfig())
             .then((response) => response.data.aktiviteter)
     );
 };
@@ -48,7 +48,7 @@ export const hentBehandlingStatus = (skjematype: Skjematype): Promise<boolean> =
         .get<boolean>(
             // TODO: For at dette kallet skal fungere for reise til samling, må endepunktet tilpasses slik at det tar i mot skjematype i stedet for stønadstype
             // https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=Nav-29436
-            `${Environment().apiProxyUrl}/person/har-behandling?stonadstype=${encodeURIComponent(skjematype)}`,
+            `${Environment().apiProxyUrl}/person/har-behandling?skjematype=${encodeURIComponent(skjematype)}`,
             defaultConfig()
         )
         .then((response) => response.data);
@@ -56,11 +56,11 @@ export const hentBehandlingStatus = (skjematype: Skjematype): Promise<boolean> =
 
 const skjematypeTilPath = (skjematype: Skjematype): string => {
     switch (skjematype) {
-        case Skjematype.BARNETILSYN:
+        case Skjematype.SØKNAD_BARNETILSYN:
             return 'pass-av-barn';
-        case Skjematype.LÆREMIDLER:
+        case Skjematype.SØKNAD_LÆREMIDLER:
             return 'laremidler';
-        case Skjematype.REISE_TIL_SAMLING:
+        case Skjematype.SØKNAD_REISE_TIL_SAMLING:
             return 'reise-til-samling';
     }
 };

--- a/src/frontend/api/api.ts
+++ b/src/frontend/api/api.ts
@@ -21,37 +21,32 @@ export const defaultConfig = () => ({
     withCredentials: true,
 });
 
-export const hentPersonData = (medBarn: boolean): Promise<Person> => {
-    return axios
-        .get<Person>(
-            `${Environment().apiProxyUrl}/person${medBarn ? '/med-barn' : ''}`,
-            defaultConfig()
-        )
-        .then((response) => response.data);
+export const hentPersonData = async (medBarn: boolean): Promise<Person> => {
+    const response = await axios.get<Person>(
+        `${Environment().apiProxyUrl}/person${medBarn ? '/med-barn' : ''}`,
+        defaultConfig()
+    );
+    return response.data;
 };
 
-export const hentArbeidsrettedeAktiviteter = (
+export const hentArbeidsrettedeAktiviteter = async (
     skjematype: Skjematype
 ): Promise<RegisterAktivitet[]> => {
     const url = `${Environment().apiProxyUrl}/aktivitet`;
-    return (
-        axios
-            // TODO: For at dette kallet skal fungere for reise til samling, må endepunktet tilpasses slik at det tar i mot skjematype i stedet for stønadstype
-            // https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=Nav-29433
-            .post<RegisterAktiviteterResponse>(url, { skjematype: skjematype }, defaultConfig())
-            .then((response) => response.data.aktiviteter)
+    const response = await axios.post<RegisterAktiviteterResponse>(
+        url,
+        { skjematype },
+        defaultConfig()
     );
+    return response.data.aktiviteter;
 };
 
-export const hentBehandlingStatus = (skjematype: Skjematype): Promise<boolean> => {
-    return axios
-        .get<boolean>(
-            // TODO: For at dette kallet skal fungere for reise til samling, må endepunktet tilpasses slik at det tar i mot skjematype i stedet for stønadstype
-            // https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=Nav-29436
-            `${Environment().apiProxyUrl}/person/har-behandling?skjematype=${encodeURIComponent(skjematype)}`,
-            defaultConfig()
-        )
-        .then((response) => response.data);
+export const hentBehandlingStatus = async (skjematype: Skjematype): Promise<boolean> => {
+    const response = await axios.get<boolean>(
+        `${Environment().apiProxyUrl}/person/har-behandling?skjematype=${encodeURIComponent(skjematype)}`,
+        defaultConfig()
+    );
+    return response.data;
 };
 
 const skjematypeTilPath = (skjematype: Skjematype): string => {

--- a/src/frontend/barnetilsyn/BarnetilsynApp.tsx
+++ b/src/frontend/barnetilsyn/BarnetilsynApp.tsx
@@ -18,7 +18,7 @@ const BarnetilsynInnhold = () => {
 
     return (
         <SøknadProvider
-            skjematype={Skjematype.BARNETILSYN}
+            skjematype={Skjematype.SØKNAD_BARNETILSYN}
             søknad={{
                 hovedytelse: hovedytelse,
                 aktivitet: aktivitet,
@@ -40,14 +40,14 @@ export const BarnetilsynApp = () => {
     const { locale } = useSpråk();
 
     useEffect(() => {
-        document.title = teksterStønad.tittelHtml[Skjematype.BARNETILSYN][locale];
+        document.title = teksterStønad.tittelHtml[Skjematype.SØKNAD_BARNETILSYN][locale];
     }, [locale]);
 
     return (
-        <PersonRouting skjematype={Skjematype.BARNETILSYN}>
+        <PersonRouting skjematype={Skjematype.SØKNAD_BARNETILSYN}>
             <ValideringsfeilProvider>
                 <PassAvBarnSøknadProvider>
-                    <RegisterAktiviteterProvider skjematype={Skjematype.BARNETILSYN}>
+                    <RegisterAktiviteterProvider skjematype={Skjematype.SØKNAD_BARNETILSYN}>
                         <BarnetilsynInnhold />
                     </RegisterAktiviteterProvider>
                 </PassAvBarnSøknadProvider>

--- a/src/frontend/barnetilsyn/Forside.tsx
+++ b/src/frontend/barnetilsyn/Forside.tsx
@@ -42,12 +42,12 @@ export const Forside: React.FC = () => {
 
     useEffect(() => {
         const route = RoutesBarnetilsyn[0];
-        loggBesøk(Skjematype.BARNETILSYN, route.path, route.label);
+        loggBesøk(Skjematype.SØKNAD_BARNETILSYN, route.path, route.label);
     }, []);
 
     const startSøknad = () => {
         if (harBekreftet) {
-            loggSkjemaStartet(Skjematype.BARNETILSYN);
+            loggSkjemaStartet(Skjematype.SØKNAD_BARNETILSYN);
             const nesteRoute = hentNesteRoute(RoutesBarnetilsyn, location.pathname);
             navigate(nesteRoute.path);
         } else {
@@ -56,7 +56,12 @@ export const Forside: React.FC = () => {
     };
 
     const loggAccordionÅpning = (skalÅpne: boolean, tittel: string) => {
-        loggAccordionEvent(Skjematype.BARNETILSYN, skalÅpne, tittel, ERouteBarnetilsyn.FORSIDE);
+        loggAccordionEvent(
+            Skjematype.SØKNAD_BARNETILSYN,
+            skalÅpne,
+            tittel,
+            ERouteBarnetilsyn.FORSIDE
+        );
     };
 
     return (

--- a/src/frontend/barnetilsyn/Søknadsdialog.tsx
+++ b/src/frontend/barnetilsyn/Søknadsdialog.tsx
@@ -24,7 +24,7 @@ export const Søknadsdialog: React.FC = () => {
         <>
             <SøknadsskjemaHeader
                 tittel={fellesTekster.banner_bt}
-                skjemaId={skjematypeTilSkjemaId[Skjematype.BARNETILSYN]}
+                skjemaId={skjematypeTilSkjemaId[Skjematype.SØKNAD_BARNETILSYN]}
             />
             <Routes>
                 <Route path={'/'} element={<RootRoute forside={<Forside />} />} />

--- a/src/frontend/components/PersonRouting.tsx
+++ b/src/frontend/components/PersonRouting.tsx
@@ -13,7 +13,7 @@ const erFeilOgSkalRouteTilPapirsøknad = (req: AxiosError<{ detail?: string }, u
     return req?.response?.data?.detail === 'ROUTING_GAMMEL_SØKNAD';
 };
 
-const skjematyperMedBarn = [Skjematype.BARNETILSYN];
+const skjematyperMedBarn = [Skjematype.SØKNAD_BARNETILSYN];
 
 const skalHenteMedBarn = (skjematype: Skjematype) => skjematyperMedBarn.indexOf(skjematype) > -1;
 

--- a/src/frontend/components/RootRoute.tsx
+++ b/src/frontend/components/RootRoute.tsx
@@ -15,9 +15,9 @@ interface RootRouteProps {
 }
 
 const route: Record<Skjematype, IRoute> = {
-    [Skjematype.BARNETILSYN]: RoutesBarnetilsyn[0],
-    [Skjematype.LÆREMIDLER]: routesLæremidler[0],
-    [Skjematype.REISE_TIL_SAMLING]: routesReiseTilSamling[0],
+    [Skjematype.SØKNAD_BARNETILSYN]: RoutesBarnetilsyn[0],
+    [Skjematype.SØKNAD_LÆREMIDLER]: routesLæremidler[0],
+    [Skjematype.SØKNAD_REISE_TIL_SAMLING]: routesReiseTilSamling[0],
 };
 
 export const RootRoute: React.FC<RootRouteProps> = ({ forside }) => {

--- a/src/frontend/components/Vedlegg/Dokumentasjonskrav.tsx
+++ b/src/frontend/components/Vedlegg/Dokumentasjonskrav.tsx
@@ -43,7 +43,7 @@ export const Dokumentasjonskrav: React.FC<{
                     </Dokumentasjonskravsliste>
                 </Box>
             </div>
-            {skjematype === Skjematype.BARNETILSYN && (
+            {skjematype === Skjematype.SØKNAD_BARNETILSYN && (
                 <BodyShort>
                     <LocaleTekst tekst={vedleggTekster.dokumentasjonskrav_samlet_faktura} />
                 </BodyShort>

--- a/src/frontend/læremidler/Forside.tsx
+++ b/src/frontend/læremidler/Forside.tsx
@@ -31,12 +31,12 @@ export const Forside: React.FC = () => {
 
     useEffect(() => {
         const route = routesLæremidler[0];
-        loggBesøk(Skjematype.LÆREMIDLER, route.path, route.label);
+        loggBesøk(Skjematype.SØKNAD_LÆREMIDLER, route.path, route.label);
     }, []);
 
     const startSøknad = () => {
         if (harBekreftet) {
-            loggSkjemaStartet(Skjematype.LÆREMIDLER);
+            loggSkjemaStartet(Skjematype.SØKNAD_LÆREMIDLER);
             const nesteRoute = hentNesteRoute(routesLæremidler, location.pathname);
             navigate(nesteRoute.path);
         } else {
@@ -45,7 +45,12 @@ export const Forside: React.FC = () => {
     };
 
     const loggAccordionÅpning = (skalÅpne: boolean, tittel: string) => {
-        loggAccordionEvent(Skjematype.LÆREMIDLER, skalÅpne, tittel, ERouteLæremidler.FORSIDE);
+        loggAccordionEvent(
+            Skjematype.SØKNAD_LÆREMIDLER,
+            skalÅpne,
+            tittel,
+            ERouteLæremidler.FORSIDE
+        );
     };
 
     return (

--- a/src/frontend/læremidler/LæremidlerApp.tsx
+++ b/src/frontend/læremidler/LæremidlerApp.tsx
@@ -17,7 +17,7 @@ const LæremidlerInnhold = () => {
 
     return (
         <SøknadProvider
-            skjematype={Skjematype.LÆREMIDLER}
+            skjematype={Skjematype.SØKNAD_LÆREMIDLER}
             søknad={{
                 hovedytelse: hovedytelse,
                 utdanning: utdanning,
@@ -38,14 +38,14 @@ export const LæremidlerApp = () => {
     const { locale } = useSpråk();
 
     useEffect(() => {
-        document.title = teksterStønad.tittelHtml[Skjematype.LÆREMIDLER][locale];
+        document.title = teksterStønad.tittelHtml[Skjematype.SØKNAD_LÆREMIDLER][locale];
     }, [locale]);
 
     return (
-        <PersonRouting skjematype={Skjematype.LÆREMIDLER}>
+        <PersonRouting skjematype={Skjematype.SØKNAD_LÆREMIDLER}>
             <ValideringsfeilProvider>
                 <LæremidlerSøknadProvider>
-                    <RegisterAktiviteterProvider skjematype={Skjematype.LÆREMIDLER}>
+                    <RegisterAktiviteterProvider skjematype={Skjematype.SØKNAD_LÆREMIDLER}>
                         <LæremidlerInnhold />
                     </RegisterAktiviteterProvider>
                 </LæremidlerSøknadProvider>

--- a/src/frontend/læremidler/Søknadsdialog.tsx
+++ b/src/frontend/læremidler/Søknadsdialog.tsx
@@ -22,7 +22,7 @@ export const Søknadsdialog: React.FC = () => {
         <>
             <SøknadsskjemaHeader
                 tittel={fellesTekster.banner_læremidler}
-                skjemaId={skjematypeTilSkjemaId[Skjematype.LÆREMIDLER]}
+                skjemaId={skjematypeTilSkjemaId[Skjematype.SØKNAD_LÆREMIDLER]}
             />
             <Routes>
                 <Route path={'/'} element={<RootRoute forside={<Forside />} />} />

--- a/src/frontend/reiseTilSamling/Forside.tsx
+++ b/src/frontend/reiseTilSamling/Forside.tsx
@@ -36,7 +36,7 @@ export const Forside: React.FC = () => {
 
     useEffect(() => {
         const route = routesReiseTilSamling[0];
-        loggBesøk(Skjematype.REISE_TIL_SAMLING, route.path, route.label);
+        loggBesøk(Skjematype.SØKNAD_REISE_TIL_SAMLING, route.path, route.label);
     }, []);
 
     const startSøknad = () => {
@@ -45,7 +45,7 @@ export const Forside: React.FC = () => {
             return;
         }
 
-        loggSkjemaStartet(Skjematype.REISE_TIL_SAMLING);
+        loggSkjemaStartet(Skjematype.SØKNAD_REISE_TIL_SAMLING);
         const nesteRoute = hentNesteRoute(routesReiseTilSamling, location.pathname);
         navigate(nesteRoute.path);
     };

--- a/src/frontend/reiseTilSamling/ReiseTilSamlingApp.tsx
+++ b/src/frontend/reiseTilSamling/ReiseTilSamlingApp.tsx
@@ -28,7 +28,7 @@ const ReiseTilSamlingInnhold = () => {
 
     return (
         <SøknadProvider
-            skjematype={Skjematype.REISE_TIL_SAMLING}
+            skjematype={Skjematype.SØKNAD_REISE_TIL_SAMLING}
             søknad={{
                 hovedytelse: hovedytelse,
                 aktivitet: aktivitet,
@@ -52,14 +52,14 @@ export const ReiseTilSamlingApp = () => {
     const { locale } = useSpråk();
 
     useEffect(() => {
-        document.title = teksterStønad.tittelHtml[Skjematype.REISE_TIL_SAMLING][locale];
+        document.title = teksterStønad.tittelHtml[Skjematype.SØKNAD_REISE_TIL_SAMLING][locale];
     }, [locale]);
 
     return (
-        <PersonRouting skjematype={Skjematype.REISE_TIL_SAMLING}>
+        <PersonRouting skjematype={Skjematype.SØKNAD_REISE_TIL_SAMLING}>
             <ValideringsfeilProvider>
                 <ReiseTilSamlingSøknadProvider>
-                    <RegisterAktiviteterProvider skjematype={Skjematype.REISE_TIL_SAMLING}>
+                    <RegisterAktiviteterProvider skjematype={Skjematype.SØKNAD_REISE_TIL_SAMLING}>
                         <ReiseTilSamlingInnhold />
                     </RegisterAktiviteterProvider>
                 </ReiseTilSamlingSøknadProvider>

--- a/src/frontend/reiseTilSamling/Søknadsdialog.tsx
+++ b/src/frontend/reiseTilSamling/Søknadsdialog.tsx
@@ -24,7 +24,7 @@ export const Søknadsdialog: React.FC = () => {
         <>
             <SøknadsskjemaHeader
                 tittel={forsideTekster.banner_tittel}
-                skjemaId={skjematypeTilSkjemaId[Skjematype.REISE_TIL_SAMLING]}
+                skjemaId={skjematypeTilSkjemaId[Skjematype.SØKNAD_REISE_TIL_SAMLING]}
             />
             <Routes>
                 <Route path={'/'} element={<Forside />} />

--- a/src/frontend/tekster/harEksisterendeBehandling.ts
+++ b/src/frontend/tekster/harEksisterendeBehandling.ts
@@ -32,13 +32,13 @@ export const harEksisterendeBehandlingTekster: HarEksistendeBehandlingInnhold = 
         nb: 'Vil du likevel sende ny søknad?',
     },
     vil_forstatt_sende_søknad_innhold: {
-        [Skjematype.BARNETILSYN]: {
+        [Skjematype.SØKNAD_BARNETILSYN]: {
             nb: 'Hvis du har begynt på nytt tiltak, ny utdanning eller det er et nytt skole/barnehageår kan du sende ny søknad.',
         },
-        [Skjematype.LÆREMIDLER]: {
+        [Skjematype.SØKNAD_LÆREMIDLER]: {
             nb: 'Hvis du har begynt på en ny utdanning eller opplæring, eller det gjelder et nytt skoleår, kan du sende ny søknad.',
         },
-        [Skjematype.REISE_TIL_SAMLING]: {
+        [Skjematype.SØKNAD_REISE_TIL_SAMLING]: {
             nb: 'Hvis du har deltatt på en ny samling, kan du sende ny søknad.',
         },
     },

--- a/src/frontend/tekster/stønad.ts
+++ b/src/frontend/tekster/stønad.ts
@@ -7,13 +7,13 @@ interface StønadInnhold {
 
 export const teksterStønad: StønadInnhold = {
     tittelHtml: {
-        BARNETILSYN: {
+        SØKNAD_BARNETILSYN: {
             nb: 'Søknad om støtte til pass av barn',
         },
-        LÆREMIDLER: {
+        SØKNAD_LÆREMIDLER: {
             nb: 'Søknad om støtte til læremidler',
         },
-        REISE_TIL_SAMLING: {
+        SØKNAD_REISE_TIL_SAMLING: {
             nb: 'Søknad om støtte til reise til samling',
         },
     },

--- a/src/frontend/typer/skjemanavn.ts
+++ b/src/frontend/typer/skjemanavn.ts
@@ -1,13 +1,13 @@
 import { Skjematype } from './skjematyper';
 
 export const skjematypeTilSkjemaId: Record<Skjematype, string> = {
-    [Skjematype.BARNETILSYN]: 'NAV 11-12.15',
-    [Skjematype.LÆREMIDLER]: 'NAV 11-12.16',
-    [Skjematype.REISE_TIL_SAMLING]: 'NAV 11-12.17',
+    [Skjematype.SØKNAD_BARNETILSYN]: 'NAV 11-12.15',
+    [Skjematype.SØKNAD_LÆREMIDLER]: 'NAV 11-12.16',
+    [Skjematype.SØKNAD_REISE_TIL_SAMLING]: 'NAV 11-12.17',
 };
 
 export const skjematypeTilSkjemanavn: Record<Skjematype, string> = {
-    [Skjematype.BARNETILSYN]: 'Pass av barn',
-    [Skjematype.LÆREMIDLER]: 'Læremidler',
-    [Skjematype.REISE_TIL_SAMLING]: 'Reise til samling',
+    [Skjematype.SØKNAD_BARNETILSYN]: 'Pass av barn',
+    [Skjematype.SØKNAD_LÆREMIDLER]: 'Læremidler',
+    [Skjematype.SØKNAD_REISE_TIL_SAMLING]: 'Reise til samling',
 };

--- a/src/frontend/typer/skjematyper.ts
+++ b/src/frontend/typer/skjematyper.ts
@@ -1,6 +1,6 @@
 // Gjelder de skjematypene som håndteres av vår søknad-app (altså ikke videresendes til Fyll ut-søknaden)
 export enum Skjematype {
-    BARNETILSYN = 'BARNETILSYN',
-    LÆREMIDLER = 'LÆREMIDLER',
-    REISE_TIL_SAMLING = 'REISE_TIL_SAMLING',
+    SØKNAD_BARNETILSYN = 'SØKNAD_BARNETILSYN',
+    SØKNAD_LÆREMIDLER = 'SØKNAD_LÆREMIDLER',
+    SØKNAD_REISE_TIL_SAMLING = 'SØKNAD_REISE_TIL_SAMLING',
 }

--- a/src/frontend/utils/routeUtils.ts
+++ b/src/frontend/utils/routeUtils.ts
@@ -21,11 +21,11 @@ import { Skjematype } from '../typer/skjematyper';
 
 export const hentRoutes = (skjematype: Skjematype): IRoute[] => {
     switch (skjematype) {
-        case Skjematype.BARNETILSYN:
+        case Skjematype.SØKNAD_BARNETILSYN:
             return RoutesBarnetilsyn;
-        case Skjematype.LÆREMIDLER:
+        case Skjematype.SØKNAD_LÆREMIDLER:
             return routesLæremidler;
-        case Skjematype.REISE_TIL_SAMLING:
+        case Skjematype.SØKNAD_REISE_TIL_SAMLING:
             return routesReiseTilSamling;
     }
 };
@@ -42,11 +42,11 @@ export const hentForrigeRoute = (routes: IRoute[], nåværendePath: string) => {
 
 export const hentStartRoute = (skjematype: Skjematype) => {
     switch (skjematype) {
-        case Skjematype.BARNETILSYN:
+        case Skjematype.SØKNAD_BARNETILSYN:
             return barnetilsynPath;
-        case Skjematype.LÆREMIDLER:
+        case Skjematype.SØKNAD_LÆREMIDLER:
             return læremidlerPath;
-        case Skjematype.REISE_TIL_SAMLING:
+        case Skjematype.SØKNAD_REISE_TIL_SAMLING:
             return reiseTilSamlingPath;
     }
 };
@@ -61,11 +61,11 @@ export const erOppsummeringsside = (route: RouteType): boolean => {
 
 export const finnOppsummeringRoute = (skjematype: Skjematype): string => {
     switch (skjematype) {
-        case Skjematype.BARNETILSYN:
+        case Skjematype.SØKNAD_BARNETILSYN:
             return RouteToPathPassAvBarn.OPPSUMMERING;
-        case Skjematype.LÆREMIDLER:
+        case Skjematype.SØKNAD_LÆREMIDLER:
             return RouteToPathLæremidler.OPPSUMMERING;
-        case Skjematype.REISE_TIL_SAMLING:
+        case Skjematype.SØKNAD_REISE_TIL_SAMLING:
             return RouteToPathReiseTilSamling.OPPSUMMERING;
     }
 };

--- a/tests/mocks/harSøknadFraFør.ts
+++ b/tests/mocks/harSøknadFraFør.ts
@@ -1,31 +1,46 @@
 import { Page } from '@playwright/test';
 
 export const mockHarSøknadTilsynBarnFraFør = async (page: Page) => {
-    await page.route('api/person/har-behandling?stonadstype=BARNETILSYN', async (route) => {
-        await route.fulfill({ json: true });
-    });
+    await page.route(
+        'api/person/har-behandling?skjematype=S%C3%98KNAD_BARNETILSYN',
+        async (route) => {
+            await route.fulfill({ json: true });
+        }
+    );
 };
 
 export const mockHarIngenSøknadTilsynBarnFraFør = async (page: Page) => {
-    await page.route('api/person/har-behandling?stonadstype=BARNETILSYN', async (route) => {
-        await route.fulfill({ json: false });
-    });
+    await page.route(
+        'api/person/har-behandling?skjematype=S%C3%98KNAD_BARNETILSYN',
+        async (route) => {
+            await route.fulfill({ json: false });
+        }
+    );
 };
 
 export const mockHarSøknadLæremidlerFraFør = async (page: Page) => {
-    await page.route('api/person/har-behandling?stonadstype=L%C3%86REMIDLER', async (route) => {
-        await route.fulfill({ json: true });
-    });
+    await page.route(
+        'api/person/har-behandling?skjematype=S%C3%98KNAD_L%C3%86REMIDLER',
+        async (route) => {
+            await route.fulfill({ json: true });
+        }
+    );
 };
 
 export const mockHarIngenSøknadLæremidlerFraFør = async (page: Page) => {
-    await page.route('api/person/har-behandling?stonadstype=L%C3%86REMIDLER', async (route) => {
-        await route.fulfill({ json: false });
-    });
+    await page.route(
+        'api/person/har-behandling?skjematype=S%C3%98KNAD_L%C3%86REMIDLER',
+        async (route) => {
+            await route.fulfill({ json: false });
+        }
+    );
 };
 
 export const mockHarIngenSøknadReiseTilSamlingFraFør = async (page: Page) => {
-    await page.route('api/person/har-behandling?stonadstype=REISE_TIL_SAMLING', async (route) => {
-        await route.fulfill({ json: false });
-    });
+    await page.route(
+        'api/person/har-behandling?skjematype=S%C3%98KNAD_REISE_TIL_SAMLING',
+        async (route) => {
+            await route.fulfill({ json: false });
+        }
+    );
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

I søknaden har vi ikke noe kontekst om stønadstype (TSO vs TSR osv). Vi vet bare hvilket skjema vi er inne på. 

API-ene har blitt tilpasset til å ta i mot både skjematype og stønadstype, og sistnevnte skal fjernes. 