### PR TITLE
✨ Legg inn støtte for å reise fra andre adresser enn den folkeregistrerte

### DIFF
--- a/src/frontend/components/Landvelger/Landvelger.tsx
+++ b/src/frontend/components/Landvelger/Landvelger.tsx
@@ -1,25 +1,12 @@
 import React, { useEffect, useMemo } from 'react';
 
-import countries from 'i18n-iso-countries';
-import codesData from 'i18n-iso-countries/codes.json';
-import nbLocale from 'i18n-iso-countries/langs/nb.json';
-
 import { UNSAFE_Combobox } from '@navikt/ds-react';
 
 import { useSpråk } from '../../context/SpråkContext';
 import { fellesTekster } from '../../tekster/felles';
 import { SelectFelt } from '../../typer/skjema';
 import { TekstElement } from '../../typer/tekst';
-
-countries.registerLocale(nbLocale);
-
-// Webpack fjerner innholdet i codes.json fra i18n-iso-countries når den bygger,
-// noe som gjør at alpha2ToAlpha3 returnerer undefined. Her importerer og bygger vi mappingen direkte
-// for å sikre at dataene er inkludert i bundlen.
-const alpha2ToAlpha3Map: Record<string, string> = {};
-codesData.forEach(([alpha2, alpha3]) => {
-    alpha2ToAlpha3Map[alpha2] = alpha3;
-});
+import { landkodeTilNavn } from '../../utils/adresseUtils';
 
 interface Props {
     id?: string;
@@ -31,22 +18,8 @@ interface Props {
     defaultNorge?: boolean;
 }
 
-/**
- * NOR = Norge
- * SJM = Svalbard og Jan Mayen
- */
 const utenNorskeOmråder = (country: [string, string]): boolean =>
     country[0] !== 'NOR' && country[0] !== 'SJM';
-
-const landkodeTilNavn = Object.entries(countries.getNames('nb', { select: 'official' }))
-    .map((country) => [alpha2ToAlpha3Map[country[0]], country[1]] as [string, string])
-    .reduce(
-        (prev, curr) => {
-            prev[curr[0]] = curr[1];
-            return prev;
-        },
-        {} as { [key: string]: string }
-    );
 
 const sorterteLand = Object.entries(landkodeTilNavn).sort(
     (a, b) => (a[1] > b[1] ? 1 : -1) // Sorterer alfabetisk på navn i stedet for landkode

--- a/src/frontend/context/ReiseTilSamlingSøknadContext.tsx
+++ b/src/frontend/context/ReiseTilSamlingSøknadContext.tsx
@@ -10,6 +10,7 @@ import {
 import {
     Aktivitet,
     Aktivitetsadresse,
+    Avreiseadresse,
     Hovedytelse,
     Reiseavstand,
     Reisemåte,
@@ -56,6 +57,13 @@ const [ReiseTilSamlingSøknadProvider, useReiseTilSamlingSøknad] = createUseCon
         }));
     };
 
+    const settAdresseDuSkalReiseFra = (oppdatering: Partial<Avreiseadresse>) => {
+        settReiseavstand((prev) => ({
+            ...prev,
+            adresseDuSkalReiseFra: { ...prev.adresseDuSkalReiseFra, ...oppdatering },
+        }));
+    };
+
     return {
         harBekreftet,
         settHarBekreftet,
@@ -68,6 +76,7 @@ const [ReiseTilSamlingSøknadProvider, useReiseTilSamlingSøknad] = createUseCon
         reiseavstand,
         settReiseavstand,
         settAktivitetsadresse,
+        settAdresseDuSkalReiseFra,
         reisemåte,
         settReisemåte,
         dokumentasjonsbehov,

--- a/src/frontend/mock/initiellPerson.ts
+++ b/src/frontend/mock/initiellPerson.ts
@@ -7,7 +7,7 @@ export const initiellPerson: Person = {
     adresse: '',
     strukturertAdresse: {
         land: 'NOR',
-        adressenavn: '',
+        gateadresse: '',
         postnummer: '',
         poststed: '',
     },

--- a/src/frontend/mock/initiellPerson.ts
+++ b/src/frontend/mock/initiellPerson.ts
@@ -5,5 +5,11 @@ export const initiellPerson: Person = {
     visningsnavn: '',
     alder: 0,
     adresse: '',
+    strukturertAdresse: {
+        land: 'NOR',
+        adressenavn: '',
+        postnummer: '',
+        poststed: '',
+    },
     barn: [],
 };

--- a/src/frontend/reiseTilSamling/steg/3-reiseavstand/ReiseavstandReiseTilSamling.tsx
+++ b/src/frontend/reiseTilSamling/steg/3-reiseavstand/ReiseavstandReiseTilSamling.tsx
@@ -96,6 +96,7 @@ export const ReiseavstandReiseTilSamling = () => {
                             href={reiseavstandTekster.avreiseadresse_fra_folkereg_lenke_url}
                             target="_blank"
                             inlineText
+                            rel="noopener noreferrer"
                         >
                             {reiseavstandTekster.avreiseadresse_fra_folkereg_lenke_tekst[locale]}
                         </Link>

--- a/src/frontend/reiseTilSamling/steg/3-reiseavstand/ReiseavstandReiseTilSamling.tsx
+++ b/src/frontend/reiseTilSamling/steg/3-reiseavstand/ReiseavstandReiseTilSamling.tsx
@@ -2,23 +2,33 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { BodyShort, Link, TextField, VStack } from '@navikt/ds-react';
+import { BodyShort, InlineMessage, Link, TextField, VStack } from '@navikt/ds-react';
 import { BgSunken } from '@navikt/ds-tokens/js';
 
 import {
     errorKeyAntallKm,
+    errorKeyAvreiseGateadresse,
+    errorKeyAvreiseLand,
+    errorKeyAvreisePostnummer,
+    errorKeyAvreisePoststed,
     errorKeyGateadresse,
     errorKeyLand,
     errorKeyPostnummer,
     errorKeyPoststed,
+    errorKeySkalReiseFraFolkeregAdr,
     validerReiseavstand,
 } from './validering';
 import { Landvelger } from '../../../components/Landvelger/Landvelger';
 import { Side } from '../../../components/Side';
 import { LocaleHeading } from '../../../components/Teksthåndtering/LocaleHeading';
+import { LocaleRadioGroup } from '../../../components/Teksthåndtering/LocaleRadioGroup';
+import { LocaleTekst } from '../../../components/Teksthåndtering/LocaleTekst';
+import { usePerson } from '../../../context/PersonContext';
 import { useReiseTilSamlingSøknad } from '../../../context/ReiseTilSamlingSøknadContext';
 import { useSpråk } from '../../../context/SpråkContext';
 import { useValideringsfeil } from '../../../context/ValideringsfeilContext';
+import { EnumFelt } from '../../../typer/skjema';
+import { JaNei } from '../../../typer/søknad';
 import { inneholderFeil } from '../../../typer/validering';
 import { reiseavstandTekster } from '../../tekster/reiseavstand';
 
@@ -40,7 +50,9 @@ const KmFelt = styled(TextField)`
 
 export const ReiseavstandReiseTilSamling = () => {
     const { locale } = useSpråk();
-    const { reiseavstand, settReiseavstand, settAktivitetsadresse } = useReiseTilSamlingSøknad();
+    const { person } = usePerson();
+    const { reiseavstand, settReiseavstand, settAktivitetsadresse, settAdresseDuSkalReiseFra } =
+        useReiseTilSamlingSøknad();
     const { valideringsfeil, settValideringsfeil } = useValideringsfeil();
 
     const nullstillFeil = (verdi: string | undefined, errorKey: string) => {
@@ -55,11 +67,135 @@ export const ReiseavstandReiseTilSamling = () => {
         return !inneholderFeil(feil);
     };
 
+    const oppdaterSkalReiseFraFolkeregAdr = (verdi: EnumFelt<JaNei>) => {
+        settReiseavstand((prev) => ({
+            ...prev,
+            skalReiseFraFolkeregAdr: verdi,
+            adresseDuSkalReiseFra: verdi.verdi === 'JA' ? undefined : prev.adresseDuSkalReiseFra,
+        }));
+        settValideringsfeil((prev) => ({ ...prev, [errorKeySkalReiseFraFolkeregAdr]: undefined }));
+    };
+
+    const skalReiseFraFolkeregAdr = reiseavstand.skalReiseFraFolkeregAdr?.verdi;
+
     return (
         <Side validerSteg={kanFortsette}>
             <LocaleHeading tekst={reiseavstandTekster.tittel} level="2" size="medium" />
             <VStack gap="space-4">
                 <BodyShort spacing>{reiseavstandTekster.info_minsteavstand[locale]}</BodyShort>
+                <BodyShort spacing>
+                    <LocaleTekst
+                        tekst={reiseavstandTekster.folkereg_adresse}
+                        argument0={person.adresse}
+                    />
+                </BodyShort>
+                <InlineMessage status="info">
+                    <BodyShort spacing>
+                        {reiseavstandTekster.avreiseadresse_fra_folkereg_info[locale]}
+                        <Link
+                            href={reiseavstandTekster.avreiseadresse_fra_folkereg_lenke_url}
+                            target="_blank"
+                            inlineText
+                        >
+                            {reiseavstandTekster.avreiseadresse_fra_folkereg_lenke_tekst[locale]}
+                        </Link>
+                        .
+                    </BodyShort>
+                </InlineMessage>
+                <LocaleRadioGroup
+                    id={valideringsfeil[errorKeySkalReiseFraFolkeregAdr]?.id}
+                    tekst={reiseavstandTekster.radio_skalReiseFraFolkeregAdr}
+                    value={reiseavstand.skalReiseFraFolkeregAdr?.verdi ?? ''}
+                    onChange={oppdaterSkalReiseFraFolkeregAdr}
+                    error={valideringsfeil[errorKeySkalReiseFraFolkeregAdr]?.melding}
+                />
+                {skalReiseFraFolkeregAdr === 'NEI' && (
+                    <VStack gap="space-4" style={{ marginBottom: 'var(--a-spacing-2)' }}>
+                        <BodyShort weight="semibold">
+                            {reiseavstandTekster.avreiseadresse_tittel[locale]}
+                        </BodyShort>
+                        <AdresseBoks>
+                            <VStack gap="space-16">
+                                <Landvelger
+                                    id={valideringsfeil[errorKeyAvreiseLand]?.id}
+                                    label={reiseavstandTekster.velg_land_label}
+                                    value={reiseavstand.adresseDuSkalReiseFra?.land?.verdi}
+                                    onChange={(verdi) => {
+                                        settAdresseDuSkalReiseFra({ land: verdi });
+                                        nullstillFeil(verdi.verdi, errorKeyAvreiseLand);
+                                    }}
+                                    medNorskeOmråder={true}
+                                    error={valideringsfeil[errorKeyAvreiseLand]?.melding}
+                                    defaultNorge
+                                />
+                                <TextField
+                                    id={valideringsfeil[errorKeyAvreiseGateadresse]?.id}
+                                    label={
+                                        reiseavstandTekster.avreiseadresse_vegadresse_label[locale]
+                                    }
+                                    value={
+                                        reiseavstand.adresseDuSkalReiseFra?.gateadresse?.verdi ?? ''
+                                    }
+                                    error={valideringsfeil[errorKeyAvreiseGateadresse]?.melding}
+                                    onChange={(e) => {
+                                        const verdi = e.target.value;
+                                        settAdresseDuSkalReiseFra({
+                                            gateadresse: {
+                                                label: reiseavstandTekster
+                                                    .avreiseadresse_vegadresse_label[locale],
+                                                verdi,
+                                            },
+                                        });
+                                        nullstillFeil(verdi, errorKeyAvreiseGateadresse);
+                                    }}
+                                />
+                                <PostnummerFelt
+                                    id={valideringsfeil[errorKeyAvreisePostnummer]?.id}
+                                    label={
+                                        reiseavstandTekster.avreiseadresse_postnummer_label[locale]
+                                    }
+                                    value={
+                                        reiseavstand.adresseDuSkalReiseFra?.postnummer?.verdi ?? ''
+                                    }
+                                    error={valideringsfeil[errorKeyAvreisePostnummer]?.melding}
+                                    inputMode="numeric"
+                                    onChange={(e) => {
+                                        const verdi = e.target.value;
+                                        settAdresseDuSkalReiseFra({
+                                            postnummer: {
+                                                label: reiseavstandTekster
+                                                    .avreiseadresse_postnummer_label[locale],
+                                                verdi,
+                                            },
+                                        });
+                                        nullstillFeil(verdi, errorKeyAvreisePostnummer);
+                                    }}
+                                />
+                                <TextField
+                                    id={valideringsfeil[errorKeyAvreisePoststed]?.id}
+                                    label={
+                                        reiseavstandTekster.avreiseadresse_poststed_label[locale]
+                                    }
+                                    value={
+                                        reiseavstand.adresseDuSkalReiseFra?.poststed?.verdi ?? ''
+                                    }
+                                    error={valideringsfeil[errorKeyAvreisePoststed]?.melding}
+                                    onChange={(e) => {
+                                        const verdi = e.target.value;
+                                        settAdresseDuSkalReiseFra({
+                                            poststed: {
+                                                label: reiseavstandTekster
+                                                    .avreiseadresse_poststed_label[locale],
+                                                verdi,
+                                            },
+                                        });
+                                        nullstillFeil(verdi, errorKeyAvreisePoststed);
+                                    }}
+                                />
+                            </VStack>
+                        </AdresseBoks>
+                    </VStack>
+                )}
                 <KmFelt
                     id={valideringsfeil[errorKeyAntallKm]?.id}
                     label={reiseavstandTekster.antall_km_label[locale]}
@@ -80,22 +216,11 @@ export const ReiseavstandReiseTilSamling = () => {
                     }}
                 />
             </VStack>
-            <BodyShort>
-                {reiseavstandTekster.folkeregistrert_adresse_info[locale]}
-                <Link
-                    href={reiseavstandTekster.folkeregistrert_adresse_lenke_url}
-                    target="_blank"
-                    inlineText
-                >
-                    {reiseavstandTekster.folkeregistrert_adresse_lenke_tekst[locale]}
-                </Link>
-                .
-            </BodyShort>
             <VStack gap="space-4">
                 <BodyShort weight="semibold">
                     {reiseavstandTekster.aktivitetsadresse_tittel[locale]}
                 </BodyShort>
-                <AdresseBoks>
+                <AdresseBoks style={{ paddingBottom: '2rem' }}>
                     <VStack gap="space-16">
                         <Landvelger
                             id={valideringsfeil[errorKeyLand]?.id}

--- a/src/frontend/reiseTilSamling/steg/3-reiseavstand/validering.ts
+++ b/src/frontend/reiseTilSamling/steg/3-reiseavstand/validering.ts
@@ -4,6 +4,11 @@ import { Valideringsfeil } from '../../../typer/validering';
 import { harVerdi } from '../../../utils/typeUtils';
 import { reiseavstandTekster } from '../../tekster/reiseavstand';
 
+export const errorKeySkalReiseFraFolkeregAdr = 'reiseavstand_skalReiseFraFolkeregAdr';
+export const errorKeyAvreiseLand = 'reiseavstand_avreise_land';
+export const errorKeyAvreiseGateadresse = 'reiseavstand_avreise_gateadresse';
+export const errorKeyAvreisePostnummer = 'reiseavstand_avreise_postnummer';
+export const errorKeyAvreisePoststed = 'reiseavstand_avreise_poststed';
 export const errorKeyAntallKm = 'reiseavstand_antall_km';
 export const errorKeyLand = 'reiseavstand_land';
 export const errorKeyGateadresse = 'reiseavstand_gateadresse';
@@ -15,6 +20,53 @@ export const validerReiseavstand = (
     locale: Locale
 ): Valideringsfeil => {
     let feil: Valideringsfeil = {};
+
+    if (!harVerdi(reiseavstand.skalReiseFraFolkeregAdr?.verdi)) {
+        feil = {
+            ...feil,
+            [errorKeySkalReiseFraFolkeregAdr]: {
+                id: errorKeySkalReiseFraFolkeregAdr,
+                melding: reiseavstandTekster.feilmelding_skalReiseFraFolkeregAdr[locale],
+            },
+        };
+    } else if (reiseavstand.skalReiseFraFolkeregAdr?.verdi === 'NEI') {
+        if (!harVerdi(reiseavstand.adresseDuSkalReiseFra?.land?.verdi)) {
+            feil = {
+                ...feil,
+                [errorKeyAvreiseLand]: {
+                    id: errorKeyAvreiseLand,
+                    melding: reiseavstandTekster.feilmelding_avreise_land[locale],
+                },
+            };
+        }
+        if (!harVerdi(reiseavstand.adresseDuSkalReiseFra?.gateadresse?.verdi)) {
+            feil = {
+                ...feil,
+                [errorKeyAvreiseGateadresse]: {
+                    id: errorKeyAvreiseGateadresse,
+                    melding: reiseavstandTekster.feilmelding_avreise_gateadresse[locale],
+                },
+            };
+        }
+        if (!harVerdi(reiseavstand.adresseDuSkalReiseFra?.postnummer?.verdi)) {
+            feil = {
+                ...feil,
+                [errorKeyAvreisePostnummer]: {
+                    id: errorKeyAvreisePostnummer,
+                    melding: reiseavstandTekster.feilmelding_avreise_postnummer[locale],
+                },
+            };
+        }
+        if (!harVerdi(reiseavstand.adresseDuSkalReiseFra?.poststed?.verdi)) {
+            feil = {
+                ...feil,
+                [errorKeyAvreisePoststed]: {
+                    id: errorKeyAvreisePoststed,
+                    melding: reiseavstandTekster.feilmelding_avreise_poststed[locale],
+                },
+            };
+        }
+    }
 
     const km = reiseavstand.antallKilometerEnVei?.verdi;
     if (!harVerdi(km)) {

--- a/src/frontend/reiseTilSamling/steg/7-oppsummering/ReiseavstandOppsummering.tsx
+++ b/src/frontend/reiseTilSamling/steg/7-oppsummering/ReiseavstandOppsummering.tsx
@@ -6,6 +6,7 @@ import { FormSummaryFooterMedEndreKnapp } from '../../../components/Oppsummering
 import { LocaleTekst } from '../../../components/Teksthåndtering/LocaleTekst';
 import { usePerson } from '../../../context/PersonContext';
 import { Reiseavstand } from '../../../typer/søknad';
+import { adressefelterTilVisning } from '../../../utils/adresseUtils';
 import { RouteTilPath } from '../../routing/routesReiseTilSamling';
 import { oppsummeringTekster } from '../../tekster/oppsummering';
 
@@ -14,40 +15,27 @@ export const ReiseavstandOppsummering: React.FC<{ reiseavstand: Reiseavstand }> 
 }) => {
     const { person } = usePerson();
 
-    const avreiseAdresseVisning =
-        reiseavstand.skalReiseFraFolkeregAdr?.verdi === 'JA' && person.strukturertAdresse
-            ? [
-                  person.strukturertAdresse.adressenavn,
-                  [person.strukturertAdresse.postnummer, person.strukturertAdresse.poststed]
-                      .filter(Boolean)
-                      .join(' '),
-              ]
-                  .filter(Boolean)
-                  .join(', ')
-            : [
-                  reiseavstand.adresseDuSkalReiseFra?.gateadresse?.verdi,
-                  [
-                      reiseavstand.adresseDuSkalReiseFra?.postnummer?.verdi,
-                      reiseavstand.adresseDuSkalReiseFra?.poststed?.verdi,
-                  ]
-                      .filter(Boolean)
-                      .join(' '),
-              ]
-                  .filter(Boolean)
-                  .join(', ');
+    const avreiseAdresseVisning = () => {
+        if (reiseavstand.skalReiseFraFolkeregAdr?.verdi === 'JA') {
+            return person.strukturertAdresse
+                ? adressefelterTilVisning(person.strukturertAdresse)
+                : person.adresse;
+        }
 
-    const aktivitetsAdresseVisning = [
-        reiseavstand.aktivitetsadresse.gateadresse?.verdi,
-        [
-            reiseavstand.aktivitetsadresse.postnummer?.verdi,
-            reiseavstand.aktivitetsadresse.poststed?.verdi,
-        ]
-            .filter((del) => !!del)
-            .join(' '),
-        reiseavstand.aktivitetsadresse.land?.svarTekst,
-    ]
-        .filter((del) => !!del)
-        .join(', ');
+        return adressefelterTilVisning({
+            gateadresse: reiseavstand.adresseDuSkalReiseFra?.gateadresse?.verdi,
+            postnummer: reiseavstand.adresseDuSkalReiseFra?.postnummer?.verdi,
+            poststed: reiseavstand.adresseDuSkalReiseFra?.poststed?.verdi,
+            land: reiseavstand.adresseDuSkalReiseFra?.land?.verdi,
+        });
+    };
+
+    const aktivitetsAdresseVisning = adressefelterTilVisning({
+        gateadresse: reiseavstand.aktivitetsadresse.gateadresse?.verdi,
+        postnummer: reiseavstand.aktivitetsadresse.postnummer?.verdi,
+        poststed: reiseavstand.aktivitetsadresse.poststed?.verdi,
+        land: reiseavstand.aktivitetsadresse.land?.verdi,
+    });
 
     return (
         <FormSummary>
@@ -62,7 +50,7 @@ export const ReiseavstandOppsummering: React.FC<{ reiseavstand: Reiseavstand }> 
                         <FormSummary.Label>
                             <LocaleTekst tekst={oppsummeringTekster.adressen_du_skal_reise_fra} />
                         </FormSummary.Label>
-                        <FormSummary.Value>{avreiseAdresseVisning}</FormSummary.Value>
+                        <FormSummary.Value>{avreiseAdresseVisning()}</FormSummary.Value>
                     </FormSummary.Answer>
                 )}
                 {reiseavstand.antallKilometerEnVei && (

--- a/src/frontend/reiseTilSamling/steg/7-oppsummering/ReiseavstandOppsummering.tsx
+++ b/src/frontend/reiseTilSamling/steg/7-oppsummering/ReiseavstandOppsummering.tsx
@@ -45,7 +45,7 @@ export const ReiseavstandOppsummering: React.FC<{ reiseavstand: Reiseavstand }> 
                 </FormSummary.Heading>
             </FormSummary.Header>
             <FormSummary.Answers>
-                {avreiseAdresseVisning && (
+                {avreiseAdresseVisning() !== '' && (
                     <FormSummary.Answer>
                         <FormSummary.Label>
                             <LocaleTekst tekst={oppsummeringTekster.adressen_du_skal_reise_fra} />
@@ -63,7 +63,7 @@ export const ReiseavstandOppsummering: React.FC<{ reiseavstand: Reiseavstand }> 
                         </FormSummary.Value>
                     </FormSummary.Answer>
                 )}
-                {aktivitetsAdresseVisning && (
+                {aktivitetsAdresseVisning !== '' && (
                     <FormSummary.Answer>
                         <FormSummary.Label>
                             <LocaleTekst tekst={oppsummeringTekster.adressen_du_skal_reise_til} />

--- a/src/frontend/reiseTilSamling/steg/7-oppsummering/ReiseavstandOppsummering.tsx
+++ b/src/frontend/reiseTilSamling/steg/7-oppsummering/ReiseavstandOppsummering.tsx
@@ -4,6 +4,7 @@ import { FormSummary } from '@navikt/ds-react';
 
 import { FormSummaryFooterMedEndreKnapp } from '../../../components/Oppsummering/FormSummaryFooterMedEndreKnapp';
 import { LocaleTekst } from '../../../components/Teksthåndtering/LocaleTekst';
+import { usePerson } from '../../../context/PersonContext';
 import { Reiseavstand } from '../../../typer/søknad';
 import { RouteTilPath } from '../../routing/routesReiseTilSamling';
 import { oppsummeringTekster } from '../../tekster/oppsummering';
@@ -11,7 +12,31 @@ import { oppsummeringTekster } from '../../tekster/oppsummering';
 export const ReiseavstandOppsummering: React.FC<{ reiseavstand: Reiseavstand }> = ({
     reiseavstand,
 }) => {
-    const adresse = [
+    const { person } = usePerson();
+
+    const avreiseAdresseVisning =
+        reiseavstand.skalReiseFraFolkeregAdr?.verdi === 'JA' && person.strukturertAdresse
+            ? [
+                  person.strukturertAdresse.adressenavn,
+                  [person.strukturertAdresse.postnummer, person.strukturertAdresse.poststed]
+                      .filter(Boolean)
+                      .join(' '),
+              ]
+                  .filter(Boolean)
+                  .join(', ')
+            : [
+                  reiseavstand.adresseDuSkalReiseFra?.gateadresse?.verdi,
+                  [
+                      reiseavstand.adresseDuSkalReiseFra?.postnummer?.verdi,
+                      reiseavstand.adresseDuSkalReiseFra?.poststed?.verdi,
+                  ]
+                      .filter(Boolean)
+                      .join(' '),
+              ]
+                  .filter(Boolean)
+                  .join(', ');
+
+    const aktivitetsAdresseVisning = [
         reiseavstand.aktivitetsadresse.gateadresse?.verdi,
         [
             reiseavstand.aktivitetsadresse.postnummer?.verdi,
@@ -32,6 +57,14 @@ export const ReiseavstandOppsummering: React.FC<{ reiseavstand: Reiseavstand }> 
                 </FormSummary.Heading>
             </FormSummary.Header>
             <FormSummary.Answers>
+                {avreiseAdresseVisning && (
+                    <FormSummary.Answer>
+                        <FormSummary.Label>
+                            <LocaleTekst tekst={oppsummeringTekster.adressen_du_skal_reise_fra} />
+                        </FormSummary.Label>
+                        <FormSummary.Value>{avreiseAdresseVisning}</FormSummary.Value>
+                    </FormSummary.Answer>
+                )}
                 {reiseavstand.antallKilometerEnVei && (
                     <FormSummary.Answer>
                         <FormSummary.Label>
@@ -42,12 +75,12 @@ export const ReiseavstandOppsummering: React.FC<{ reiseavstand: Reiseavstand }> 
                         </FormSummary.Value>
                     </FormSummary.Answer>
                 )}
-                {adresse && (
+                {aktivitetsAdresseVisning && (
                     <FormSummary.Answer>
                         <FormSummary.Label>
                             <LocaleTekst tekst={oppsummeringTekster.adressen_du_skal_reise_til} />
                         </FormSummary.Label>
-                        <FormSummary.Value>{adresse}</FormSummary.Value>
+                        <FormSummary.Value>{aktivitetsAdresseVisning}</FormSummary.Value>
                     </FormSummary.Answer>
                 )}
             </FormSummary.Answers>

--- a/src/frontend/reiseTilSamling/tekster/oppsummering.ts
+++ b/src/frontend/reiseTilSamling/tekster/oppsummering.ts
@@ -3,6 +3,7 @@ import { TekstElement } from '../../typer/tekst';
 interface OppsummeringInnhold {
     tittel: TekstElement<string>;
     reiseavstand_tittel: TekstElement<string>;
+    adressen_du_skal_reise_fra: TekstElement<string>;
     adressen_du_skal_reise_til: TekstElement<string>;
     samlinger_tittel: TekstElement<string>;
     reisemåte_tittel: TekstElement<string>;
@@ -11,6 +12,7 @@ interface OppsummeringInnhold {
 export const oppsummeringTekster: OppsummeringInnhold = {
     tittel: { nb: 'Oppsummering' },
     reiseavstand_tittel: { nb: 'Reiseavstand' },
+    adressen_du_skal_reise_fra: { nb: 'Adressen du skal reise fra' },
     adressen_du_skal_reise_til: { nb: 'Adressen du skal reise til' },
     samlinger_tittel: { nb: 'Samlinger' },
     reisemåte_tittel: { nb: 'Reisemåte' },

--- a/src/frontend/reiseTilSamling/tekster/reiseavstand.ts
+++ b/src/frontend/reiseTilSamling/tekster/reiseavstand.ts
@@ -1,18 +1,31 @@
-import { TekstElement } from '../../typer/tekst';
+import { JaNeiTilTekst } from '../../tekster/felles';
+import { JaNei } from '../../typer/søknad';
+import { Radiogruppe, TekstElement } from '../../typer/tekst';
 
 interface ReiseavstandInnhold {
     tittel: TekstElement<string>;
     info_minsteavstand: TekstElement<string>;
+    folkereg_adresse: TekstElement<string>;
+    radio_skalReiseFraFolkeregAdr: Radiogruppe<JaNei>;
+    avreiseadresse_fra_folkereg_info: TekstElement<string>;
+    avreiseadresse_fra_folkereg_lenke_tekst: TekstElement<string>;
+    avreiseadresse_fra_folkereg_lenke_url: string;
+    avreiseadresse_tittel: TekstElement<string>;
+    avreiseadresse_vegadresse_label: TekstElement<string>;
+    avreiseadresse_postnummer_label: TekstElement<string>;
+    avreiseadresse_poststed_label: TekstElement<string>;
     antall_km_label: TekstElement<string>;
     antall_km_beskrivelse: TekstElement<string>;
-    folkeregistrert_adresse_info: TekstElement<string>;
-    folkeregistrert_adresse_lenke_tekst: TekstElement<string>;
-    folkeregistrert_adresse_lenke_url: string;
     aktivitetsadresse_tittel: TekstElement<string>;
     velg_land_label: TekstElement<string>;
     gateadresse_label: TekstElement<string>;
     postnummer_label: TekstElement<string>;
     poststed_label: TekstElement<string>;
+    feilmelding_skalReiseFraFolkeregAdr: TekstElement<string>;
+    feilmelding_avreise_land: TekstElement<string>;
+    feilmelding_avreise_gateadresse: TekstElement<string>;
+    feilmelding_avreise_postnummer: TekstElement<string>;
+    feilmelding_avreise_poststed: TekstElement<string>;
     feilmelding_antall_km: TekstElement<string>;
     feilmelding_antall_km_ugyldig: TekstElement<string>;
     feilmelding_land: TekstElement<string>;
@@ -28,19 +41,41 @@ export const reiseavstandTekster: ReiseavstandInnhold = {
     info_minsteavstand: {
         nb: 'For at du skal få støtte, må det være minst 30 kilometer mellom hjemmet ditt og aktivitetsadressen.',
     },
+    folkereg_adresse: {
+        nb: 'Din folkeregistrerte adresse er [0].',
+    },
+    radio_skalReiseFraFolkeregAdr: {
+        header: {
+            nb: 'Skal du reise fra din folkeregistrerte adresse?',
+        },
+        alternativer: JaNeiTilTekst,
+    },
+    avreiseadresse_fra_folkereg_info: {
+        nb: 'Adressen er hentet fra Folkeregisteret. Det er viktig at denne adressen er korrekt. Du kan ',
+    },
+    avreiseadresse_fra_folkereg_lenke_tekst: {
+        nb: 'endre adressen på Skatteetatens nettsider (åpnes i ny fane)',
+    },
+    avreiseadresse_fra_folkereg_lenke_url:
+        'https://www.skatteetaten.no/person/folkeregister/endre/',
+    avreiseadresse_tittel: {
+        nb: 'Oppgi adressen du skal reise fra',
+    },
+    avreiseadresse_vegadresse_label: {
+        nb: 'Gateadresse',
+    },
+    avreiseadresse_postnummer_label: {
+        nb: 'Postnummer',
+    },
+    avreiseadresse_poststed_label: {
+        nb: 'Poststed',
+    },
     antall_km_label: {
         nb: 'Hvor lang reisevei har du?',
     },
     antall_km_beskrivelse: {
         nb: 'Oppgi antall kilometer én vei.',
     },
-    folkeregistrert_adresse_info: {
-        nb: 'Vi tar utgangspunkt i den folkeregisterte adressen din som hjemmeadresse. Du kan ',
-    },
-    folkeregistrert_adresse_lenke_tekst: {
-        nb: 'se og endre adressen på Skatteetatens nettsider (åpnes i ny fane)',
-    },
-    folkeregistrert_adresse_lenke_url: 'https://www.skatteetaten.no/person/folkeregister/endre/',
     aktivitetsadresse_tittel: {
         nb: 'Oppgi adressen du skal reise til',
     },
@@ -55,6 +90,21 @@ export const reiseavstandTekster: ReiseavstandInnhold = {
     },
     poststed_label: {
         nb: 'Poststed',
+    },
+    feilmelding_skalReiseFraFolkeregAdr: {
+        nb: 'Du må svare på om du skal reise fra din folkeregistrerte adresse.',
+    },
+    feilmelding_avreise_land: {
+        nb: 'Du må velge land.',
+    },
+    feilmelding_avreise_gateadresse: {
+        nb: 'Du må fylle inn gateadresse.',
+    },
+    feilmelding_avreise_postnummer: {
+        nb: 'Du må fylle inn postnummer.',
+    },
+    feilmelding_avreise_poststed: {
+        nb: 'Du må fylle inn poststed.',
     },
     feilmelding_antall_km: {
         nb: 'Du må fylle inn antall kilometer.',

--- a/src/frontend/typer/person.ts
+++ b/src/frontend/typer/person.ts
@@ -1,9 +1,17 @@
 import { Barn } from './barn';
 
+export interface Adresse {
+    land: string;
+    adressenavn: string;
+    postnummer: string;
+    poststed: string;
+}
+
 export interface Person {
     fornavn: string;
     alder: number;
     visningsnavn: string;
     adresse: string;
+    strukturertAdresse?: Adresse;
     barn: Barn[];
 }

--- a/src/frontend/typer/person.ts
+++ b/src/frontend/typer/person.ts
@@ -2,7 +2,7 @@ import { Barn } from './barn';
 
 export interface Adresse {
     land: string;
-    adressenavn: string;
+    gateadresse: string;
     postnummer: string;
     poststed: string;
 }

--- a/src/frontend/typer/søknad.ts
+++ b/src/frontend/typer/søknad.ts
@@ -45,7 +45,16 @@ export interface Aktivitetsadresse {
     poststed?: VerdiFelt<string>;
 }
 
+export interface Avreiseadresse {
+    land?: SelectFelt;
+    gateadresse?: VerdiFelt<string>;
+    postnummer?: VerdiFelt<string>;
+    poststed?: VerdiFelt<string>;
+}
+
 export interface Reiseavstand {
+    skalReiseFraFolkeregAdr?: EnumFelt<JaNei>;
+    adresseDuSkalReiseFra?: Avreiseadresse;
     antallKilometerEnVei?: VerdiFelt<string>;
     aktivitetsadresse: Aktivitetsadresse;
 }

--- a/src/frontend/utils/adresseUtils.ts
+++ b/src/frontend/utils/adresseUtils.ts
@@ -1,0 +1,42 @@
+import countries from 'i18n-iso-countries';
+import codesData from 'i18n-iso-countries/codes.json';
+import nbLocale from 'i18n-iso-countries/langs/nb.json';
+
+countries.registerLocale(nbLocale);
+
+// Webpack fjerner innholdet i codes.json fra i18n-iso-countries når den bygger,
+// noe som gjør at alpha2ToAlpha3 returnerer undefined. Her importerer og bygger vi mappingen direkte
+// for å sikre at dataene er inkludert i bundlen.
+const alpha2ToAlpha3Map: Record<string, string> = {};
+codesData.forEach(([alpha2, alpha3]) => {
+    alpha2ToAlpha3Map[alpha2] = alpha3;
+});
+
+/**
+ * NOR = Norge
+ * SJM = Svalbard og Jan Mayen
+ */
+export const landkodeTilNavn = Object.entries(countries.getNames('nb', { select: 'official' }))
+    .map((country) => [alpha2ToAlpha3Map[country[0]], country[1]] as [string, string])
+    .reduce(
+        (prev, curr) => {
+            prev[curr[0]] = curr[1];
+            return prev;
+        },
+        {} as { [key: string]: string }
+    );
+
+export const adressefelterTilVisning = (adresse: {
+    gateadresse?: string;
+    postnummer?: string;
+    poststed?: string;
+    land?: string;
+}) => {
+    return [
+        adresse.gateadresse,
+        [adresse.postnummer, adresse.poststed].filter(Boolean).join(' '),
+        landkodeTilNavn[adresse.land || ''],
+    ]
+        .filter(Boolean)
+        .join(', ');
+};

--- a/tests/mocks/person.ts
+++ b/tests/mocks/person.ts
@@ -7,6 +7,12 @@ export const mockPersonMedBarnApi = async (page: Page) => {
             alder: 20,
             visningsnavn: 'fornavn etternavn',
             adresse: 'Hildes vei 3 a, 0100 Oslo',
+            strukturertAdresse: {
+                land: 'NOR',
+                gateadresse: 'Hildes vei',
+                postnummer: '0100',
+                poststed: 'Oslo',
+            },
             barn: [
                 {
                     ident: '08921997974',

--- a/tests/søknader/reiseTilSamling/happyPath.spec.ts
+++ b/tests/søknader/reiseTilSamling/happyPath.spec.ts
@@ -74,6 +74,10 @@ test('At reise til samling viser førstesiden og går videre fra din situasjon',
 
     await forventIngenWcagViolations(page);
 
+    await page
+        .getByRole('radiogroup', { name: 'Skal du reise fra din folkeregistrerte adresse?' })
+        .getByLabel('Ja')
+        .check();
     await page.getByLabel('Hvor lang reisevei har du?').fill('45');
     await page.getByLabel('Gateadresse').fill('Testveien 1');
     await page.getByLabel('Postnummer').fill('0123');


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

For reise til samling skal bruker kunne velge annen fra-adresse enn den folkeregistrerte. 

Avhengig av https://github.com/navikt/tilleggsstonader-soknad-api/pull/296 for å fungere. 


