### PR TITLE
Skal vise advarsel om endring på overgangsstønad

### DIFF
--- a/src/frontend/barnetilsyn/Forside.tsx
+++ b/src/frontend/barnetilsyn/Forside.tsx
@@ -17,6 +17,7 @@ import {
 import { ERouteBarnetilsyn, RoutesBarnetilsyn } from './routing/routesBarnetilsyn';
 import { forsideTekster } from './tekster/forside';
 import { loggAccordionEvent, loggBesøk, loggSkjemaStartet } from '../api/analytics';
+import { AdvarselEndringOvergangsstønad } from '../components/AdvarselEndringOvergangsstønad';
 import { BekreftelseCheckbox } from '../components/BekreftelseCheckbox';
 import { InfoPunktliste } from '../components/InfoPunktliste';
 import { Container } from '../components/Side';
@@ -83,6 +84,7 @@ export const Forside: React.FC = () => {
                     <LocaleTekstAvsnitt tekst={forsideTekster.mottatt_faktura_alert_innhold} />
                 </Alert>
             )}
+            <AdvarselEndringOvergangsstønad />
             <div>
                 <LocaleHeading tekst={forsideTekster.viktig_å_vite_tittel} level="2" size="small" />
                 <LocalePunktliste innhold={forsideTekster.viktig_å_vite_innhold} />

--- a/src/frontend/components/AdvarselEndringOvergangsstønad.tsx
+++ b/src/frontend/components/AdvarselEndringOvergangsstønad.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+import { Alert, BodyLong, Heading } from '@navikt/ds-react';
+
+export const AdvarselEndringOvergangsstønad = () => {
+    return (
+        <Alert variant="info">
+            <Heading size="small" spacing>
+                Fra 1. juli 2026 er reglene for enslig mor eller far endret.
+            </Heading>
+            <BodyLong spacing>
+                Du kan fortsatt få tilleggsstønader hvis du har rett til overgangsstønad etter
+                reglene som gjaldt før 1. juli 2026, eller etter overgangsreglene. Hvis du har rett
+                til overgangsstønad etter de nye reglene som gjelder fra 1. juli 2026, har du ikke
+                rett til tilleggsstønader.
+            </BodyLong>
+            <BodyLong weight="semibold">Kan jeg få tilleggsstønader?</BodyLong>
+            <BodyLong spacing>
+                Hvis du har rett til overgangsstønad etter de gamle reglene eller etter
+                overgangsreglene, kan du ha rett til tilleggsstønader.
+            </BodyLong>
+            <BodyLong>
+                Hvis du har rett til overgangsstønad etter de nye reglene som gjelder fra 1. juli
+                2026, har du ikke rett til tilleggsstønader.
+            </BodyLong>
+        </Alert>
+    );
+};

--- a/src/frontend/læremidler/Forside.tsx
+++ b/src/frontend/læremidler/Forside.tsx
@@ -7,6 +7,7 @@ import { Accordion, BodyLong, Button, GuidePanel, HStack, Label, VStack } from '
 import { ERouteLæremidler, routesLæremidler } from './routing/routesLæremidler';
 import { forsideTekster } from './tekster/forside';
 import { loggAccordionEvent, loggBesøk, loggSkjemaStartet } from '../api/analytics';
+import { AdvarselEndringOvergangsstønad } from '../components/AdvarselEndringOvergangsstønad';
 import { BekreftelseCheckbox } from '../components/BekreftelseCheckbox';
 import { InfoPunktliste } from '../components/InfoPunktliste';
 import { Container } from '../components/Side';
@@ -64,6 +65,7 @@ export const Forside: React.FC = () => {
                 </Label>
                 <LocaleTekstAvsnitt tekst={forsideTekster.veileder_innhold} />
             </GuidePanel>
+            <AdvarselEndringOvergangsstønad />
             <div>
                 <LocaleHeading tekst={forsideTekster.viktig_å_vite_tittel} level="2" size="small" />
                 <LocalePunktliste innhold={forsideTekster.viktig_å_vite_innhold} />


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Gjort i forbindelse med regelverksendringene på overgangsstønad.

Gadd ikke å lagre teksten i egen fil fordi advarselen kun skal leve midlertidig

<img width="861" height="750" alt="image" src="https://github.com/user-attachments/assets/bfd61687-afd2-4e8e-837f-67329f3a816e" />
