### PR TITLE
Legg til årsaker på reiseavstand, samt utgifter privat bil

### DIFF
--- a/src/frontend/components/Oppsummering/OppsummeringSvar.tsx
+++ b/src/frontend/components/Oppsummering/OppsummeringSvar.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import { FormSummary } from '@navikt/ds-react';
 
 import { EnumFelt, EnumFlereValgFelt, VerdiFelt } from '../../typer/skjema';

--- a/src/frontend/components/Oppsummering/OppsummeringSvar.tsx
+++ b/src/frontend/components/Oppsummering/OppsummeringSvar.tsx
@@ -1,0 +1,40 @@
+import { FormSummary } from '@navikt/ds-react';
+
+import { EnumFelt, EnumFlereValgFelt, VerdiFelt } from '../../typer/skjema';
+
+type OppsummeringSvarProps = {
+    felt: EnumFelt<unknown> | EnumFlereValgFelt<unknown> | VerdiFelt<string | number> | undefined;
+    valuePostfix?: string;
+};
+
+export const OppsummeringSvar: React.FC<OppsummeringSvarProps> = ({ felt, valuePostfix }) => {
+    if (!felt) {
+        return null;
+    }
+
+    const hentVerdi = (): string => {
+        if ('svarTekst' in felt) {
+            return felt.svarTekst;
+        }
+
+        if ('verdier' in felt) {
+            return felt.verdier.map((verdi) => verdi.label).join(', ');
+        }
+
+        if ('verdi' in felt) {
+            return felt.verdi.toString();
+        }
+
+        return '';
+    };
+
+    return (
+        <FormSummary.Answer>
+            <FormSummary.Label>{felt.label}</FormSummary.Label>
+            <FormSummary.Value>
+                {hentVerdi()}
+                {valuePostfix && ` ${valuePostfix}`}
+            </FormSummary.Value>
+        </FormSummary.Answer>
+    );
+};

--- a/src/frontend/context/ReiseTilSamlingSøknadContext.tsx
+++ b/src/frontend/context/ReiseTilSamlingSøknadContext.tsx
@@ -42,11 +42,11 @@ const [ReiseTilSamlingSøknadProvider, useReiseTilSamlingSøknad] = createUseCon
         const behov: Dokumentasjonsbehov[] = [
             { type: VedleggstypeReiseTilSamling.BEKREFTELSE_SAMLINGER },
         ];
-        if (reisemåte?.kanReiseKollektivt?.verdi === 'JA') {
+        if (reisemåte?.kanReiseMedOffentligTransport?.verdi === 'JA') {
             behov.push({ type: VedleggstypeReiseTilSamling.UTGIFTER_OFFENTLIG_TRANSPORT });
         }
         return behov;
-    }, [reisemåte?.kanReiseKollektivt?.verdi]);
+    }, [reisemåte?.kanReiseMedOffentligTransport?.verdi]);
     const [dokumentasjon, settDokumentasjon] =
         useState<DokumentasjonFelt[]>(initialDokumentasjon());
 

--- a/src/frontend/mock/reiseTilSamlingMock.ts
+++ b/src/frontend/mock/reiseTilSamlingMock.ts
@@ -53,13 +53,13 @@ export const mockReiseavstand: Reiseavstand = {
 
 export const mockReisemåte: Reisemåte = {
     kanReiseMedOffentligTransport: {
-        label: 'Kan du reise kollektivt?',
+        label: 'Kan du reise med offentlig transport?',
         verdi: 'JA',
         svarTekst: 'Ja',
         alternativer: ['Ja', 'Nei'],
     },
     totalUtgifterOffentligTransport: {
         verdi: '500',
-        label: 'Hva er totalutgiftene til kollektivtransport til og fra samlingene?',
+        label: 'Hva er totalutgiftene til offentlig transport til og fra samlingene?',
     },
 };

--- a/src/frontend/mock/reiseTilSamlingMock.ts
+++ b/src/frontend/mock/reiseTilSamlingMock.ts
@@ -52,13 +52,13 @@ export const mockReiseavstand: Reiseavstand = {
 };
 
 export const mockReisemåte: Reisemåte = {
-    kanReiseKollektivt: {
+    kanReiseMedOffentligTransport: {
         label: 'Kan du reise kollektivt?',
         verdi: 'JA',
         svarTekst: 'Ja',
         alternativer: ['Ja', 'Nei'],
     },
-    totalutgifterKollektivt: {
+    totalUtgifterOffentligTransport: {
         verdi: '500',
         label: 'Hva er totalutgiftene til kollektivtransport til og fra samlingene?',
     },

--- a/src/frontend/reiseTilSamling/steg/5-reisemåte/ReisemåteReiseTilSamling.tsx
+++ b/src/frontend/reiseTilSamling/steg/5-reisemåte/ReisemåteReiseTilSamling.tsx
@@ -10,9 +10,9 @@ import {
     errorKeyKanBenytteDrosje,
     errorKeyKanBenytteEgenBil,
     errorKeyKanIkkeBenytteEgenBilBegrunnelse,
-    errorKeyKanIkkeReiseKollektivtBegrunnelse,
-    errorKeyKanReiseKollektivt,
-    errorKeyTotalutgifterKollektivt,
+    errorKeyKanIkkeReiseMedOffentligTransportBegrunnelse,
+    errorKeyKanReiseMedOffentligTransport,
+    errorKeyTotalutgifterOffentligTransport,
     validerReisemåte,
 } from './validering';
 import { Side } from '../../../components/Side';
@@ -51,7 +51,7 @@ export const ReisemåteReiseTilSamling = () => {
 
     const oppdaterKanReiseMedOffentligTransport = (verdi: EnumFelt<JaNei>) => {
         settReisemåte({ kanReiseMedOffentligTransport: verdi });
-        nullstillFeil(errorKeyKanReiseKollektivt);
+        nullstillFeil(errorKeyKanReiseMedOffentligTransport);
     };
 
     const oppdaterKanIkkeReiseOffentligBegrunnelse = (verdier: EnumFlereValgFelt<string>) => {
@@ -59,7 +59,7 @@ export const ReisemåteReiseTilSamling = () => {
             ...prev,
             kanIkkeReiseMedOffentligTransportBegrunnelser: verdier,
         }));
-        nullstillFeil(errorKeyKanIkkeReiseKollektivtBegrunnelse);
+        nullstillFeil(errorKeyKanIkkeReiseMedOffentligTransportBegrunnelse);
     };
 
     const oppdaterKanBenytteEgenBil = (verdi: EnumFelt<JaNei>) => {
@@ -166,22 +166,22 @@ export const ReisemåteReiseTilSamling = () => {
             <LocaleHeading tekst={reisemåteTekster.tittel} level="2" size="medium" />
             <VStack gap="space-8">
                 <LocaleRadioGroup
-                    id={valideringsfeil[errorKeyKanReiseKollektivt]?.id}
+                    id={valideringsfeil[errorKeyKanReiseMedOffentligTransport]?.id}
                     tekst={reisemåteTekster.radio_kan_reise_offentlig}
                     value={reisemåte?.kanReiseMedOffentligTransport?.verdi ?? ''}
                     onChange={oppdaterKanReiseMedOffentligTransport}
-                    error={valideringsfeil[errorKeyKanReiseKollektivt]?.melding}
+                    error={valideringsfeil[errorKeyKanReiseMedOffentligTransport]?.melding}
                 />
                 {offentligTransportJa && (
                     <TotalutgifterFelt
-                        id={valideringsfeil[errorKeyTotalutgifterKollektivt]?.id}
+                        id={valideringsfeil[errorKeyTotalutgifterOffentligTransport]?.id}
                         label={reisemåteTekster.totalutgifter_offentlig_transport_label[locale]}
                         description={
                             reisemåteTekster.totalutgifter_offentlig_transport_beskrivelse[locale]
                         }
                         inputMode="numeric"
                         value={reisemåte?.totalUtgifterOffentligTransport?.verdi ?? ''}
-                        error={valideringsfeil[errorKeyTotalutgifterKollektivt]?.melding}
+                        error={valideringsfeil[errorKeyTotalutgifterOffentligTransport]?.melding}
                         onChange={(e) => {
                             const verdi = e.target.value;
                             settReisemåte((prev) => ({
@@ -193,14 +193,18 @@ export const ReisemåteReiseTilSamling = () => {
                                     verdi,
                                 },
                             }));
-                            nullstillFeil(errorKeyTotalutgifterKollektivt);
+                            nullstillFeil(errorKeyTotalutgifterOffentligTransport);
                         }}
                     />
                 )}
                 {offentligTransportNei && (
                     <>
                         <LocaleCheckboxGroup
-                            id={valideringsfeil[errorKeyKanIkkeReiseKollektivtBegrunnelse]?.id}
+                            id={
+                                valideringsfeil[
+                                    errorKeyKanIkkeReiseMedOffentligTransportBegrunnelse
+                                ]?.id
+                            }
                             tekst={reisemåteTekster.check_kan_ikke_reise_offentlig_begrunnelse}
                             onChange={oppdaterKanIkkeReiseOffentligBegrunnelse}
                             value={
@@ -208,7 +212,9 @@ export const ReisemåteReiseTilSamling = () => {
                                 []
                             }
                             error={
-                                valideringsfeil[errorKeyKanIkkeReiseKollektivtBegrunnelse]?.melding
+                                valideringsfeil[
+                                    errorKeyKanIkkeReiseMedOffentligTransportBegrunnelse
+                                ]?.melding
                             }
                         />
                         {dårligTransporttilbudValgt && (

--- a/src/frontend/reiseTilSamling/steg/5-reisemåte/ReisemåteReiseTilSamling.tsx
+++ b/src/frontend/reiseTilSamling/steg/5-reisemåte/ReisemåteReiseTilSamling.tsx
@@ -1,23 +1,29 @@
-import React from 'react';
-
 import styled from 'styled-components';
 
 import { Alert, TextField, VStack } from '@navikt/ds-react';
 
 import {
+    errorKeyEgenbilUtgifterBompenger,
+    errorKeyEgenbilUtgifterDrivstoffType,
+    errorKeyEgenbilUtgifterFerge,
+    errorKeyEgenbilUtgifterPiggdekkavgift,
     errorKeyKanBenytteDrosje,
     errorKeyKanBenytteEgenBil,
+    errorKeyKanIkkeBenytteEgenBilBegrunnelse,
+    errorKeyKanIkkeReiseKollektivtBegrunnelse,
     errorKeyKanReiseKollektivt,
     errorKeyTotalutgifterKollektivt,
     validerReisemåte,
 } from './validering';
 import { Side } from '../../../components/Side';
+import { LocaleCheckboxGroup } from '../../../components/Teksthåndtering/LocaleCheckboxGroup';
 import { LocaleHeading } from '../../../components/Teksthåndtering/LocaleHeading';
 import { LocaleRadioGroup } from '../../../components/Teksthåndtering/LocaleRadioGroup';
+import { LocaleTekst } from '../../../components/Teksthåndtering/LocaleTekst';
 import { useReiseTilSamlingSøknad } from '../../../context/ReiseTilSamlingSøknadContext';
 import { useSpråk } from '../../../context/SpråkContext';
 import { useValideringsfeil } from '../../../context/ValideringsfeilContext';
-import { EnumFelt } from '../../../typer/skjema';
+import { EnumFelt, EnumFlereValgFelt } from '../../../typer/skjema';
 import { JaNei } from '../../../typer/søknad';
 import { inneholderFeil } from '../../../typer/validering';
 import { reisemåteTekster } from '../../tekster/reisemåte';
@@ -43,32 +49,117 @@ export const ReisemåteReiseTilSamling = () => {
         return !inneholderFeil(feil);
     };
 
-    const oppdaterKanReiseKollektivt = (verdi: EnumFelt<JaNei>) => {
-        settReisemåte({ kanReiseKollektivt: verdi });
+    const oppdaterKanReiseMedOffentligTransport = (verdi: EnumFelt<JaNei>) => {
+        settReisemåte({ kanReiseMedOffentligTransport: verdi });
         nullstillFeil(errorKeyKanReiseKollektivt);
+    };
+
+    const oppdaterKanIkkeReiseOffentligBegrunnelse = (verdier: EnumFlereValgFelt<string>) => {
+        settReisemåte((prev) => ({
+            ...prev,
+            kanIkkeReiseMedOffentligTransportBegrunnelser: verdier,
+        }));
+        nullstillFeil(errorKeyKanIkkeReiseKollektivtBegrunnelse);
     };
 
     const oppdaterKanBenytteEgenBil = (verdi: EnumFelt<JaNei>) => {
         settReisemåte((prev) => ({
-            kanReiseKollektivt: prev?.kanReiseKollektivt,
+            kanReiseMedOffentligTransport: prev?.kanReiseMedOffentligTransport,
+            kanIkkeReiseMedOffentligTransportBegrunnelser:
+                prev?.kanIkkeReiseMedOffentligTransportBegrunnelser,
             kanBenytteEgenBil: verdi,
         }));
         nullstillFeil(errorKeyKanBenytteEgenBil);
     };
 
+    const oppdaterKanIkkeBenytteEgenBilBegrunnelse = (verdier: EnumFlereValgFelt<string>) => {
+        settReisemåte((prev) => ({
+            ...prev,
+            kanIkkeBenytteEgenBilBegrunnelser: verdier,
+        }));
+        nullstillFeil(errorKeyKanIkkeBenytteEgenBilBegrunnelse);
+    };
+
     const oppdaterKanBenytteDrosje = (verdi: EnumFelt<JaNei>) => {
         settReisemåte((prev) => ({
-            kanReiseKollektivt: prev?.kanReiseKollektivt,
+            ...prev,
+            kanReiseMedOffentligTransport: prev?.kanReiseMedOffentligTransport,
             kanBenytteEgenBil: prev?.kanBenytteEgenBil,
             kanBenytteDrosje: verdi,
         }));
         nullstillFeil(errorKeyKanBenytteDrosje);
     };
 
-    const kollektivtJa = reisemåte?.kanReiseKollektivt?.verdi === 'JA';
-    const kollektivtNei = reisemåte?.kanReiseKollektivt?.verdi === 'NEI';
+    const oppdaterEgenBilUtgifterDrivstoffType: (verdi: EnumFelt<string>) => void = (verdi) => {
+        settReisemåte((prev) => ({
+            ...prev,
+            egenBilUtgifter: {
+                ...prev?.egenBilUtgifter,
+                drivstoffType: verdi,
+            },
+        }));
+        nullstillFeil(errorKeyEgenbilUtgifterDrivstoffType);
+    };
+
+    const oppdaterEgenBilUtgifterBompenger = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const verdi = e.target.value;
+        settReisemåte((prev) => ({
+            ...prev,
+            egenBilUtgifter: {
+                ...prev?.egenBilUtgifter,
+                bompenger: {
+                    label: reisemåteTekster.egen_bil_utgifter_bompenger_tittel[locale],
+                    verdi,
+                },
+            },
+        }));
+        nullstillFeil(errorKeyEgenbilUtgifterBompenger);
+    };
+
+    const oppdaterEgenBilUtgifterFerge = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const verdi = e.target.value;
+        settReisemåte((prev) => ({
+            ...prev,
+            egenBilUtgifter: {
+                ...prev?.egenBilUtgifter,
+                ferge: { label: reisemåteTekster.egen_bil_utgifter_ferge_tittel[locale], verdi },
+            },
+        }));
+        nullstillFeil(errorKeyEgenbilUtgifterFerge);
+    };
+
+    const oppdaterEgenBilUtgifterPiggdekkavgift = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const verdi = e.target.value;
+        settReisemåte((prev) => ({
+            ...prev,
+            egenBilUtgifter: {
+                ...prev?.egenBilUtgifter,
+                piggdekkavgift: {
+                    label: reisemåteTekster.egen_bil_utgifter_piggdekkavgift_tittel[locale],
+                    verdi,
+                },
+            },
+        }));
+        nullstillFeil(errorKeyEgenbilUtgifterPiggdekkavgift);
+    };
+
+    const offentligTransportJa = reisemåte?.kanReiseMedOffentligTransport?.verdi === 'JA';
+    const offentligTransportNei = reisemåte?.kanReiseMedOffentligTransport?.verdi === 'NEI';
     const bilNei = reisemåte?.kanBenytteEgenBil?.verdi === 'NEI';
+    const bilJa = reisemåte?.kanBenytteEgenBil?.verdi === 'JA';
     const drosjeNei = reisemåte?.kanBenytteDrosje?.verdi === 'NEI';
+
+    const kanIkkeReiseOffentligBegrunnelser =
+        reisemåte?.kanIkkeReiseMedOffentligTransportBegrunnelser?.verdier.map((v) => v.verdi) ?? [];
+    const helsemessigeÅrsakerOffentligValgt =
+        kanIkkeReiseOffentligBegrunnelser.includes('helsemessigeÅrsaker');
+    const dårligTransporttilbudValgt =
+        kanIkkeReiseOffentligBegrunnelser.includes('dårligTransportTilbud');
+
+    const helsemessigeÅrsakerBilValgt =
+        reisemåte?.kanIkkeReiseMedOffentligTransportBegrunnelser?.verdier
+            .map((v) => v.verdi)
+            .includes('helsemessigeÅrsaker');
 
     return (
         <Side validerSteg={kanFortsette}>
@@ -76,24 +167,24 @@ export const ReisemåteReiseTilSamling = () => {
             <VStack gap="space-8">
                 <LocaleRadioGroup
                     id={valideringsfeil[errorKeyKanReiseKollektivt]?.id}
-                    tekst={reisemåteTekster.radio_kan_reise_kollektivt}
-                    value={reisemåte?.kanReiseKollektivt?.verdi ?? ''}
-                    onChange={oppdaterKanReiseKollektivt}
+                    tekst={reisemåteTekster.radio_kan_reise_offentlig}
+                    value={reisemåte?.kanReiseMedOffentligTransport?.verdi ?? ''}
+                    onChange={oppdaterKanReiseMedOffentligTransport}
                     error={valideringsfeil[errorKeyKanReiseKollektivt]?.melding}
                 />
-                {kollektivtJa && (
+                {offentligTransportJa && (
                     <TotalutgifterFelt
                         id={valideringsfeil[errorKeyTotalutgifterKollektivt]?.id}
                         label={reisemåteTekster.totalutgifter_kollektivt_label[locale]}
                         description={reisemåteTekster.totalutgifter_kollektivt_beskrivelse[locale]}
                         inputMode="numeric"
-                        value={reisemåte?.totalutgifterKollektivt?.verdi ?? ''}
+                        value={reisemåte?.totalUtgifterOffentligTransport?.verdi ?? ''}
                         error={valideringsfeil[errorKeyTotalutgifterKollektivt]?.melding}
                         onChange={(e) => {
                             const verdi = e.target.value;
                             settReisemåte((prev) => ({
                                 ...prev,
-                                totalutgifterKollektivt: {
+                                totalUtgifterOffentligTransport: {
                                     label: reisemåteTekster.totalutgifter_kollektivt_label[locale],
                                     verdi,
                                 },
@@ -102,28 +193,135 @@ export const ReisemåteReiseTilSamling = () => {
                         }}
                     />
                 )}
-                {kollektivtNei && (
-                    <LocaleRadioGroup
-                        id={valideringsfeil[errorKeyKanBenytteEgenBil]?.id}
-                        tekst={reisemåteTekster.radio_kan_benytte_egen_bil}
-                        value={reisemåte?.kanBenytteEgenBil?.verdi ?? ''}
-                        onChange={oppdaterKanBenytteEgenBil}
-                        error={valideringsfeil[errorKeyKanBenytteEgenBil]?.melding}
-                    />
-                )}
-                {kollektivtNei && bilNei && (
-                    <LocaleRadioGroup
-                        id={valideringsfeil[errorKeyKanBenytteDrosje]?.id}
-                        tekst={reisemåteTekster.radio_kan_benytte_drosje}
-                        value={reisemåte?.kanBenytteDrosje?.verdi ?? ''}
-                        onChange={oppdaterKanBenytteDrosje}
-                        error={valideringsfeil[errorKeyKanBenytteDrosje]?.melding}
-                    />
-                )}
-                {kollektivtNei && bilNei && drosjeNei && (
-                    <Alert variant="warning">
-                        {reisemåteTekster.advarsel_ingen_reisemåte[locale]}
-                    </Alert>
+                {offentligTransportNei && (
+                    <>
+                        <LocaleCheckboxGroup
+                            id={valideringsfeil[errorKeyKanIkkeReiseKollektivtBegrunnelse]?.id}
+                            tekst={reisemåteTekster.check_kan_ikke_reise_offentlig_begrunnelse}
+                            onChange={oppdaterKanIkkeReiseOffentligBegrunnelse}
+                            value={
+                                reisemåte?.kanIkkeReiseMedOffentligTransportBegrunnelser?.verdier ??
+                                []
+                            }
+                            error={
+                                valideringsfeil[errorKeyKanIkkeReiseKollektivtBegrunnelse]?.melding
+                            }
+                        />
+                        {dårligTransporttilbudValgt && (
+                            <Alert variant="info">
+                                {reisemåteTekster.info_dårlig_transporttilbud_valg[locale]}
+                            </Alert>
+                        )}
+                        {helsemessigeÅrsakerOffentligValgt && (
+                            <Alert variant="info">
+                                {reisemåteTekster.info_helsemessige_årsaker_valg[locale]}
+                            </Alert>
+                        )}
+                        <LocaleRadioGroup
+                            id={valideringsfeil[errorKeyKanBenytteEgenBil]?.id}
+                            tekst={reisemåteTekster.radio_kan_benytte_egen_bil}
+                            value={reisemåte?.kanBenytteEgenBil?.verdi ?? ''}
+                            onChange={oppdaterKanBenytteEgenBil}
+                            error={valideringsfeil[errorKeyKanBenytteEgenBil]?.melding}
+                        />
+                        {bilNei && (
+                            <>
+                                <LocaleCheckboxGroup
+                                    id={
+                                        valideringsfeil[errorKeyKanIkkeBenytteEgenBilBegrunnelse]
+                                            ?.id
+                                    }
+                                    tekst={
+                                        reisemåteTekster.check_kan_ikke_benytte_egen_bil_begrunnelse
+                                    }
+                                    onChange={oppdaterKanIkkeBenytteEgenBilBegrunnelse}
+                                    value={
+                                        reisemåte?.kanIkkeBenytteEgenBilBegrunnelser?.verdier ?? []
+                                    }
+                                    error={
+                                        valideringsfeil[errorKeyKanIkkeBenytteEgenBilBegrunnelse]
+                                            ?.melding
+                                    }
+                                />
+                                {helsemessigeÅrsakerBilValgt && (
+                                    <Alert variant="info">
+                                        {reisemåteTekster.info_helsemessige_årsaker_valg[locale]}
+                                    </Alert>
+                                )}
+                                <LocaleRadioGroup
+                                    id={valideringsfeil[errorKeyKanBenytteDrosje]?.id}
+                                    tekst={reisemåteTekster.radio_kan_benytte_drosje}
+                                    value={reisemåte?.kanBenytteDrosje?.verdi ?? ''}
+                                    onChange={oppdaterKanBenytteDrosje}
+                                    error={valideringsfeil[errorKeyKanBenytteDrosje]?.melding}
+                                />
+                                {drosjeNei && (
+                                    <Alert variant="info">
+                                        {reisemåteTekster.advarsel_ingen_reisemåte[locale]}
+                                    </Alert>
+                                )}
+                            </>
+                        )}
+                        {bilJa && (
+                            <VStack gap="space-12">
+                                <div>
+                                    <LocaleHeading
+                                        tekst={reisemåteTekster.egen_bil_utgifter_tittel}
+                                        level="3"
+                                        size="small"
+                                    />
+                                    <LocaleTekst
+                                        tekst={reisemåteTekster.egen_bil_utgifter_beskrivelse}
+                                    />
+                                </div>
+                                <LocaleRadioGroup
+                                    id={valideringsfeil[errorKeyEgenbilUtgifterDrivstoffType]?.id}
+                                    tekst={reisemåteTekster.egen_bil_utgifter_drivstoff_type}
+                                    value={reisemåte?.egenBilUtgifter?.drivstoffType?.verdi ?? ''}
+                                    onChange={oppdaterEgenBilUtgifterDrivstoffType}
+                                    error={
+                                        valideringsfeil[errorKeyEgenbilUtgifterDrivstoffType]
+                                            ?.melding
+                                    }
+                                />
+                                <TextField
+                                    id={valideringsfeil[errorKeyEgenbilUtgifterBompenger]?.id}
+                                    label={
+                                        reisemåteTekster.egen_bil_utgifter_bompenger_tittel[locale]
+                                    }
+                                    inputMode="numeric"
+                                    value={reisemåte?.egenBilUtgifter?.bompenger?.verdi ?? ''}
+                                    onChange={oppdaterEgenBilUtgifterBompenger}
+                                    error={
+                                        valideringsfeil[errorKeyEgenbilUtgifterBompenger]?.melding
+                                    }
+                                />
+                                <TextField
+                                    id={valideringsfeil[errorKeyEgenbilUtgifterFerge]?.id}
+                                    label={reisemåteTekster.egen_bil_utgifter_ferge_tittel[locale]}
+                                    inputMode="numeric"
+                                    value={reisemåte?.egenBilUtgifter?.ferge?.verdi ?? ''}
+                                    onChange={oppdaterEgenBilUtgifterFerge}
+                                    error={valideringsfeil[errorKeyEgenbilUtgifterFerge]?.melding}
+                                />
+                                <TextField
+                                    id={valideringsfeil[errorKeyEgenbilUtgifterPiggdekkavgift]?.id}
+                                    label={
+                                        reisemåteTekster.egen_bil_utgifter_piggdekkavgift_tittel[
+                                            locale
+                                        ]
+                                    }
+                                    inputMode="numeric"
+                                    value={reisemåte?.egenBilUtgifter?.piggdekkavgift?.verdi ?? ''}
+                                    onChange={oppdaterEgenBilUtgifterPiggdekkavgift}
+                                    error={
+                                        valideringsfeil[errorKeyEgenbilUtgifterPiggdekkavgift]
+                                            ?.melding
+                                    }
+                                />
+                            </VStack>
+                        )}
+                    </>
                 )}
             </VStack>
         </Side>

--- a/src/frontend/reiseTilSamling/steg/5-reisemåte/ReisemåteReiseTilSamling.tsx
+++ b/src/frontend/reiseTilSamling/steg/5-reisemåte/ReisemåteReiseTilSamling.tsx
@@ -175,8 +175,10 @@ export const ReisemåteReiseTilSamling = () => {
                 {offentligTransportJa && (
                     <TotalutgifterFelt
                         id={valideringsfeil[errorKeyTotalutgifterKollektivt]?.id}
-                        label={reisemåteTekster.totalutgifter_kollektivt_label[locale]}
-                        description={reisemåteTekster.totalutgifter_kollektivt_beskrivelse[locale]}
+                        label={reisemåteTekster.totalutgifter_offentlig_transport_label[locale]}
+                        description={
+                            reisemåteTekster.totalutgifter_offentlig_transport_beskrivelse[locale]
+                        }
                         inputMode="numeric"
                         value={reisemåte?.totalUtgifterOffentligTransport?.verdi ?? ''}
                         error={valideringsfeil[errorKeyTotalutgifterKollektivt]?.melding}
@@ -185,7 +187,9 @@ export const ReisemåteReiseTilSamling = () => {
                             settReisemåte((prev) => ({
                                 ...prev,
                                 totalUtgifterOffentligTransport: {
-                                    label: reisemåteTekster.totalutgifter_kollektivt_label[locale],
+                                    label: reisemåteTekster.totalutgifter_offentlig_transport_label[
+                                        locale
+                                    ],
                                     verdi,
                                 },
                             }));

--- a/src/frontend/reiseTilSamling/steg/5-reisemåte/validering.ts
+++ b/src/frontend/reiseTilSamling/steg/5-reisemåte/validering.ts
@@ -1,13 +1,15 @@
 import { Reisemåte } from '../../../typer/søknad';
 import { Locale } from '../../../typer/tekst';
 import { Valideringsfeil } from '../../../typer/validering';
+import { erGyldigKostnad } from '../../../utils/tall';
 import { harVerdi } from '../../../utils/typeUtils';
 import { reisemåteTekster } from '../../tekster/reisemåte';
 
-export const errorKeyKanReiseKollektivt = 'reisemåte_kan_reise_kollektivt';
-export const errorKeyKanIkkeReiseKollektivtBegrunnelse =
-    'reisemåte_kan_ikke_reise_kollektivt_begrunnelse';
-export const errorKeyTotalutgifterKollektivt = 'reisemåte_totalutgifter_kollektivt';
+export const errorKeyKanReiseMedOffentligTransport = 'reisemåte_kan_reise_med_offentlig_transport';
+export const errorKeyKanIkkeReiseMedOffentligTransportBegrunnelse =
+    'reisemåte_kan_ikke_reise_med_offentlig_transport_begrunnelse';
+export const errorKeyTotalutgifterOffentligTransport =
+    'reisemåte_totalutgifter_offentlig_transport';
 export const errorKeyKanBenytteEgenBil = 'reisemåte_kan_benytte_egen_bil';
 export const errorKeyKanBenytteDrosje = 'reisemåte_kan_benytte_drosje';
 export const errorKeyKanIkkeBenytteEgenBilBegrunnelse =
@@ -26,8 +28,8 @@ export const validerReisemåte = (
 
     if (!harVerdi(reisemåte?.kanReiseMedOffentligTransport?.verdi)) {
         return {
-            [errorKeyKanReiseKollektivt]: {
-                id: errorKeyKanReiseKollektivt,
+            [errorKeyKanReiseMedOffentligTransport]: {
+                id: errorKeyKanReiseMedOffentligTransport,
                 melding: reisemåteTekster.feilmelding_offentlig_mangler[locale],
             },
         };
@@ -38,16 +40,16 @@ export const validerReisemåte = (
         if (!harVerdi(utgifter)) {
             feil = {
                 ...feil,
-                [errorKeyTotalutgifterKollektivt]: {
-                    id: errorKeyTotalutgifterKollektivt,
+                [errorKeyTotalutgifterOffentligTransport]: {
+                    id: errorKeyTotalutgifterOffentligTransport,
                     melding: reisemåteTekster.feilmelding_totalutgifter_mangler[locale],
                 },
             };
-        } else if (isNaN(Number(utgifter)) || Number(utgifter) <= 0) {
+        } else if (!erGyldigKostnad(utgifter)) {
             feil = {
                 ...feil,
-                [errorKeyTotalutgifterKollektivt]: {
-                    id: errorKeyTotalutgifterKollektivt,
+                [errorKeyTotalutgifterOffentligTransport]: {
+                    id: errorKeyTotalutgifterOffentligTransport,
                     melding: reisemåteTekster.feilmelding_totalutgifter_ugyldig[locale],
                 },
             };
@@ -62,8 +64,8 @@ export const validerReisemåte = (
         ) {
             feil = {
                 ...feil,
-                [errorKeyKanIkkeReiseKollektivtBegrunnelse]: {
-                    id: errorKeyKanIkkeReiseKollektivtBegrunnelse,
+                [errorKeyKanIkkeReiseMedOffentligTransportBegrunnelse]: {
+                    id: errorKeyKanIkkeReiseMedOffentligTransportBegrunnelse,
                     melding:
                         reisemåteTekster.feilmelding_kan_ikke_reise_offentlig_begrunnelse[locale],
                 },
@@ -116,9 +118,7 @@ export const validerReisemåte = (
                 };
             }
 
-            const bompenger = reisemåte?.egenBilUtgifter?.bompenger?.verdi;
-
-            if (bompenger && (isNaN(Number(bompenger)) || Number(bompenger) <= 0)) {
+            if (!erGyldigKostnad(reisemåte?.egenBilUtgifter?.bompenger?.verdi)) {
                 feil = {
                     ...feil,
                     [errorKeyEgenbilUtgifterBompenger]: {
@@ -128,9 +128,7 @@ export const validerReisemåte = (
                 };
             }
 
-            const ferge = reisemåte?.egenBilUtgifter?.ferge?.verdi;
-
-            if (ferge && (isNaN(Number(ferge)) || Number(ferge) <= 0)) {
+            if (!erGyldigKostnad(reisemåte?.egenBilUtgifter?.ferge?.verdi)) {
                 feil = {
                     ...feil,
                     [errorKeyEgenbilUtgifterFerge]: {
@@ -140,9 +138,7 @@ export const validerReisemåte = (
                 };
             }
 
-            const piggdekkavgift = reisemåte?.egenBilUtgifter?.piggdekkavgift?.verdi;
-
-            if (piggdekkavgift && (isNaN(Number(piggdekkavgift)) || Number(piggdekkavgift) <= 0)) {
+            if (!erGyldigKostnad(reisemåte?.egenBilUtgifter?.piggdekkavgift?.verdi)) {
                 feil = {
                     ...feil,
                     [errorKeyEgenbilUtgifterPiggdekkavgift]: {

--- a/src/frontend/reiseTilSamling/steg/5-reisemåte/validering.ts
+++ b/src/frontend/reiseTilSamling/steg/5-reisemåte/validering.ts
@@ -5,9 +5,18 @@ import { harVerdi } from '../../../utils/typeUtils';
 import { reisemåteTekster } from '../../tekster/reisemåte';
 
 export const errorKeyKanReiseKollektivt = 'reisemåte_kan_reise_kollektivt';
+export const errorKeyKanIkkeReiseKollektivtBegrunnelse =
+    'reisemåte_kan_ikke_reise_kollektivt_begrunnelse';
 export const errorKeyTotalutgifterKollektivt = 'reisemåte_totalutgifter_kollektivt';
 export const errorKeyKanBenytteEgenBil = 'reisemåte_kan_benytte_egen_bil';
 export const errorKeyKanBenytteDrosje = 'reisemåte_kan_benytte_drosje';
+export const errorKeyKanIkkeBenytteEgenBilBegrunnelse =
+    'reisemåte_kan_ikke_benytte_egen_bil_begrunnelse';
+
+export const errorKeyEgenbilUtgifterDrivstoffType = 'reisemåte_egenbil_utgifter_drivstoff_type';
+export const errorKeyEgenbilUtgifterBompenger = 'reisemåte_egenbil_utgifter_bompenger';
+export const errorKeyEgenbilUtgifterFerge = 'reisemåte_egenbil_utgifter_ferge';
+export const errorKeyEgenbilUtgifterPiggdekkavgift = 'reisemåte_egenbil_utgifter_piggdekkavgift';
 
 export const validerReisemåte = (
     reisemåte: Reisemåte | undefined,
@@ -15,17 +24,17 @@ export const validerReisemåte = (
 ): Valideringsfeil => {
     let feil: Valideringsfeil = {};
 
-    if (!harVerdi(reisemåte?.kanReiseKollektivt?.verdi)) {
+    if (!harVerdi(reisemåte?.kanReiseMedOffentligTransport?.verdi)) {
         return {
             [errorKeyKanReiseKollektivt]: {
                 id: errorKeyKanReiseKollektivt,
-                melding: reisemåteTekster.feilmelding_kollektivt_mangler[locale],
+                melding: reisemåteTekster.feilmelding_offentlig_mangler[locale],
             },
         };
     }
 
-    if (reisemåte?.kanReiseKollektivt?.verdi === 'JA') {
-        const utgifter = reisemåte?.totalutgifterKollektivt?.verdi;
+    if (reisemåte?.kanReiseMedOffentligTransport?.verdi === 'JA') {
+        const utgifter = reisemåte?.totalUtgifterOffentligTransport?.verdi;
         if (!harVerdi(utgifter)) {
             feil = {
                 ...feil,
@@ -45,7 +54,21 @@ export const validerReisemåte = (
         }
     }
 
-    if (reisemåte?.kanReiseKollektivt?.verdi === 'NEI') {
+    if (reisemåte?.kanReiseMedOffentligTransport?.verdi === 'NEI') {
+        if (
+            !reisemåte?.kanIkkeReiseMedOffentligTransportBegrunnelser?.verdier.some((felt) =>
+                harVerdi(felt.verdi)
+            )
+        ) {
+            feil = {
+                ...feil,
+                [errorKeyKanIkkeReiseKollektivtBegrunnelse]: {
+                    id: errorKeyKanIkkeReiseKollektivtBegrunnelse,
+                    melding:
+                        reisemåteTekster.feilmelding_kan_ikke_reise_offentlig_begrunnelse[locale],
+                },
+            };
+        }
         if (!harVerdi(reisemåte?.kanBenytteEgenBil?.verdi)) {
             feil = {
                 ...feil,
@@ -55,12 +78,77 @@ export const validerReisemåte = (
                 },
             };
         } else if (reisemåte?.kanBenytteEgenBil?.verdi === 'NEI') {
+            if (
+                !reisemåte?.kanIkkeBenytteEgenBilBegrunnelser?.verdier.some((felt) =>
+                    harVerdi(felt.verdi)
+                )
+            ) {
+                feil = {
+                    ...feil,
+                    [errorKeyKanIkkeBenytteEgenBilBegrunnelse]: {
+                        id: errorKeyKanIkkeBenytteEgenBilBegrunnelse,
+                        melding:
+                            reisemåteTekster.feilmelding_kan_ikke_benytte_egen_bil_begrunnelse[
+                                locale
+                            ],
+                    },
+                };
+            }
+
             if (!harVerdi(reisemåte?.kanBenytteDrosje?.verdi)) {
                 feil = {
                     ...feil,
                     [errorKeyKanBenytteDrosje]: {
                         id: errorKeyKanBenytteDrosje,
                         melding: reisemåteTekster.feilmelding_drosje_mangler[locale],
+                    },
+                };
+            }
+        } else if (reisemåte?.kanBenytteEgenBil?.verdi === 'JA') {
+            if (!harVerdi(reisemåte?.egenBilUtgifter?.drivstoffType?.verdi)) {
+                feil = {
+                    ...feil,
+                    [errorKeyEgenbilUtgifterDrivstoffType]: {
+                        id: errorKeyEgenbilUtgifterDrivstoffType,
+                        melding:
+                            reisemåteTekster.feilmelding_egenbil_utgifter_drivstoff_type[locale],
+                    },
+                };
+            }
+
+            const bompenger = reisemåte?.egenBilUtgifter?.bompenger?.verdi;
+
+            if (bompenger && (isNaN(Number(bompenger)) || Number(bompenger) <= 0)) {
+                feil = {
+                    ...feil,
+                    [errorKeyEgenbilUtgifterBompenger]: {
+                        id: errorKeyEgenbilUtgifterBompenger,
+                        melding: reisemåteTekster.feilmelding_egenbil_utgifter_bompenger[locale],
+                    },
+                };
+            }
+
+            const ferge = reisemåte?.egenBilUtgifter?.ferge?.verdi;
+
+            if (ferge && (isNaN(Number(ferge)) || Number(ferge) <= 0)) {
+                feil = {
+                    ...feil,
+                    [errorKeyEgenbilUtgifterFerge]: {
+                        id: errorKeyEgenbilUtgifterFerge,
+                        melding: reisemåteTekster.feilmelding_egenbil_utgifter_ferge[locale],
+                    },
+                };
+            }
+
+            const piggdekkavgift = reisemåte?.egenBilUtgifter?.piggdekkavgift?.verdi;
+
+            if (piggdekkavgift && (isNaN(Number(piggdekkavgift)) || Number(piggdekkavgift) <= 0)) {
+                feil = {
+                    ...feil,
+                    [errorKeyEgenbilUtgifterPiggdekkavgift]: {
+                        id: errorKeyEgenbilUtgifterPiggdekkavgift,
+                        melding:
+                            reisemåteTekster.feilmelding_egenbil_utgifter_piggdekkavgift[locale],
                     },
                 };
             }

--- a/src/frontend/reiseTilSamling/steg/7-oppsummering/AktivitetOppsummering.tsx
+++ b/src/frontend/reiseTilSamling/steg/7-oppsummering/AktivitetOppsummering.tsx
@@ -3,34 +3,11 @@ import React from 'react';
 import { FormSummary } from '@navikt/ds-react';
 
 import { FormSummaryFooterMedEndreKnapp } from '../../../components/Oppsummering/FormSummaryFooterMedEndreKnapp';
+import { OppsummeringSvar } from '../../../components/Oppsummering/OppsummeringSvar';
 import { LocaleTekst } from '../../../components/Teksthåndtering/LocaleTekst';
-import { EnumFelt, EnumFlereValgFelt } from '../../../typer/skjema';
 import { RouteTilPath } from '../../routing/routesReiseTilSamling';
 import { oppsummeringTekster } from '../../tekster/oppsummering';
 import { AktivitetReiseTilSamling } from '../../typer/aktivitet';
-
-// TODO Senere, flytte denne til eget og gjenbruk i andre oppsummeringer
-type OppsummeringSvarProps = {
-    felt: EnumFelt<unknown> | EnumFlereValgFelt<unknown> | undefined;
-    valuePostfix?: string;
-};
-export const OppsummeringSvar: React.FC<OppsummeringSvarProps> = ({ felt, valuePostfix }) => {
-    if (!felt) {
-        return null;
-    }
-
-    return (
-        <FormSummary.Answer>
-            <FormSummary.Label>{felt.label}</FormSummary.Label>
-            <FormSummary.Value>
-                {'verdier' in felt
-                    ? felt.verdier.map((verdi) => verdi.label).join(', ')
-                    : felt.svarTekst}
-                {valuePostfix && ` ${valuePostfix}`}
-            </FormSummary.Value>
-        </FormSummary.Answer>
-    );
-};
 
 export const AktivitetOppsummering: React.FC<{
     aktivitet: AktivitetReiseTilSamling;

--- a/src/frontend/reiseTilSamling/steg/7-oppsummering/ReisemåteOppsummering.tsx
+++ b/src/frontend/reiseTilSamling/steg/7-oppsummering/ReisemåteOppsummering.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { FormSummary } from '@navikt/ds-react';
 
 import { FormSummaryFooterMedEndreKnapp } from '../../../components/Oppsummering/FormSummaryFooterMedEndreKnapp';
+import { OppsummeringSvar } from '../../../components/Oppsummering/OppsummeringSvar';
 import { LocaleTekst } from '../../../components/Teksthåndtering/LocaleTekst';
 import { Reisemåte } from '../../../typer/søknad';
 import { RouteTilPath } from '../../routing/routesReiseTilSamling';
@@ -17,40 +18,22 @@ export const ReisemåteOppsummering: React.FC<{ reisemåte: Reisemåte }> = ({ r
                 </FormSummary.Heading>
             </FormSummary.Header>
             <FormSummary.Answers>
-                {reisemåte.kanReiseKollektivt && (
-                    <FormSummary.Answer>
-                        <FormSummary.Label>{reisemåte.kanReiseKollektivt.label}</FormSummary.Label>
-                        <FormSummary.Value>
-                            {reisemåte.kanReiseKollektivt.svarTekst}
-                        </FormSummary.Value>
-                    </FormSummary.Answer>
-                )}
-                {reisemåte.totalutgifterKollektivt && (
-                    <FormSummary.Answer>
-                        <FormSummary.Label>
-                            {reisemåte.totalutgifterKollektivt.label}
-                        </FormSummary.Label>
-                        <FormSummary.Value>
-                            {reisemåte.totalutgifterKollektivt.verdi} kr
-                        </FormSummary.Value>
-                    </FormSummary.Answer>
-                )}
-                {reisemåte.kanBenytteEgenBil && (
-                    <FormSummary.Answer>
-                        <FormSummary.Label>{reisemåte.kanBenytteEgenBil.label}</FormSummary.Label>
-                        <FormSummary.Value>
-                            {reisemåte.kanBenytteEgenBil.svarTekst}
-                        </FormSummary.Value>
-                    </FormSummary.Answer>
-                )}
-                {reisemåte.kanBenytteDrosje && (
-                    <FormSummary.Answer>
-                        <FormSummary.Label>{reisemåte.kanBenytteDrosje.label}</FormSummary.Label>
-                        <FormSummary.Value>
-                            {reisemåte.kanBenytteDrosje.svarTekst}
-                        </FormSummary.Value>
-                    </FormSummary.Answer>
-                )}
+                <OppsummeringSvar felt={reisemåte.kanReiseMedOffentligTransport} />
+                <OppsummeringSvar
+                    felt={reisemåte.totalUtgifterOffentligTransport}
+                    valuePostfix="kr"
+                />
+                <OppsummeringSvar felt={reisemåte.kanIkkeReiseMedOffentligTransportBegrunnelser} />
+                <OppsummeringSvar felt={reisemåte.kanBenytteEgenBil} />
+                <OppsummeringSvar felt={reisemåte.kanIkkeBenytteEgenBilBegrunnelser} />
+                <OppsummeringSvar felt={reisemåte.egenBilUtgifter?.drivstoffType} />
+                <OppsummeringSvar felt={reisemåte.egenBilUtgifter?.bompenger} valuePostfix="kr" />
+                <OppsummeringSvar felt={reisemåte.egenBilUtgifter?.ferge} valuePostfix="kr" />
+                <OppsummeringSvar
+                    felt={reisemåte.egenBilUtgifter?.piggdekkavgift}
+                    valuePostfix="kr"
+                />
+                <OppsummeringSvar felt={reisemåte.kanBenytteDrosje} />
             </FormSummary.Answers>
             <FormSummaryFooterMedEndreKnapp lenke={RouteTilPath.REISEMÅTE} />
         </FormSummary>

--- a/src/frontend/reiseTilSamling/tekster/reisemåte.ts
+++ b/src/frontend/reiseTilSamling/tekster/reisemåte.ts
@@ -6,8 +6,8 @@ interface ReisemåteInnhold {
     tittel: TekstElement<string>;
     radio_kan_reise_offentlig: Radiogruppe<JaNei>;
     check_kan_ikke_reise_offentlig_begrunnelse: CheckboxGruppe<string>;
-    totalutgifter_kollektivt_label: TekstElement<string>;
-    totalutgifter_kollektivt_beskrivelse: TekstElement<string>;
+    totalutgifter_offentlig_transport_label: TekstElement<string>;
+    totalutgifter_offentlig_transport_beskrivelse: TekstElement<string>;
     radio_kan_benytte_egen_bil: Radiogruppe<JaNei>;
     check_kan_ikke_benytte_egen_bil_begrunnelse: CheckboxGruppe<string>;
     egen_bil_utgifter_tittel: TekstElement<string>;
@@ -71,10 +71,10 @@ export const reisemåteTekster: ReisemåteInnhold = {
     feilmelding_kan_ikke_reise_offentlig_begrunnelse: {
         nb: 'Du må oppgi hvorfor du ikke kan reise med offentlig transport.',
     },
-    totalutgifter_kollektivt_label: {
-        nb: 'Hva er totalutgiftene til kollektivtransport til og fra samlingene?',
+    totalutgifter_offentlig_transport_label: {
+        nb: 'Hva er totalutgiftene til offentlig transport til og fra samlingene?',
     },
-    totalutgifter_kollektivt_beskrivelse: {
+    totalutgifter_offentlig_transport_beskrivelse: {
         nb: 'Oppgi totalbeløpet i kroner for alle samlingene du søker for.',
     },
     radio_kan_benytte_egen_bil: {

--- a/src/frontend/reiseTilSamling/tekster/reisemåte.ts
+++ b/src/frontend/reiseTilSamling/tekster/reisemåte.ts
@@ -1,31 +1,75 @@
 import { JaNeiTilTekst } from '../../tekster/felles';
 import { JaNei } from '../../typer/søknad';
-import { Radiogruppe, TekstElement } from '../../typer/tekst';
+import { CheckboxGruppe, Radiogruppe, TekstElement } from '../../typer/tekst';
 
 interface ReisemåteInnhold {
     tittel: TekstElement<string>;
-    radio_kan_reise_kollektivt: Radiogruppe<JaNei>;
+    radio_kan_reise_offentlig: Radiogruppe<JaNei>;
+    check_kan_ikke_reise_offentlig_begrunnelse: CheckboxGruppe<string>;
     totalutgifter_kollektivt_label: TekstElement<string>;
     totalutgifter_kollektivt_beskrivelse: TekstElement<string>;
     radio_kan_benytte_egen_bil: Radiogruppe<JaNei>;
+    check_kan_ikke_benytte_egen_bil_begrunnelse: CheckboxGruppe<string>;
+    egen_bil_utgifter_tittel: TekstElement<string>;
+    egen_bil_utgifter_beskrivelse: TekstElement<string>;
+    egen_bil_utgifter_drivstoff_type: Radiogruppe<string>;
+    egen_bil_utgifter_bompenger_tittel: TekstElement<string>;
+    egen_bil_utgifter_ferge_tittel: TekstElement<string>;
+    egen_bil_utgifter_piggdekkavgift_tittel: TekstElement<string>;
     radio_kan_benytte_drosje: Radiogruppe<JaNei>;
     advarsel_ingen_reisemåte: TekstElement<string>;
-    feilmelding_kollektivt_mangler: TekstElement<string>;
+    info_helsemessige_årsaker_valg: TekstElement<string>;
+    info_dårlig_transporttilbud_valg: TekstElement<string>;
+    feilmelding_offentlig_mangler: TekstElement<string>;
+    feilmelding_kan_ikke_reise_offentlig_begrunnelse: TekstElement<string>;
     feilmelding_totalutgifter_mangler: TekstElement<string>;
     feilmelding_totalutgifter_ugyldig: TekstElement<string>;
     feilmelding_bil_mangler: TekstElement<string>;
+    feilmelding_kan_ikke_benytte_egen_bil_begrunnelse: TekstElement<string>;
     feilmelding_drosje_mangler: TekstElement<string>;
+    feilmelding_egenbil_utgifter_drivstoff_type: TekstElement<string>;
+    feilmelding_egenbil_utgifter_bompenger: TekstElement<string>;
+    feilmelding_egenbil_utgifter_ferge: TekstElement<string>;
+    feilmelding_egenbil_utgifter_piggdekkavgift: TekstElement<string>;
 }
 
 export const reisemåteTekster: ReisemåteInnhold = {
     tittel: {
         nb: 'Reisemåte',
     },
-    radio_kan_reise_kollektivt: {
+    radio_kan_reise_offentlig: {
         header: {
-            nb: 'Kan du reise kollektivt?',
+            nb: 'Kan du reise med offentlig transport?',
         },
         alternativer: JaNeiTilTekst,
+        beskrivelse: {
+            nb: 'Med offentlig transport menes buss, tog, trikk, t-bane, ferge og lignende.',
+        },
+    },
+    check_kan_ikke_reise_offentlig_begrunnelse: {
+        legend: {
+            nb: 'Hvorfor kan du ikke reise med offentlig transport?',
+        },
+        alternativer: {
+            dårligTransportTilbud: {
+                nb: 'Dårlig transporttilbud',
+            },
+            helsemessigeÅrsaker: {
+                nb: 'Helsemessige årsaker',
+            },
+            leveringHentingIBarnehage: {
+                nb: 'Levering/henting i barnehage eller skolefritidsordning (SFO/AKS)',
+            },
+        },
+    },
+    info_helsemessige_årsaker_valg: {
+        nb: 'Du må dokumentere din helsetilstand med legeerklæring eller annen uttalelse fra helsepersonell.',
+    },
+    info_dårlig_transporttilbud_valg: {
+        nb: 'Siden du valgte at du ikke kan reise med offentlig transport grunnet dårlig transporttilbud, kommer vi til å gjøre en vurdering av dette.',
+    },
+    feilmelding_kan_ikke_reise_offentlig_begrunnelse: {
+        nb: 'Du må oppgi hvorfor du ikke kan reise med offentlig transport.',
     },
     totalutgifter_kollektivt_label: {
         nb: 'Hva er totalutgiftene til kollektivtransport til og fra samlingene?',
@@ -35,9 +79,55 @@ export const reisemåteTekster: ReisemåteInnhold = {
     },
     radio_kan_benytte_egen_bil: {
         header: {
-            nb: 'Kan du benytte egen bil?',
+            nb: 'Skal du kjøre bil til aktivitetsstedet?',
         },
         alternativer: JaNeiTilTekst,
+    },
+    check_kan_ikke_benytte_egen_bil_begrunnelse: {
+        legend: {
+            nb: 'Hvorfor kan du ikke kjøre bil til aktivitetsstedet?',
+        },
+        alternativer: {
+            manglendeFørerkortEllerBil: {
+                nb: 'Har ikke bil eller førerkort',
+            },
+            helsemessigeÅrsaker: {
+                nb: 'Helsemessige årsaker',
+            },
+            annet: {
+                nb: 'Annet',
+            },
+        },
+    },
+    egen_bil_utgifter_tittel: {
+        nb: 'Utgifter til kjøring med privat bil',
+    },
+    egen_bil_utgifter_beskrivelse: {
+        nb: 'Du trenger bare å fylle inn det som gjelder for din reise.',
+    },
+    egen_bil_utgifter_drivstoff_type: {
+        header: {
+            nb: 'Bilens drivstofftype?',
+        },
+        alternativer: {
+            Elbil: { nb: 'Elbil' },
+            Hydrogen: { nb: 'Hydrogen' },
+            Bensin: { nb: 'Bensin' },
+            Hybrid: { nb: 'Hybrid' },
+            Diesel: { nb: 'Diesel' },
+        },
+        beskrivelse: {
+            nb: 'Bompenger og fergepriser beregnes ut fra bilens offisielle miljøklasse, derfor må du velge drivstofftype.',
+        },
+    },
+    egen_bil_utgifter_bompenger_tittel: {
+        nb: 'Bompenger per dag (valgfritt)',
+    },
+    egen_bil_utgifter_ferge_tittel: {
+        nb: 'Ferge per dag (valgfritt)',
+    },
+    egen_bil_utgifter_piggdekkavgift_tittel: {
+        nb: 'Piggdekkavgift per dag (valgfritt)',
     },
     radio_kan_benytte_drosje: {
         header: {
@@ -46,10 +136,10 @@ export const reisemåteTekster: ReisemåteInnhold = {
         alternativer: JaNeiTilTekst,
     },
     advarsel_ingen_reisemåte: {
-        nb: 'Du har oppgitt at du ikke kan reise kollektivt, benytte egen bil eller drosje. Du vil derfor sannsynligvis få avslag på søknaden om stønad til reiser.',
+        nb: 'Du har oppgitt at du ikke kan reise med offentlig transport, benytte egen bil eller drosje. Du vil derfor sannsynligvis få avslag på søknaden om stønad til reiser.',
     },
-    feilmelding_kollektivt_mangler: {
-        nb: 'Du må svare på om du kan reise kollektivt.',
+    feilmelding_offentlig_mangler: {
+        nb: 'Du må svare på om du kan reise med offentlig transport.',
     },
     feilmelding_totalutgifter_mangler: {
         nb: 'Du må fylle inn totalutgiftene.',
@@ -62,5 +152,20 @@ export const reisemåteTekster: ReisemåteInnhold = {
     },
     feilmelding_drosje_mangler: {
         nb: 'Du må svare på om du kan benytte drosje.',
+    },
+    feilmelding_kan_ikke_benytte_egen_bil_begrunnelse: {
+        nb: 'Du må oppgi hvorfor du ikke kan benytte egen bil.',
+    },
+    feilmelding_egenbil_utgifter_drivstoff_type: {
+        nb: 'Du må oppgi bilens drivstofftype.',
+    },
+    feilmelding_egenbil_utgifter_bompenger: {
+        nb: 'Bompenger må være et positivt tall.',
+    },
+    feilmelding_egenbil_utgifter_ferge: {
+        nb: 'Ferge må være et positivt tall.',
+    },
+    feilmelding_egenbil_utgifter_piggdekkavgift: {
+        nb: 'Piggdekkavgift må være et positivt tall.',
     },
 };

--- a/src/frontend/typer/søknad.ts
+++ b/src/frontend/typer/søknad.ts
@@ -33,10 +33,18 @@ export interface SøknadReiseTilSamling {
 }
 
 export interface Reisemåte {
-    kanReiseKollektivt?: EnumFelt<JaNei>;
-    totalutgifterKollektivt?: VerdiFelt<string>;
+    kanReiseMedOffentligTransport?: EnumFelt<JaNei>;
+    kanIkkeReiseMedOffentligTransportBegrunnelser?: EnumFlereValgFelt<string>;
+    totalUtgifterOffentligTransport?: VerdiFelt<string>;
     kanBenytteEgenBil?: EnumFelt<JaNei>;
+    kanIkkeBenytteEgenBilBegrunnelser?: EnumFlereValgFelt<string>;
     kanBenytteDrosje?: EnumFelt<JaNei>;
+    egenBilUtgifter?: {
+        drivstoffType?: EnumFelt<string>;
+        bompenger?: VerdiFelt<string>;
+        ferge?: VerdiFelt<string>;
+        piggdekkavgift?: VerdiFelt<string>;
+    };
 }
 
 export interface Aktivitetsadresse {

--- a/src/frontend/typer/tekst.ts
+++ b/src/frontend/typer/tekst.ts
@@ -32,6 +32,12 @@ export type Radiogruppe<T extends string> = {
     alternativer: Alternativer<T>;
 };
 
+export type SelectGruppe<T extends string> = {
+    header: TekstElement<string>;
+    beskrivelse?: TekstElement<string>;
+    alternativer: Alternativer<T>;
+};
+
 export type RadiogruppeMedUtvalg<T extends string> = {
     header: TekstElement<string>;
     beskrivelse?: TekstElement<string>;

--- a/src/frontend/utils/tall.ts
+++ b/src/frontend/utils/tall.ts
@@ -1,0 +1,15 @@
+export const tilHeltall = (verdi: number | string | undefined): number | undefined => {
+    if (!verdi) {
+        return undefined;
+    }
+    if (typeof verdi === 'string') {
+        return isNaN(parseInt(verdi)) ? undefined : parseInt(verdi);
+    }
+    return verdi;
+};
+
+export const erGyldigKostnad = (verdi: string | undefined): boolean => {
+    const tall = tilHeltall(verdi);
+
+    return tall !== undefined && tall > 0;
+};

--- a/tests/søknader/reiseTilSamling/happyPath.spec.ts
+++ b/tests/søknader/reiseTilSamling/happyPath.spec.ts
@@ -116,11 +116,11 @@ test('At reise til samling viser førstesiden og går videre fra din situasjon',
     await forventIngenWcagViolations(page);
 
     await page
-        .getByRole('radiogroup', { name: 'Kan du reise kollektivt?' })
+        .getByRole('radiogroup', { name: 'Kan du reise med offentlig transport?' })
         .getByLabel('Ja')
         .check();
     await page
-        .getByLabel('Hva er totalutgiftene til kollektivtransport til og fra samlingene?')
+        .getByLabel('Hva er totalutgiftene til offentlig transport til og fra samlingene?')
         .fill('500');
     await page.getByRole('button', { name: 'Neste' }).click();
     await fjernWebpackOverlay(page);


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Gjør at informasjon man får om reisen til bruker stemmer bedre overens med informasjon vi behøver, slik som er i dagens søknad om daglig reise.

Legger til:
1. Årsaker til at bruker ikke kan bruke offentlig transport
2. Årsaker til at bruker ikke kan bruke egen bil
3. Utgifter og drivstofftype for privat bil

Justeringer:
1. Endrer kollektiv -> offentlig transport
2. Forenkler oppsummering en smule, tenker jeg gjør enda litt mer jobb her videre. Kommer en "rydde"-PR

Behøver fortsatt avklaring rundt bruk av drosje til samling.


Litt bilder:

Skjema
<img width="487" height="1016" alt="image" src="https://github.com/user-attachments/assets/f7badc43-a882-4853-9902-946c5209f074" />


Oppsummering
<img width="586" height="802" alt="image" src="https://github.com/user-attachments/assets/d1cc8584-2630-4364-90b3-1a195e883a4d" />
