### PR TITLE
legg til varseltekst for enslig forsørger ved valg av ytelsen også

### DIFF
--- a/src/frontend/components/Hovedytelse/Hovedytelse.tsx
+++ b/src/frontend/components/Hovedytelse/Hovedytelse.tsx
@@ -12,6 +12,7 @@ import { hovedytelseInnhold } from '../../tekster/hovedytelse';
 import { EnumFlereValgFelt } from '../../typer/skjema';
 import { ArbeidOgOpphold, Hovedytelse } from '../../typer/søknad';
 import { inneholderFeil } from '../../typer/validering';
+import { AdvarselEndringOvergangsstønad } from '../AdvarselEndringOvergangsstønad';
 import { Side } from '../Side';
 import { LocaleCheckboxGroup } from '../Teksthåndtering/LocaleCheckboxGroup';
 import { LocaleHeading } from '../Teksthåndtering/LocaleHeading';
@@ -56,6 +57,9 @@ export const HovedytelseSide: React.FC<Props> = ({ hovedytelse, oppdaterHovedyte
         }
     };
 
+    const skalViseVarselOmRegelendring =
+        ytelse?.verdier.some((ytelse) => ytelse.verdi === 'OVERGANGSSTØNAD') || false;
+
     return (
         <Side
             validerSteg={() => kanFortsette(ytelse)}
@@ -88,6 +92,7 @@ export const HovedytelseSide: React.FC<Props> = ({ hovedytelse, oppdaterHovedyte
                     settArbeidOgOpphold={settArbeidOgOpphold}
                 />
             )}
+            {skalViseVarselOmRegelendring && <AdvarselEndringOvergangsstønad />}
         </Side>
     );
 };

--- a/src/frontend/components/Hovedytelse/Hovedytelse.tsx
+++ b/src/frontend/components/Hovedytelse/Hovedytelse.tsx
@@ -58,7 +58,7 @@ export const HovedytelseSide: React.FC<Props> = ({ hovedytelse, oppdaterHovedyte
     };
 
     const skalViseVarselOmRegelendring =
-        ytelse?.verdier.some((ytelse) => ytelse.verdi === 'OVERGANGSSTØNAD') || false;
+        ytelse?.verdier.some((ytelseFelt) => ytelseFelt.verdi === 'OVERGANGSSTØNAD') ?? false;
 
     return (
         <Side

--- a/src/frontend/reiseTilSamling/Forside.tsx
+++ b/src/frontend/reiseTilSamling/Forside.tsx
@@ -16,6 +16,7 @@ import {
 import { routesReiseTilSamling } from './routing/routesReiseTilSamling';
 import { forsideTekster } from './tekster/forside';
 import { loggBesøk, loggSkjemaStartet } from '../api/analytics';
+import { AdvarselEndringOvergangsstønad } from '../components/AdvarselEndringOvergangsstønad';
 import { BekreftelseCheckbox } from '../components/BekreftelseCheckbox';
 import { InfoPunktliste } from '../components/InfoPunktliste';
 import { Container } from '../components/Side';
@@ -62,6 +63,7 @@ export const Forside: React.FC = () => {
                     <LocaleTekst tekst={forsideTekster.veileder_innhold} />
                 </BodyShort>
             </GuidePanel>
+            <AdvarselEndringOvergangsstønad />
             <div>
                 <LocaleHeading
                     tekst={forsideTekster.kan_soke_tittel}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Gjør det enda tydeligere for bruker dersom de velger overgangsstønad at regelendringene vil kunne påvirke dem, som forhåpentligvis gjør at vi unngår ekstra søknader.